### PR TITLE
Update parserImplASCII.cpp

### DIFF
--- a/zenload/parserImplASCII.cpp
+++ b/zenload/parserImplASCII.cpp
@@ -37,7 +37,7 @@ bool ParserImplASCII::readChunkStart(ZenParser::ChunkHeader& header)
         size_t tmpSeek = m_pParser->m_Seek;
         while (m_pParser->m_Data[tmpSeek] != ']')
         {
-            if (m_pParser->m_Data[tmpSeek] == '\r' && m_pParser->m_Data[tmpSeek] == '\n')
+            if (m_pParser->m_Data[tmpSeek] == '\r' || m_pParser->m_Data[tmpSeek] == '\n')
                 throw std::runtime_error("Invalid vob descriptor");
 
             ++tmpSeek;


### PR DESCRIPTION
The data at tmpSeek cannot be "\r" and "\n" at the same time. Or was probably intended.