### PR TITLE
Fixed detection of newline inside string. Replaced tabs with spaces.

### DIFF
--- a/daedalus/DATFile.cpp
+++ b/daedalus/DATFile.cpp
@@ -89,8 +89,8 @@ void DATFile::readSymTable()
     if(m_Verbose) LogInfo() << "Reading Sym-Table...";
 
     uint32_t count = m_Parser.readBinaryDWord();
-	m_SymTable.symbolsByName.reserve(count);
-	m_SymTable.symbols.resize(count);
+    m_SymTable.symbolsByName.reserve(count);
+    m_SymTable.symbols.resize(count);
     m_SymTable.sortTable.resize(count);
     m_Parser.readBinaryRaw(m_SymTable.sortTable.data(), sizeof(uint32_t) * count);
 
@@ -159,9 +159,17 @@ void DATFile::readSymTable()
                             b = m_Parser.readBinaryByte();
                         };
 
+                        auto replace = [](std::string& searchSpace, const std::string& from, const std::string& to) {
+                            size_t start_pos = 0;
+                            while((start_pos = searchSpace.find(from, start_pos)) != std::string::npos) {
+                                searchSpace.replace(start_pos, from.length(), to);
+                                start_pos += to.length();
+                            }
+                        };
+                        replace(s.strData[j], "\\n", "\n");
+
                         if(m_Verbose) LogInfo() << " - String[" << j << "]: " << s.strData[j];
                     }
-
                     break;
 
                 case EParType_Class:
@@ -183,8 +191,8 @@ void DATFile::readSymTable()
 
         s.parent = static_cast<int32_t>(m_Parser.readBinaryDWord());
 
-		if(!s.name.empty())
-			m_SymTable.symbolsByName.emplace(s.name, i);
+        if(!s.name.empty())
+            m_SymTable.symbolsByName.emplace(s.name, i);
 
         // check for callable object
         if (s.isEParType(EParType_Prototype) || // is a Prototype
@@ -195,7 +203,7 @@ void DATFile::readSymTable()
             m_SymTable.functionsByAddress.emplace(s.address, i);
         }
 
-		m_SymTable.symbols[i] = std::move(s);
+        m_SymTable.symbols[i] = std::move(s);
     }
 
     readStack();
@@ -210,8 +218,8 @@ void DATFile::readStack()
 
     m_Stack.stackOffset = m_Parser.getSeek();
 
-	std::string ss;
-	std::stringstream sss;
+    std::string ss;
+    std::stringstream sss;
 
     size_t seek=0;
     while(m_Parser.getSeek() < m_Parser.getFileSize())
@@ -220,16 +228,16 @@ void DATFile::readStack()
         memset(&s, 0, sizeof(s));
         s.op = static_cast<EParOp>(m_Parser.readBinaryByte());
 
-		if(m_Verbose)
-		{
-			sss.str(std::string());
-			sss.clear();
+        if(m_Verbose)
+        {
+            sss.str(std::string());
+            sss.clear();
 
-			sss << seek << ": " << OP_MAP[s.op];
-			ss = sss.str();
-		}
+            sss << seek << ": " << OP_MAP[s.op];
+            ss = sss.str();
+        }
 
-		seek += sizeof(uint8_t);
+        seek += sizeof(uint8_t);
 
         switch(s.op)
         {


### PR DESCRIPTION
This fixes the bug that newlines inside multiline text like "Aktuelle\nMissionen" were not recognized.