### PR TITLE
Fix wrong integer size.

### DIFF
--- a/zenload/parserImplBinary.cpp
+++ b/zenload/parserImplBinary.cpp
@@ -85,10 +85,14 @@ void ParserImplBinary::readEntry(const char* /*expectedName*/, void* target, siz
         // 32-bit
         case ZVT_INT:
         case ZVT_FLOAT:
-        case ZVT_WORD:
         case ZVT_VEC3:
         case ZVT_COLOR:
             size = sizeof(uint32_t);
+            break;
+            
+        // 16-bit
+        case ZVT_WORD:
+            size = sizeof(uint16_t);
             break;
 
         // Raw


### PR DESCRIPTION
I think ZVT_WORD is meant to reference a 16-bit integer not a 32-bit one.