### PR TITLE
[WIP] Use cmake modules for PhysFS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ compile_commands.json
  
 # clion
 .idea/
+
+.vscode/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "lib/libsquish"]
 	path = lib/libsquish
 	url = https://github.com/tito/libsquish.git
-[submodule "lib/physfs"]
-	path = lib/physfs
-	url = https://github.com/REGoth-project/physfs

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,22 @@ addons:
 
 git:
   submodules: false
+install:
+  - wget https://www.icculus.org/physfs/downloads/physfs-3.0.1.tar.bz2
+  - tar xf physfs-3.0.1.tar.bz2
+  - mkdir deps
+  - mkdir build-physfs
+  - cd build-physfs
+  - cmake -DCMAKE_INSTALL_PREFIX=../deps ../physfs-3.0.1 -DPHYSFS_BUILD_TEST=OFF
+  - cmake --build . --target install
+  - cd ..
 
 script:
   - if [ "$CXX" = "g++" ]; then export CXX="g++-6" CC="gcc-6"; fi
   - git submodule update --init --recursive
   - mkdir -p build
   - cd build
-  - cmake -GNinja -DZENLIB_BUILD_EXAMPLES=On -DZENLIB_BUILD_TESTS=On ..
+  - cmake -GNinja -DZENLIB_BUILD_EXAMPLES=On -DZENLIB_BUILD_TESTS=On -DCMAKE_PREFIX_PATH=../deps ..
   - ninja
   - cd ../tests
   - ../build/tests/test_vdfs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 2.4)
 project(ZenLib)
 
 include(ExternalProject)
