### PR TITLE
Insert G26f version ID

### DIFF
--- a/zenload/zCBspTree.h
+++ b/zenload/zCBspTree.h
@@ -14,7 +14,7 @@ namespace ZenLoad
     public:
         enum EVersion
         {
-            Gothic_26f = 0,  // TODO
+            Gothic_26f = 67698688,
             Gothic_18k = 34144256
         };
 


### PR DESCRIPTION
Tested with latest G2 steam version and patched CD version with all files that could be parsed. Some worlds could not be parsed (see #42).