### PR TITLE
Change OutputDebugString to ansi version

### DIFF
--- a/utils/logger.h
+++ b/utils/logger.h
@@ -190,7 +190,7 @@ namespace Utils
 			}
 
 #if defined(WIN32) || defined(_WIN32)
-			OutputDebugString((m_Info.str() + m_Message.str() + "\n").c_str());
+			OutputDebugStringA((m_Info.str() + m_Message.str() + "\n").c_str());
 #elif defined(__ANDROID__)
 			__android_log_print(ANDROID_LOG_INFO, "OpenZE", (m_Info.str() + m_Message.str() + "\n").c_str());
 #endif


### PR DESCRIPTION
The Logger class does not implement functions for wide strings. OutputDebugString translates to OutputDebugStringW if the UNICODE definition is set (e.g. in Qt projects or other programs using wstrings).
Using OutputDebugStringA solves this possible conflict.