### PR TITLE
Disable building PhysFS tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ endif()
 
 # 3rd-party dependencies
 add_subdirectory(lib/libsquish)
+
+set(PHYSFS_BUILD_TEST OFF CACHE STRING "" FORCE)
 add_subdirectory(lib/physfs)
 
 include_directories(lib/glm/glm)


### PR DESCRIPTION
Fixes that otherwise the ncurses library was sometimes needed to build ZenLib/REGoth on *nix systems