+set(CMAKE_MODULE_PATH
+  ${CMAKE_MODULE_PATH}
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 set(ZENLIB_BUILD_EXAMPLES OFF CACHE BOOL "Whether to build the examples")
 set(ZENLIB_BUILD_TESTS OFF CACHE BOOL "Whether to build tests")
@@ -15,14 +18,8 @@ if(MSVC)
 endif()
 
 # 3rd-party dependencies
-add_subdirectory(lib/libsquish)
-
-set(PHYSFS_BUILD_TEST OFF CACHE STRING "" FORCE)
-add_subdirectory(lib/physfs)
-
 include_directories(lib/glm/glm)
 include_directories(lib/libsquish)
-include_directories(lib/physfs/src)
 include_directories(.)
 
 # Internal libraries

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ if(MSVC)
 endif()
 
 # 3rd-party dependencies
+add_subdirectory(lib/libsquish)
+
 include_directories(lib/glm/glm)
 include_directories(lib/libsquish)
 include_directories(.)

--- a/cmake/FindPhysFS.cmake
+++ b/cmake/FindPhysFS.cmake
@@ -1,0 +1,33 @@
+find_path(PhysFS_INCLUDE_DIR NAMES physfs.h)
+find_library(PhysFS_LIBRARY NAMES physfs libphysfs)
+mark_as_advanced(PhysFS_INCLUDE_DIR PhysFS_LIBRARY)
+
+include(FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args(PhysFS REQUIRED_VARS PhysFS_LIBRARY PhysFS_INCLUDE_DIR)
+
+if(PhysFS_FOUND)
+  if(NOT TARGET PhysFS::PhysFS)
+    add_library(PhysFS::PhysFS UNKNOWN IMPORTED)
+    set_target_properties(PhysFS::PhysFS PROPERTIES
+      IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+      IMPORTED_LOCATION "${PhysFS_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES "${PhysFS_INCLUDE_DIR}")
+  endif()
+
+  if (PhysFS_INCLUDE_DIR AND EXISTS "${PhysFS_INCLUDE_DIR}/physfs.h")
+    file(STRINGS "${PhysFS_INCLUDE_DIR}/physfs.h" physfs_major_version REGEX "^#define[ \\t]+PHYSFS_VER_MAJOR[ \\t]+\\d+")
+    file(STRINGS "${PhysFS_INCLUDE_DIR}/physfs.h" physfs_minor_version REGEX "^#define[ \\t]+PHYSFS_VER_MINOR[ \\t]+\\d+")
+    file(STRINGS "${PhysFS_INCLUDE_DIR}/physfs.h" physfs_patch_version REGEX "^#define[ \\t]+PHYSFS_VER_PATCH[ \\t]+\\d+")
+
+    string(REGEX REPLACE "^#define[ \\t]+PHYSFS_VER_MAJOR[ \\t]+(\\d+)" "\\1" PHYSFS_MAJOR "${physfs_major_version}")
+    string(REGEX REPLACE "^#define[ \\t]+PHYSFS_VER_MAJOR[ \\t]+(\\d+)" "\\1" PHYSFS_MINOR "${physfs_minor_version}")
+    string(REGEX REPLACE "^#define[ \\t]+PHYSFS_VER_MAJOR[ \\t]+(\\d+)" "\\1" PHYSFS_PATCH "${physfs_patch_version}")
+
+    set(PHYSFS_VERSION_STRING "${PHYSFS_MAJOR}.${PHYSFS_MINOR}.${PHYSFS_PATCH}")
+    
+    unset(physfs_major_version)
+    unset(physfs_minor_version)
+    unset(physfs_patch_version)
+  endif ()
+endif()

--- a/vdfs/CMakeLists.txt
+++ b/vdfs/CMakeLists.txt
@@ -3,16 +3,18 @@ project(VDFS)
 
 file(GLOB SRC
     *.cpp
+    *.c
     *.h
 )
 
-add_library(vdfs STATIC ${SRC} "../lib/physfs/extras/ignorecase.c")
+find_package(PhysFS 3 REQUIRED)
+add_library(vdfs STATIC ${SRC})
 
 # Remove WIN-API min and max macros since they mess up std::min/max
 if(MSVC)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DNOMINMAX")
 endif()
 
-target_link_libraries(vdfs physfs-static)
+target_link_libraries(vdfs PhysFS::PhysFS)
 set_target_properties(vdfs PROPERTIES LINKER_LANGUAGE C)
 target_include_directories(vdfs PUBLIC ..)

--- a/vdfs/fileIndex.cpp
+++ b/vdfs/fileIndex.cpp
@@ -6,7 +6,7 @@
 #include <algorithm>
 #include <physfs.h>
 #include <assert.h>
-#include "../lib/physfs/extras/ignorecase.h"
+#include "ignorecase.h"
 
 using namespace VDFS;
 

--- a/vdfs/ignorecase.c
+++ b/vdfs/ignorecase.c
@@ -1,0 +1,199 @@
+/** \file ignorecase.c */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+
+#include <physfs.h>
+#include "ignorecase.h"
+
+/**
+ * Please see ignorecase.h for details.
+ *
+ * License: this code is public domain. I make no warranty that it is useful,
+ *  correct, harmless, or environmentally safe.
+ *
+ * This particular file may be used however you like, including copying it
+ *  verbatim into a closed-source project, exploiting it commercially, and
+ *  removing any trace of my name from the source (although I hope you won't
+ *  do that). I welcome enhancements and corrections to this file, but I do
+ *  not require you to send me patches if you make changes. This code has
+ *  NO WARRANTY.
+ *
+ * Unless otherwise stated, the rest of PhysicsFS falls under the zlib license.
+ *  Please see LICENSE.txt in the root of the source tree.
+ *
+ *  \author Ryan C. Gordon.
+ */
+
+static int locateOneElement(char *buf)
+{
+    char *ptr;
+    char **rc;
+    char **i;
+
+    if (PHYSFS_exists(buf))
+        return 1;  /* quick rejection: exists in current case. */
+
+    ptr = strrchr(buf, '/');  /* find entry at end of path. */
+    if (ptr == NULL)
+    {
+        rc = PHYSFS_enumerateFiles("/");
+        ptr = buf;
+    } /* if */
+    else
+    {
+        *ptr = '\0';
+        rc = PHYSFS_enumerateFiles(buf);
+        *ptr = '/';
+        ptr++;  /* point past dirsep to entry itself. */
+    } /* else */
+
+    for (i = rc; *i != NULL; i++)
+    {
+        if (PHYSFS_utf8stricmp(*i, ptr) == 0)
+        {
+            strcpy(ptr, *i); /* found a match. Overwrite with this case. */
+            PHYSFS_freeList(rc);
+            return 1;
+        } /* if */
+    } /* for */
+
+    /* no match at all... */
+    PHYSFS_freeList(rc);
+    return 0;
+} /* locateOneElement */
+
+
+int PHYSFSEXT_locateCorrectCase(char *buf)
+{
+    int rc;
+    char *ptr;
+
+    while (*buf == '/')  /* skip any '/' at start of string... */
+        buf++;
+
+    ptr = buf;
+    if (*ptr == '\0')
+        return 0;  /* Uh...I guess that's success. */
+
+    while ( (ptr = strchr(ptr + 1, '/')) != NULL )
+    {
+        *ptr = '\0';  /* block this path section off */
+        rc = locateOneElement(buf);
+        *ptr = '/'; /* restore path separator */
+        if (!rc)
+            return -2;  /* missing element in path. */
+    } /* while */
+
+    /* check final element... */
+    return locateOneElement(buf) ? 0 : -1;
+} /* PHYSFSEXT_locateCorrectCase */
+
+
+#ifdef TEST_PHYSFSEXT_LOCATECORRECTCASE
+int main(int argc, char **argv)
+{
+    int rc;
+    char buf[128];
+    PHYSFS_File *f;
+
+    if (!PHYSFS_init(argv[0]))
+    {
+        fprintf(stderr, "PHYSFS_init(): %s\n", PHYSFS_getLastError());
+        return 1;
+    } /* if */
+
+    if (!PHYSFS_addToSearchPath(".", 1))
+    {
+        fprintf(stderr, "PHYSFS_addToSearchPath(): %s\n", PHYSFS_getLastError());
+        PHYSFS_deinit();
+        return 1;
+    } /* if */
+
+    if (!PHYSFS_setWriteDir("."))
+    {
+        fprintf(stderr, "PHYSFS_setWriteDir(): %s\n", PHYSFS_getLastError());
+        PHYSFS_deinit();
+        return 1;
+    } /* if */
+
+    if (!PHYSFS_mkdir("/a/b/c"))
+    {
+        fprintf(stderr, "PHYSFS_mkdir(): %s\n", PHYSFS_getLastError());
+        PHYSFS_deinit();
+        return 1;
+    } /* if */
+
+    if (!PHYSFS_mkdir("/a/b/C"))
+    {
+        fprintf(stderr, "PHYSFS_mkdir(): %s\n", PHYSFS_getLastError());
+        PHYSFS_deinit();
+        return 1;
+    } /* if */
+
+    f = PHYSFS_openWrite("/a/b/c/x.txt");
+    PHYSFS_close(f);
+    if (f == NULL)
+    {
+        fprintf(stderr, "PHYSFS_openWrite(): %s\n", PHYSFS_getLastError());
+        PHYSFS_deinit();
+        return 1;
+    } /* if */
+
+    f = PHYSFS_openWrite("/a/b/C/X.txt");
+    PHYSFS_close(f);
+    if (f == NULL)
+    {
+        fprintf(stderr, "PHYSFS_openWrite(): %s\n", PHYSFS_getLastError());
+        PHYSFS_deinit();
+        return 1;
+    } /* if */
+
+    strcpy(buf, "/a/b/c/x.txt");
+    rc = PHYSFSEXT_locateCorrectCase(buf);
+    if ((rc != 0) || (strcmp(buf, "/a/b/c/x.txt") != 0))
+        printf("test 1 failed\n");
+
+    strcpy(buf, "/a/B/c/x.txt");
+    rc = PHYSFSEXT_locateCorrectCase(buf);
+    if ((rc != 0) || (strcmp(buf, "/a/b/c/x.txt") != 0))
+        printf("test 2 failed\n");
+
+    strcpy(buf, "/a/b/C/x.txt");
+    rc = PHYSFSEXT_locateCorrectCase(buf);
+    if ((rc != 0) || (strcmp(buf, "/a/b/C/X.txt") != 0))
+        printf("test 3 failed\n");
+
+    strcpy(buf, "/a/b/c/X.txt");
+    rc = PHYSFSEXT_locateCorrectCase(buf);
+    if ((rc != 0) || (strcmp(buf, "/a/b/c/x.txt") != 0))
+        printf("test 4 failed\n");
+
+    strcpy(buf, "/a/b/c/z.txt");
+    rc = PHYSFSEXT_locateCorrectCase(buf);
+    if ((rc != -1) || (strcmp(buf, "/a/b/c/z.txt") != 0))
+        printf("test 5 failed\n");
+
+    strcpy(buf, "/A/B/Z/z.txt");
+    rc = PHYSFSEXT_locateCorrectCase(buf);
+    if ((rc != -2) || (strcmp(buf, "/a/b/Z/z.txt") != 0))
+        printf("test 6 failed\n");
+
+    printf("Testing completed.\n");
+    printf("  If no errors were reported, you're good to go.\n");
+
+    PHYSFS_delete("/a/b/c/x.txt");
+    PHYSFS_delete("/a/b/C/X.txt");
+    PHYSFS_delete("/a/b/c");
+    PHYSFS_delete("/a/b/C");
+    PHYSFS_delete("/a/b");
+    PHYSFS_delete("/a");
+    PHYSFS_deinit();
+    return 0;
+} /* main */
+#endif
+
+/* end of ignorecase.c ... */
+

--- a/vdfs/ignorecase.h
+++ b/vdfs/ignorecase.h
@@ -1,0 +1,86 @@
+#ifndef INCL_PHYSFSEXT_IGNORECASE_H
+#define INCL_PHYSFSEXT_IGNORECASE_H
+
+/** \file ignorecase.h */
+
+/**
+ * \mainpage PhysicsFS ignorecase
+ *
+ * This is an extension to PhysicsFS to let you handle files in a
+ *  case-insensitive manner, regardless of what sort of filesystem or
+ *  archive they reside in. It does this by enumerating directories as
+ *  needed and manually locating matching entries.
+ *
+ * Please note that this brings with it some caveats:
+ *  - On filesystems that are case-insensitive to start with, such as those
+ *    used on Windows or MacOS, you are adding extra overhead.
+ *  - On filesystems that are case-sensitive, you might select the wrong dir
+ *    or file (which brings security considerations and potential bugs). This
+ *    code favours exact case matches, but you will lose access to otherwise
+ *    duplicate filenames, or you might go down a wrong directory tree, etc.
+ *    In practice, this is rarely a problem, but you need to be aware of it.
+ *  - This doesn't do _anything_ with the write directory; you're on your
+ *    own for opening the right files for writing. You can sort of get around
+ *    this by adding your write directory to the search path, but then the
+ *    interpolated directory tree can screw you up even more.
+ *
+ * This code should be considered an aid for legacy code. New development
+ *  shouldn't do things that require this aid in the first place.  :)
+ *
+ * Usage: Set up PhysicsFS as you normally would, then use
+ *  PHYSFSEXT_locateCorrectCase() to get a "correct" pathname to pass to
+ *  functions like PHYSFS_openRead(), etc.
+ *
+ * License: this code is public domain. I make no warranty that it is useful,
+ *  correct, harmless, or environmentally safe.
+ *
+ * This particular file may be used however you like, including copying it
+ *  verbatim into a closed-source project, exploiting it commercially, and
+ *  removing any trace of my name from the source (although I hope you won't
+ *  do that). I welcome enhancements and corrections to this file, but I do
+ *  not require you to send me patches if you make changes. This code has
+ *  NO WARRANTY.
+ *
+ * Unless otherwise stated, the rest of PhysicsFS falls under the zlib license.
+ *  Please see LICENSE.txt in the root of the source tree.
+ *
+ *  \author Ryan C. Gordon.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \fn int PHYSFSEXT_locateCorrectCase(char *buf)
+ * \brief Find an existing filename with matching case.
+ *
+ * This function will look for a path/filename that matches the passed in
+ *  buffer. Each element of the buffer's path is checked for a
+ *  case-insensitive match. The buffer must specify a null-terminated string
+ *  in platform-independent notation.
+ *
+ * Please note results may be skewed differently depending on whether symlinks
+ *  are enabled or not.
+ *
+ * Each element of the buffer is overwritten with the actual case of an
+ *  existing match. If there is no match, the search aborts and reports an
+ *  error. Exact matches are favored over case-insensitive matches.
+ *
+ * THIS IS RISKY. Please do not use this function for anything but legacy code.
+ *
+ *   \param buf Buffer with null-terminated string of path/file to locate.
+ *               This buffer will be modified by this function.
+ *  \return zero if match was found, -1 if the final element (the file itself)
+ *               is missing, -2 if one of the parent directories is missing.
+ */
+int PHYSFSEXT_locateCorrectCase(char *buf);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* include-once blocker. */
+
+/* end of ignorecase.h ... */
+


### PR DESCRIPTION
This PR should solve issue REGoth-project/REGoth#369 by removing the need to keep our git clone of the PhysFS mercurial repo.

Instead, it searches for a preinstalled copy of PhysFS in the system.
Issues with this method:
- Windows doesn't have a central source for packages, PhysFS will need to be compiled and installed manually
- Ubuntu before version 18.04 ships an obsolete version of PhysFS, so it will need to be manually compiled and installed, too

Both of the issues can be solved by distributing a script with REGoth which automatically downloads and installs the dependencies in a subdirectory, as discussed previously with @markusobi 