### PR TITLE
Move everything into 'ZenLib' namespace

### DIFF
--- a/daedalus/DATFile.cpp
+++ b/daedalus/DATFile.cpp
@@ -7,594 +7,598 @@
 #include <map>
 #include <utils/logger.h>
 
-using namespace ZenLoad;
-using namespace Daedalus;
-
-std::map<int, const char*> OP_MAP = {
-    {0, "Add"},              // a + b
-    {1, "Subract"},          // a - b
-    {2, "Multiply"},         // a * b
-    {3, "Divide"},           // a / b
-    {4, "Mod"},              // a % b
-    {5, "BinOr"},            // a | b
-    {6, "BinAnd"},           // a & b
-    {7, "Less"},             // a < b
-    {8, "Greater"},          // a > b
-    {9, "Assign"},           // a = b
-    {11, "LogOr"},           // a || b
-    {12, "LogAnd"},          // a && b
-    {13, "ShiftLeft"},       // a << b
-    {14, "ShiftRight"},      // a >> b
-    {15, "LessOrEqual"},     // a <= b
-    {16, "Equal"},           // a == b
-    {17, "NotEqual"},        // a != b
-    {18, "GreaterOrEqual"},  // a >= b
-    {19, "AssignAdd"},       // a += b (a = a + b)
-    {20, "AssignSubtract"},  // a -= b (a = a - b)
-    {21, "AssignMultiply"},  // a *= b (a = a * b)
-    {22, "AssignDivide"},    // a /= b (a = a / b)
-    {30, "Plus"},            // +a
-    {31, "Minus"},           // -a
-    {32, "Not"},             // !a
-    {33, "Negate"},          // ~a
-    {60, "Ret"},
-    {61, "Call"},
-    {62, "CallExternal"},
-    {64, "PushInt"},
-    {65, "PushVar"},
-    {67, "PushInstance"},
-    {70, "AssignString"},
-    {71, "AssignStringRef"},
-    {72, "AssignFunc"},
-    {73, "AssignFloat"},
-    {74, "AssignInstance"},
-    {75, "Jump"},
-    {76, "JumpIf"},
-    {80, "SetInstance"},
-    {245, "PushArrayVar"},  // EParOp_PushVar + EParOp_Array
-};
-
-DATFile::DATFile()
-    : m_Parser()
-    , m_Verbose(false)
+namespace ZenLib
 {
-}
+    using namespace ZenLoad;
+    using namespace Daedalus;
 
-DATFile::DATFile(const std::string& file, bool verbose)
-    : m_Parser(file)
-    , m_Verbose(verbose)
-{
-    /*
+    std::map<int, const char*> OP_MAP = {
+        {0, "Add"},              // a + b
+        {1, "Subract"},          // a - b
+        {2, "Multiply"},         // a * b
+        {3, "Divide"},           // a / b
+        {4, "Mod"},              // a % b
+        {5, "BinOr"},            // a | b
+        {6, "BinAnd"},           // a & b
+        {7, "Less"},             // a < b
+        {8, "Greater"},          // a > b
+        {9, "Assign"},           // a = b
+        {11, "LogOr"},           // a || b
+        {12, "LogAnd"},          // a && b
+        {13, "ShiftLeft"},       // a << b
+        {14, "ShiftRight"},      // a >> b
+        {15, "LessOrEqual"},     // a <= b
+        {16, "Equal"},           // a == b
+        {17, "NotEqual"},        // a != b
+        {18, "GreaterOrEqual"},  // a >= b
+        {19, "AssignAdd"},       // a += b (a = a + b)
+        {20, "AssignSubtract"},  // a -= b (a = a - b)
+        {21, "AssignMultiply"},  // a *= b (a = a * b)
+        {22, "AssignDivide"},    // a /= b (a = a / b)
+        {30, "Plus"},            // +a
+        {31, "Minus"},           // -a
+        {32, "Not"},             // !a
+        {33, "Negate"},          // ~a
+        {60, "Ret"},
+        {61, "Call"},
+        {62, "CallExternal"},
+        {64, "PushInt"},
+        {65, "PushVar"},
+        {67, "PushInstance"},
+        {70, "AssignString"},
+        {71, "AssignStringRef"},
+        {72, "AssignFunc"},
+        {73, "AssignFloat"},
+        {74, "AssignInstance"},
+        {75, "Jump"},
+        {76, "JumpIf"},
+        {80, "SetInstance"},
+        {245, "PushArrayVar"},  // EParOp_PushVar + EParOp_Array
+    };
+
+    DATFile::DATFile()
+        : m_Parser()
+        , m_Verbose(false)
+    {
+    }
+
+    DATFile::DATFile(const std::string& file, bool verbose)
+        : m_Parser(file)
+        , m_Verbose(verbose)
+    {
+        /*
     std::string end = "GOTHIC.DAT";
     //end = "PARTICLEFX.DAT";
     auto pos = file.size() - end.size();
     bool endsWith = end.size() <= file.size() && file.find(end, pos) != std::string::npos;
     m_Verbose = endsWith;
      */
-    parseFile();
-}
-
-DATFile::DATFile(const uint8_t* pData, size_t numBytes, bool verbose)
-    : m_Parser(pData, numBytes)
-    , m_Verbose(verbose)
-{
-    parseFile();
-}
-
-void DATFile::parseFile()
-{
-    uint8_t version = m_Parser.readBinaryByte();
-    if (m_Verbose) LogInfo() << "DAT-Version: " << (int)version;
-
-    readSymTable();
-}
-
-void DATFile::readSymTable()
-{
-    if (m_Verbose) LogInfo() << "Reading Sym-Table...";
-
-    uint32_t count = m_Parser.readBinaryDWord();
-    m_SymTable.symbolsByName.reserve(count);
-    m_SymTable.symbols.resize(count);
-    m_SymTable.sortTable.resize(count);
-    m_Parser.readBinaryRaw(m_SymTable.sortTable.data(), sizeof(uint32_t) * count);
-
-    if (m_Verbose) LogInfo() << "Reading " << count << " symbols ";
-
-    // Read symbols
-    for (uint32_t i = 0; i < count; i++)
-    {
-        PARSymbol s;
-        uint32_t named = m_Parser.readBinaryDWord();
-
-        if (named)
-        {
-            uint8_t b = m_Parser.readBinaryByte();
-            while (b != 0x0A)
-            {
-                if (b != 0xFF)  // FIXME: This happens at INSTANCE_HELP?
-                    s.name += b;
-
-                b = m_Parser.readBinaryByte();
-            };
-
-            if (m_Verbose) LogInfo() << "Symbol Name: " << s.name;
-        }
-
-        m_Parser.readBinaryRaw(&s.properties, sizeof(s.properties));
-
-        if (m_Verbose)
-        {
-            auto typeName = eParTypeToString(EParType(s.properties.elemProps.type));
-            LogInfo() << "Properties: " << typeName << "[" << s.properties.elemProps.count << "]";
-        }
-
-        if (0 == (s.properties.elemProps.flags & EParFlag_ClassVar))
-        {
-            switch (s.properties.elemProps.type)
-            {
-                case EParType_Float:
-                    s.floatData.resize(s.properties.elemProps.count);
-                    m_Parser.readBinaryRaw(s.floatData.data(), sizeof(float) * s.floatData.size());
-
-                    if (m_Verbose)
-                        for (uint32_t j = 0; j < s.properties.elemProps.count; j++)
-                            LogInfo() << " - Float: " << s.floatData[j];
-                    break;
-
-                case EParType_Int:
-                    s.intData.resize(s.properties.elemProps.count);
-                    m_Parser.readBinaryRaw(s.intData.data(), sizeof(uint32_t) * s.intData.size());
-
-                    if (m_Verbose)
-                        for (uint32_t j = 0; j < s.properties.elemProps.count; j++)
-                            LogInfo() << " - Int: " << s.intData[j];
-                    break;
-
-                case EParType_String:
-                    s.strData.resize(s.properties.elemProps.count);
-                    for (uint32_t j = 0; j < s.properties.elemProps.count; j++)
-                    {
-                        uint8_t b = m_Parser.readBinaryByte();
-                        while (b != 0x0A)
-                        {
-                            if (b != 0xFF)  // FIXME: This happens at INSTANCE_HELP?
-                                s.strData[j] += b;
-
-                            b = m_Parser.readBinaryByte();
-                        };
-
-                        auto replace = [](std::string& searchSpace, const std::string& from, const std::string& to) {
-                            size_t start_pos = 0;
-                            while ((start_pos = searchSpace.find(from, start_pos)) != std::string::npos)
-                            {
-                                searchSpace.replace(start_pos, from.length(), to);
-                                start_pos += to.length();
-                            }
-                        };
-                        replace(s.strData[j], "\\n", "\n");
-
-                        if (m_Verbose) LogInfo() << " - String[" << j << "]: " << s.strData[j];
-                    }
-                    break;
-
-                case EParType_Class:
-                    s.classOffset = static_cast<int32_t>(m_Parser.readBinaryDWord());
-                    if (m_Verbose) LogInfo() << " - ClassOffset: " << s.classOffset;
-                    break;
-
-                case EParType_Func:
-                case EParType_Prototype:
-                case EParType_Instance:
-                    s.address = static_cast<int32_t>(m_Parser.readBinaryDWord());
-                    if (m_Verbose) LogInfo() << " - Address: " << s.address;
-
-                    if (s.properties.elemProps.flags & EParFlag_External)
-                        if (m_Verbose) LogInfo() << "External: Address: " << s.address << " Name: " << s.name;
-                    break;
-            }
-        }
-
-        s.parent = static_cast<int32_t>(m_Parser.readBinaryDWord());
-
-        if (!s.name.empty())
-            m_SymTable.symbolsByName.emplace(s.name, i);
-
-        // check for callable object
-        if (s.isEParType(EParType_Prototype) ||    // is a Prototype
-            (s.isEParType(EParType_Func)           // or a function, which
-             && !s.hasEParFlag(EParFlag_ClassVar)  // is no class-member (skip class members of type func)
-             && s.hasEParFlag(EParFlag_Const)))    // and is const (skip function params of type func)
-        {
-            m_SymTable.functionsByAddress.emplace(s.address, i);
-        }
-
-        m_SymTable.symbols[i] = std::move(s);
+        parseFile();
     }
 
-    readStack();
-}
-
-void DATFile::readStack()
-{
-    if (m_Verbose) LogInfo() << "Reading Stack...";
-    m_Stack.stackSize = m_Parser.readBinaryDWord();
-
-    if (m_Verbose) LogInfo() << " - " << m_Stack.stackSize << " bytes";
-
-    m_Stack.stackOffset = m_Parser.getSeek();
-
-    std::string ss;
-    std::stringstream sss;
-
-    size_t seek = 0;
-    while (m_Parser.getSeek() < m_Parser.getFileSize())
+    DATFile::DATFile(const uint8_t* pData, size_t numBytes, bool verbose)
+        : m_Parser(pData, numBytes)
+        , m_Verbose(verbose)
     {
-        PARStackOpCode s;
-        memset(&s, 0, sizeof(s));
-        s.op = static_cast<EParOp>(m_Parser.readBinaryByte());
+        parseFile();
+    }
 
-        if (m_Verbose)
+    void DATFile::parseFile()
+    {
+        uint8_t version = m_Parser.readBinaryByte();
+        if (m_Verbose) LogInfo() << "DAT-Version: " << (int)version;
+
+        readSymTable();
+    }
+
+    void DATFile::readSymTable()
+    {
+        if (m_Verbose) LogInfo() << "Reading Sym-Table...";
+
+        uint32_t count = m_Parser.readBinaryDWord();
+        m_SymTable.symbolsByName.reserve(count);
+        m_SymTable.symbols.resize(count);
+        m_SymTable.sortTable.resize(count);
+        m_Parser.readBinaryRaw(m_SymTable.sortTable.data(), sizeof(uint32_t) * count);
+
+        if (m_Verbose) LogInfo() << "Reading " << count << " symbols ";
+
+        // Read symbols
+        for (uint32_t i = 0; i < count; i++)
         {
-            sss.str(std::string());
-            sss.clear();
+            PARSymbol s;
+            uint32_t named = m_Parser.readBinaryDWord();
 
-            sss << seek << ": " << OP_MAP[s.op];
-            ss = sss.str();
+            if (named)
+            {
+                uint8_t b = m_Parser.readBinaryByte();
+                while (b != 0x0A)
+                {
+                    if (b != 0xFF)  // FIXME: This happens at INSTANCE_HELP?
+                        s.name += b;
+
+                    b = m_Parser.readBinaryByte();
+                };
+
+                if (m_Verbose) LogInfo() << "Symbol Name: " << s.name;
+            }
+
+            m_Parser.readBinaryRaw(&s.properties, sizeof(s.properties));
+
+            if (m_Verbose)
+            {
+                auto typeName = eParTypeToString(EParType(s.properties.elemProps.type));
+                LogInfo() << "Properties: " << typeName << "[" << s.properties.elemProps.count << "]";
+            }
+
+            if (0 == (s.properties.elemProps.flags & EParFlag_ClassVar))
+            {
+                switch (s.properties.elemProps.type)
+                {
+                    case EParType_Float:
+                        s.floatData.resize(s.properties.elemProps.count);
+                        m_Parser.readBinaryRaw(s.floatData.data(), sizeof(float) * s.floatData.size());
+
+                        if (m_Verbose)
+                            for (uint32_t j = 0; j < s.properties.elemProps.count; j++)
+                                LogInfo() << " - Float: " << s.floatData[j];
+                        break;
+
+                    case EParType_Int:
+                        s.intData.resize(s.properties.elemProps.count);
+                        m_Parser.readBinaryRaw(s.intData.data(), sizeof(uint32_t) * s.intData.size());
+
+                        if (m_Verbose)
+                            for (uint32_t j = 0; j < s.properties.elemProps.count; j++)
+                                LogInfo() << " - Int: " << s.intData[j];
+                        break;
+
+                    case EParType_String:
+                        s.strData.resize(s.properties.elemProps.count);
+                        for (uint32_t j = 0; j < s.properties.elemProps.count; j++)
+                        {
+                            uint8_t b = m_Parser.readBinaryByte();
+                            while (b != 0x0A)
+                            {
+                                if (b != 0xFF)  // FIXME: This happens at INSTANCE_HELP?
+                                    s.strData[j] += b;
+
+                                b = m_Parser.readBinaryByte();
+                            };
+
+                            auto replace = [](std::string& searchSpace, const std::string& from, const std::string& to)
+                            {
+                                size_t start_pos = 0;
+                                while ((start_pos = searchSpace.find(from, start_pos)) != std::string::npos)
+                                {
+                                    searchSpace.replace(start_pos, from.length(), to);
+                                    start_pos += to.length();
+                                }
+                            };
+                            replace(s.strData[j], "\\n", "\n");
+
+                            if (m_Verbose) LogInfo() << " - String[" << j << "]: " << s.strData[j];
+                        }
+                        break;
+
+                    case EParType_Class:
+                        s.classOffset = static_cast<int32_t>(m_Parser.readBinaryDWord());
+                        if (m_Verbose) LogInfo() << " - ClassOffset: " << s.classOffset;
+                        break;
+
+                    case EParType_Func:
+                    case EParType_Prototype:
+                    case EParType_Instance:
+                        s.address = static_cast<int32_t>(m_Parser.readBinaryDWord());
+                        if (m_Verbose) LogInfo() << " - Address: " << s.address;
+
+                        if (s.properties.elemProps.flags & EParFlag_External)
+                            if (m_Verbose) LogInfo() << "External: Address: " << s.address << " Name: " << s.name;
+                        break;
+                }
+            }
+
+            s.parent = static_cast<int32_t>(m_Parser.readBinaryDWord());
+
+            if (!s.name.empty())
+                m_SymTable.symbolsByName.emplace(s.name, i);
+
+            // check for callable object
+            if (s.isEParType(EParType_Prototype) ||    // is a Prototype
+                (s.isEParType(EParType_Func)           // or a function, which
+                 && !s.hasEParFlag(EParFlag_ClassVar)  // is no class-member (skip class members of type func)
+                 && s.hasEParFlag(EParFlag_Const)))    // and is const (skip function params of type func)
+            {
+                m_SymTable.functionsByAddress.emplace(s.address, i);
+            }
+
+            m_SymTable.symbols[i] = std::move(s);
         }
 
-        seek += sizeof(uint8_t);
+        readStack();
+    }
+
+    void DATFile::readStack()
+    {
+        if (m_Verbose) LogInfo() << "Reading Stack...";
+        m_Stack.stackSize = m_Parser.readBinaryDWord();
+
+        if (m_Verbose) LogInfo() << " - " << m_Stack.stackSize << " bytes";
+
+        m_Stack.stackOffset = m_Parser.getSeek();
+
+        std::string ss;
+        std::stringstream sss;
+
+        size_t seek = 0;
+        while (m_Parser.getSeek() < m_Parser.getFileSize())
+        {
+            PARStackOpCode s;
+            memset(&s, 0, sizeof(s));
+            s.op = static_cast<EParOp>(m_Parser.readBinaryByte());
+
+            if (m_Verbose)
+            {
+                sss.str(std::string());
+                sss.clear();
+
+                sss << seek << ": " << OP_MAP[s.op];
+                ss = sss.str();
+            }
+
+            seek += sizeof(uint8_t);
+
+            switch (s.op)
+            {
+                case EParOp_Call:
+                    s.address = m_Parser.readBinaryDWord();
+                    seek += sizeof(int32_t);
+
+                    if (m_Verbose) LogInfo() << ss << " - address: " << s.address;
+                    break;
+
+                case EParOp_CallExternal:
+                    s.symbol = m_Parser.readBinaryDWord();
+                    seek += sizeof(int32_t);
+
+                    if (m_Verbose) LogInfo() << ss << " - symbol: " << s.symbol << " (" << m_SymTable.symbols[s.symbol].name << ")";
+                    break;
+
+                case EParOp_PushInt:
+                    s.value = m_Parser.readBinaryDWord();
+                    seek += sizeof(int32_t);
+
+                    if (m_Verbose) LogInfo() << ss << " - value: " << s.value;
+                    break;
+
+                case EParOp_PushVar:
+                    s.symbol = m_Parser.readBinaryDWord();
+                    seek += sizeof(int32_t);
+
+                    if (m_Verbose) LogInfo() << ss << " - symbol: " << s.symbol << " (" << m_SymTable.symbols[s.symbol].name << ")";
+                    break;
+
+                case EParOp_PushInstance:
+                    s.symbol = m_Parser.readBinaryDWord();
+                    seek += sizeof(int32_t);
+
+                    if (m_Verbose) LogInfo() << ss << " - symbol: " << s.symbol << " (" << m_SymTable.symbols[s.symbol].name << ")";
+                    break;
+
+                case EParOp_Jump:
+                    s.address = m_Parser.readBinaryDWord();
+                    seek += sizeof(int32_t);
+
+                    if (m_Verbose) LogInfo() << ss << " - address: " << s.address;
+                    break;
+
+                case EParOp_JumpIf:
+                    s.address = m_Parser.readBinaryDWord();
+                    seek += sizeof(int32_t);
+
+                    if (m_Verbose) LogInfo() << ss << " - address: " << s.address;
+                    break;
+
+                case EParOp_SetInstance:
+                    s.symbol = m_Parser.readBinaryDWord();
+                    seek += sizeof(int32_t);
+
+                    if (m_Verbose) LogInfo() << ss << " - symbol: " << s.symbol << " (" << m_SymTable.symbols[s.symbol].name << ")";
+                    break;
+
+                case EParOp_PushArrayVar:
+                    s.symbol = m_Parser.readBinaryDWord();
+                    seek += sizeof(int32_t);
+
+                    s.index = m_Parser.readBinaryByte();
+                    seek += sizeof(uint8_t);
+
+                    break;
+                default:
+                    if (m_Verbose) LogInfo() << ss;
+            }
+        }
+    }
+
+    std::string Daedalus::eParTypeToString(EParType type)
+    {
+        switch (type)
+        {
+            case EParType_Void:
+                return "void";
+            case EParType_Float:
+                return "float";
+            case EParType_Int:
+                return "int";
+            case EParType_String:
+                return "string";
+            case EParType_Class:
+                return "class";
+            case EParType_Func:
+                return "func";
+            case EParType_Prototype:
+                return "prototype";
+            case EParType_Instance:
+                return "instance";
+            default:
+                return "unknown_type";
+        }
+    }
+
+    namespace Daedalus
+    {
+        template <>
+        EInstanceClass enumFromClass<Daedalus::GEngineClasses::C_Npc>()
+        {
+            return IC_Npc;
+        };
+        template <>
+        EInstanceClass enumFromClass<Daedalus::GEngineClasses::C_Mission>()
+        {
+            return IC_Mission;
+        };
+        template <>
+        EInstanceClass enumFromClass<Daedalus::GEngineClasses::C_Info>()
+        {
+            return IC_Info;
+        };
+        template <>
+        EInstanceClass enumFromClass<Daedalus::GEngineClasses::C_Item>()
+        {
+            return IC_Item;
+        };
+        template <>
+        EInstanceClass enumFromClass<Daedalus::GEngineClasses::C_ItemReact>()
+        {
+            return IC_ItemReact;
+        };
+        template <>
+        EInstanceClass enumFromClass<Daedalus::GEngineClasses::C_Focus>()
+        {
+            return IC_Focus;
+        };
+        template <>
+        EInstanceClass enumFromClass<Daedalus::GEngineClasses::C_Menu>()
+        {
+            return IC_Menu;
+        };
+        template <>
+        EInstanceClass enumFromClass<Daedalus::GEngineClasses::C_Menu_Item>()
+        {
+            return IC_MenuItem;
+        };
+        template <>
+        EInstanceClass enumFromClass<Daedalus::GEngineClasses::C_SFX>()
+        {
+            return IC_Sfx;
+        };
+        template <>
+        EInstanceClass enumFromClass<Daedalus::GEngineClasses::C_ParticleFX>()
+        {
+            return IC_Pfx;
+        };
+        template <>
+        EInstanceClass enumFromClass<Daedalus::GEngineClasses::C_MusicTheme>()
+        {
+            return IC_MusicTheme;
+        };
+    }  // namespace Daedalus
+
+    PARSymbol& DATFile::getSymbolByName(const std::string& symName)
+    {
+        std::string n = std::string(symName);
+        std::transform(n.begin(), n.end(), n.begin(), ::toupper);
+        //assert(hasSymbolName(n));
+        if (!hasSymbolName(n))
+        {
+            LogWarn() << "symbol " << symName << " not found";
+        }
+        return m_SymTable.symbols[m_SymTable.symbolsByName[n]];
+    }
+
+    bool DATFile::hasSymbolName(const std::string& symName)
+    {
+        std::string n = std::string(symName);
+        std::transform(n.begin(), n.end(), n.begin(), ::toupper);
+
+        return m_SymTable.symbolsByName.find(n) != m_SymTable.symbolsByName.end();
+    }
+
+    size_t DATFile::getSymbolIndexByName(const std::string& symName)
+    {
+        std::string n = std::string(symName);
+        std::transform(n.begin(), n.end(), n.begin(), ::toupper);
+
+        return m_SymTable.symbolsByName[n];
+    }
+
+    PARSymbol& DATFile::getSymbolByIndex(size_t idx)
+    {
+        return m_SymTable.symbols[idx];
+    }
+
+    size_t DATFile::getFunctionIndexByAddress(size_t address)
+    {
+        auto it = m_SymTable.functionsByAddress.find(address);
+        if (it != m_SymTable.functionsByAddress.end())
+            return it->second;
+        else
+            return static_cast<size_t>(-1);
+    }
+
+    PARStackOpCode DATFile::getStackOpCode(size_t pc)
+    {
+        m_Parser.setSeek(m_Stack.stackOffset + pc);
+
+        PARStackOpCode s;
+        s.op = static_cast<EParOp>(m_Parser.readBinaryByte());
+
+        s.opSize = sizeof(uint8_t);
 
         switch (s.op)
         {
             case EParOp_Call:
                 s.address = m_Parser.readBinaryDWord();
-                seek += sizeof(int32_t);
+                s.opSize += sizeof(int32_t);
 
-                if (m_Verbose) LogInfo() << ss << " - address: " << s.address;
+                if (m_Verbose) LogInfo() << "    - address: " << s.address;
                 break;
 
             case EParOp_CallExternal:
                 s.symbol = m_Parser.readBinaryDWord();
-                seek += sizeof(int32_t);
+                s.opSize += sizeof(int32_t);
 
-                if (m_Verbose) LogInfo() << ss << " - symbol: " << s.symbol << " (" << m_SymTable.symbols[s.symbol].name << ")";
+                if (m_Verbose) LogInfo() << "    - symbol: " << s.symbol << " (" << m_SymTable.symbols[s.symbol].name << ")";
                 break;
 
             case EParOp_PushInt:
                 s.value = m_Parser.readBinaryDWord();
-                seek += sizeof(int32_t);
+                s.opSize += sizeof(int32_t);
 
-                if (m_Verbose) LogInfo() << ss << " - value: " << s.value;
+                if (m_Verbose) LogInfo() << "    - value: " << s.value;
                 break;
 
             case EParOp_PushVar:
                 s.symbol = m_Parser.readBinaryDWord();
-                seek += sizeof(int32_t);
+                s.opSize += sizeof(int32_t);
 
-                if (m_Verbose) LogInfo() << ss << " - symbol: " << s.symbol << " (" << m_SymTable.symbols[s.symbol].name << ")";
+                if (m_Verbose) LogInfo() << "    - symbol: " << s.symbol << " (" << m_SymTable.symbols[s.symbol].name << ")";
                 break;
 
             case EParOp_PushInstance:
                 s.symbol = m_Parser.readBinaryDWord();
-                seek += sizeof(int32_t);
+                s.opSize += sizeof(int32_t);
 
-                if (m_Verbose) LogInfo() << ss << " - symbol: " << s.symbol << " (" << m_SymTable.symbols[s.symbol].name << ")";
+                if (m_Verbose) LogInfo() << "    - symbol: " << s.symbol << " (" << m_SymTable.symbols[s.symbol].name << ")";
                 break;
 
             case EParOp_Jump:
                 s.address = m_Parser.readBinaryDWord();
-                seek += sizeof(int32_t);
+                s.opSize += sizeof(int32_t);
 
-                if (m_Verbose) LogInfo() << ss << " - address: " << s.address;
+                if (m_Verbose) LogInfo() << "    - address: " << s.address;
                 break;
 
             case EParOp_JumpIf:
                 s.address = m_Parser.readBinaryDWord();
-                seek += sizeof(int32_t);
+                s.opSize += sizeof(int32_t);
 
-                if (m_Verbose) LogInfo() << ss << " - address: " << s.address;
+                if (m_Verbose) LogInfo() << "    - address: " << s.address;
                 break;
 
             case EParOp_SetInstance:
                 s.symbol = m_Parser.readBinaryDWord();
-                seek += sizeof(int32_t);
+                s.opSize += sizeof(int32_t);
 
-                if (m_Verbose) LogInfo() << ss << " - symbol: " << s.symbol << " (" << m_SymTable.symbols[s.symbol].name << ")";
+                if (m_Verbose) LogInfo() << "    - symbol: " << s.symbol << " (" << m_SymTable.symbols[s.symbol].name << ")";
                 break;
 
             case EParOp_PushArrayVar:
                 s.symbol = m_Parser.readBinaryDWord();
-                seek += sizeof(int32_t);
+                s.opSize += sizeof(int32_t);
 
                 s.index = m_Parser.readBinaryByte();
-                seek += sizeof(uint8_t);
+                s.opSize += sizeof(uint8_t);
 
                 break;
+
             default:
-                if (m_Verbose) LogInfo() << ss;
+                break;
         }
-    }
-}
 
-std::string Daedalus::eParTypeToString(EParType type)
-{
-    switch (type)
-    {
-        case EParType_Void:
-            return "void";
-        case EParType_Float:
-            return "float";
-        case EParType_Int:
-            return "int";
-        case EParType_String:
-            return "string";
-        case EParType_Class:
-            return "class";
-        case EParType_Func:
-            return "func";
-        case EParType_Prototype:
-            return "prototype";
-        case EParType_Instance:
-            return "instance";
-        default:
-            return "unknown_type";
-    }
-}
-
-namespace Daedalus
-{
-    template <>
-    EInstanceClass enumFromClass<Daedalus::GEngineClasses::C_Npc>()
-    {
-        return IC_Npc;
-    };
-    template <>
-    EInstanceClass enumFromClass<Daedalus::GEngineClasses::C_Mission>()
-    {
-        return IC_Mission;
-    };
-    template <>
-    EInstanceClass enumFromClass<Daedalus::GEngineClasses::C_Info>()
-    {
-        return IC_Info;
-    };
-    template <>
-    EInstanceClass enumFromClass<Daedalus::GEngineClasses::C_Item>()
-    {
-        return IC_Item;
-    };
-    template <>
-    EInstanceClass enumFromClass<Daedalus::GEngineClasses::C_ItemReact>()
-    {
-        return IC_ItemReact;
-    };
-    template <>
-    EInstanceClass enumFromClass<Daedalus::GEngineClasses::C_Focus>()
-    {
-        return IC_Focus;
-    };
-    template <>
-    EInstanceClass enumFromClass<Daedalus::GEngineClasses::C_Menu>()
-    {
-        return IC_Menu;
-    };
-    template <>
-    EInstanceClass enumFromClass<Daedalus::GEngineClasses::C_Menu_Item>()
-    {
-        return IC_MenuItem;
-    };
-    template <>
-    EInstanceClass enumFromClass<Daedalus::GEngineClasses::C_SFX>()
-    {
-        return IC_Sfx;
-    };
-    template <>
-    EInstanceClass enumFromClass<Daedalus::GEngineClasses::C_ParticleFX>()
-    {
-        return IC_Pfx;
-    };
-    template <>
-    EInstanceClass enumFromClass<Daedalus::GEngineClasses::C_MusicTheme>()
-    {
-        return IC_MusicTheme;
-    };
-}  // namespace Daedalus
-
-PARSymbol& DATFile::getSymbolByName(const std::string& symName)
-{
-    std::string n = std::string(symName);
-    std::transform(n.begin(), n.end(), n.begin(), ::toupper);
-    //assert(hasSymbolName(n));
-    if (!hasSymbolName(n))
-    {
-        LogWarn() << "symbol " << symName << " not found";
-    }
-    return m_SymTable.symbols[m_SymTable.symbolsByName[n]];
-}
-
-bool DATFile::hasSymbolName(const std::string& symName)
-{
-    std::string n = std::string(symName);
-    std::transform(n.begin(), n.end(), n.begin(), ::toupper);
-
-    return m_SymTable.symbolsByName.find(n) != m_SymTable.symbolsByName.end();
-}
-
-size_t DATFile::getSymbolIndexByName(const std::string& symName)
-{
-    std::string n = std::string(symName);
-    std::transform(n.begin(), n.end(), n.begin(), ::toupper);
-
-    return m_SymTable.symbolsByName[n];
-}
-
-PARSymbol& DATFile::getSymbolByIndex(size_t idx)
-{
-    return m_SymTable.symbols[idx];
-}
-
-size_t DATFile::getFunctionIndexByAddress(size_t address)
-{
-    auto it = m_SymTable.functionsByAddress.find(address);
-    if (it != m_SymTable.functionsByAddress.end())
-        return it->second;
-    else
-        return static_cast<size_t>(-1);
-}
-
-PARStackOpCode DATFile::getStackOpCode(size_t pc)
-{
-    m_Parser.setSeek(m_Stack.stackOffset + pc);
-
-    PARStackOpCode s;
-    s.op = static_cast<EParOp>(m_Parser.readBinaryByte());
-
-    s.opSize = sizeof(uint8_t);
-
-    switch (s.op)
-    {
-        case EParOp_Call:
-            s.address = m_Parser.readBinaryDWord();
-            s.opSize += sizeof(int32_t);
-
-            if (m_Verbose) LogInfo() << "    - address: " << s.address;
-            break;
-
-        case EParOp_CallExternal:
-            s.symbol = m_Parser.readBinaryDWord();
-            s.opSize += sizeof(int32_t);
-
-            if (m_Verbose) LogInfo() << "    - symbol: " << s.symbol << " (" << m_SymTable.symbols[s.symbol].name << ")";
-            break;
-
-        case EParOp_PushInt:
-            s.value = m_Parser.readBinaryDWord();
-            s.opSize += sizeof(int32_t);
-
-            if (m_Verbose) LogInfo() << "    - value: " << s.value;
-            break;
-
-        case EParOp_PushVar:
-            s.symbol = m_Parser.readBinaryDWord();
-            s.opSize += sizeof(int32_t);
-
-            if (m_Verbose) LogInfo() << "    - symbol: " << s.symbol << " (" << m_SymTable.symbols[s.symbol].name << ")";
-            break;
-
-        case EParOp_PushInstance:
-            s.symbol = m_Parser.readBinaryDWord();
-            s.opSize += sizeof(int32_t);
-
-            if (m_Verbose) LogInfo() << "    - symbol: " << s.symbol << " (" << m_SymTable.symbols[s.symbol].name << ")";
-            break;
-
-        case EParOp_Jump:
-            s.address = m_Parser.readBinaryDWord();
-            s.opSize += sizeof(int32_t);
-
-            if (m_Verbose) LogInfo() << "    - address: " << s.address;
-            break;
-
-        case EParOp_JumpIf:
-            s.address = m_Parser.readBinaryDWord();
-            s.opSize += sizeof(int32_t);
-
-            if (m_Verbose) LogInfo() << "    - address: " << s.address;
-            break;
-
-        case EParOp_SetInstance:
-            s.symbol = m_Parser.readBinaryDWord();
-            s.opSize += sizeof(int32_t);
-
-            if (m_Verbose) LogInfo() << "    - symbol: " << s.symbol << " (" << m_SymTable.symbols[s.symbol].name << ")";
-            break;
-
-        case EParOp_PushArrayVar:
-            s.symbol = m_Parser.readBinaryDWord();
-            s.opSize += sizeof(int32_t);
-
-            s.index = m_Parser.readBinaryByte();
-            s.opSize += sizeof(uint8_t);
-
-            break;
-
-        default:
-            break;
+        return s;
     }
 
-    return s;
-}
-
-size_t DATFile::addSymbol()
-{
-    m_SymTable.symbols.emplace_back();
-    return m_SymTable.symbols.size() - 1;
-}
-
-void DATFile::iterateSymbolsOfClass(const std::string& className, std::function<void(size_t, PARSymbol&)> callback)
-{
-    constexpr auto none = uint32_t{0xFFFFFFFF};
-    // First, find the parent-symbol
-    size_t baseSym = getSymbolIndexByName(className);
-
-    for (size_t i = 0; i < m_SymTable.symbols.size(); i++)
+    size_t DATFile::addSymbol()
     {
-        PARSymbol& s = getSymbolByIndex(i);
-        if (s.parent == none || s.properties.elemProps.type != EParType_Instance)
-            continue;
+        m_SymTable.symbols.emplace_back();
+        return m_SymTable.symbols.size() - 1;
+    }
 
-        if ((s.properties.elemProps.flags & Daedalus::EParFlag::EParFlag_Const) == 0)
-            continue;  // filters out variables of type C_NPC or C_ITEM
+    void DATFile::iterateSymbolsOfClass(const std::string& className, std::function<void(size_t, PARSymbol&)> callback)
+    {
+        constexpr auto none = uint32_t{0xFFFFFFFF};
+        // First, find the parent-symbol
+        size_t baseSym = getSymbolIndexByName(className);
 
-        PARSymbol& p = getSymbolByIndex(s.parent);
-        uint32_t pBase = s.parent;
-
-        // In case this is also just a prototype, go deeper one more level
-        if (p.properties.elemProps.type == EParType_Prototype && p.parent != none)
+        for (size_t i = 0; i < m_SymTable.symbols.size(); i++)
         {
-            pBase = p.parent;
+            PARSymbol& s = getSymbolByIndex(i);
+            if (s.parent == none || s.properties.elemProps.type != EParType_Instance)
+                continue;
+
+            if ((s.properties.elemProps.flags & Daedalus::EParFlag::EParFlag_Const) == 0)
+                continue;  // filters out variables of type C_NPC or C_ITEM
+
+            PARSymbol& p = getSymbolByIndex(s.parent);
+            uint32_t pBase = s.parent;
+
+            // In case this is also just a prototype, go deeper one more level
+            if (p.properties.elemProps.type == EParType_Prototype && p.parent != none)
+            {
+                pBase = p.parent;
+            }
+
+            // If the parent-classes match, we found an instance of our class
+            if (baseSym == pBase)
+                callback(i, s);
+        }
+    }
+
+    namespace Daedalus
+    {
+        // getDataContainer specializations
+        template <>
+        std::vector<int32_t>& PARSymbol::getDataContainer()
+        {
+            return this->intData;
         }
 
-        // If the parent-classes match, we found an instance of our class
-        if (baseSym == pBase)
-            callback(i, s);
-    }
-}
+        template <>
+        std::vector<float>& PARSymbol::getDataContainer()
+        {
+            return this->floatData;
+        }
 
-namespace Daedalus
-{
-    // getDataContainer specializations
-    template <>
-    std::vector<int32_t>& PARSymbol::getDataContainer()
+        template <>
+        std::vector<std::string>& PARSymbol::getDataContainer()
+        {
+            return this->strData;
+        }
+    }  // namespace Daedalus
+
+    int32_t& PARSymbol::getInt(size_t idx, void* baseAddr)
     {
-        return this->intData;
+        return getValue<int32_t>(idx, baseAddr);
     }
 
-    template <>
-    std::vector<float>& PARSymbol::getDataContainer()
+    std::string& PARSymbol::getString(size_t idx, void* baseAddr)
     {
-        return this->floatData;
+        return getValue<std::string>(idx, baseAddr);
     }
 
-    template <>
-    std::vector<std::string>& PARSymbol::getDataContainer()
+    float& PARSymbol::getFloat(size_t idx, void* baseAddr)
     {
-        return this->strData;
+        return getValue<float>(idx, baseAddr);
     }
-}  // namespace Daedalus
-
-int32_t& PARSymbol::getInt(size_t idx, void* baseAddr)
-{
-    return getValue<int32_t>(idx, baseAddr);
-}
-
-std::string& PARSymbol::getString(size_t idx, void* baseAddr)
-{
-    return getValue<std::string>(idx, baseAddr);
-}
-
-float& PARSymbol::getFloat(size_t idx, void* baseAddr)
-{
-    return getValue<float>(idx, baseAddr);
-}
+}  // namespace ZenLib

--- a/daedalus/DATFile.h
+++ b/daedalus/DATFile.h
@@ -7,384 +7,386 @@
 #include <utils/staticReferencedAllocator.h>
 #include <zenload/zenParser.h>
 
-namespace Daedalus
+namespace ZenLib
 {
-    enum EInstanceClass
+    namespace Daedalus
     {
-        IC_Npc,
-        IC_Mission,
-        IC_Info,
-        IC_Item,
-        IC_ItemReact,
-        IC_Focus,
-        IC_Menu,
-        IC_MenuItem,
-        IC_Sfx,
-        IC_Pfx,
-        IC_MusicTheme
-    };
-
-    template <class C_Class>
-    EInstanceClass enumFromClass();
-
-    enum EParFlag
-    {
-        EParFlag_Const = 1 << 0,
-        EParFlag_Return = 1 << 1,
-        EParFlag_ClassVar = 1 << 2,
-        EParFlag_External = 1 << 3,
-        EParFlag_Merged = 1 << 4
-    };
-
-    enum EParType
-    {
-        EParType_Void = 0,
-        EParType_Float = 1,
-        EParType_Int = 2,
-        EParType_String = 3,
-        EParType_Class = 4,
-        EParType_Func = 5,
-        EParType_Prototype = 6,
-        EParType_Instance = 7
-    };
-
-    enum EParOp : uint8_t
-    {
-        EParOp_Add = 0,              // a + b
-        EParOp_Subract = 1,          // a - b
-        EParOp_Multiply = 2,         // a * b
-        EParOp_Divide = 3,           // a / b
-        EParOp_Mod = 4,              // a % b
-        EParOp_BinOr = 5,            // a | b
-        EParOp_BinAnd = 6,           // a & b
-        EParOp_Less = 7,             // a < b
-        EParOp_Greater = 8,          // a > b
-        EParOp_Assign = 9,           // a = b
-        EParOp_LogOr = 11,           // a || b
-        EParOp_LogAnd = 12,          // a && b
-        EParOp_ShiftLeft = 13,       // a << b
-        EParOp_ShiftRight = 14,      // a >> b
-        EParOp_LessOrEqual = 15,     // a <= b
-        EParOp_Equal = 16,           // a == b
-        EParOp_NotEqual = 17,        // a != b
-        EParOp_GreaterOrEqual = 18,  // a >= b
-        EParOp_AssignAdd = 19,       // a += b (a = a + b)
-        EParOp_AssignSubtract = 20,  // a -= b (a = a - b)
-        EParOp_AssignMultiply = 21,  // a *= b (a = a * b)
-        EParOp_AssignDivide = 22,    // a /= b (a = a / b)
-        EParOp_Plus = 30,            // +a
-        EParOp_Minus = 31,           // -a
-        EParOp_Not = 32,             // !a
-        EParOp_Negate = 33,          // ~a
-                                     //	EParOp_LeftBracket     = 40,    // '('
-                                     //	EParOp_RightBracket    = 41,    // ')'
-                                     //	EParOp_Semicolon       = 42,    // ';'
-                                     //	EParOp_Comma           = 43,    // ','
-                                     //	EParOp_CurlyBracket    = 44,    // '{', '}'
-                                     //	EParOp_None            = 45,
-                                     //	EParOp_Float           = 51,
-                                     //	EParOp_Var             = 52,
-                                     //	EParOp_Operator        = 53,
-        EParOp_Ret = 60,
-        EParOp_Call = 61,
-        EParOp_CallExternal = 62,
-        //	EParOp_PopInt          = 63,
-        EParOp_PushInt = 64,
-        EParOp_PushVar = 65,
-        //	EParOp_PushString      = 66,
-        EParOp_PushInstance = 67,
-        //	EParOp_PushIndex       = 68,
-        //	EParOp_PopVar          = 69,
-        EParOp_AssignString = 70,
-        EParOp_AssignStringRef = 71,
-        EParOp_AssignFunc = 72,
-        EParOp_AssignFloat = 73,
-        EParOp_AssignInstance = 74,
-        EParOp_Jump = 75,
-        EParOp_JumpIf = 76,
-        EParOp_SetInstance = 80,
-        //	EParOp_Skip            = 90,
-        //	EParOp_Label           = 91,
-        //	EParOp_Func            = 92,
-        //	EParOp_FuncEnd         = 93,
-        //	EParOp_Class           = 94,
-        //	EParOp_ClassEnd        = 95,
-        //	EParOp_Instance        = 96,
-        //	EParOp_InstanceEnd     = 97,
-        //	EParOp_String          = 98,
-        //	EParOp_Array           = 180,  // EParOp_Var + 128
-        EParOp_PushArrayVar = 245  // EParOp_PushVar + EParOp_Array
-    };
-
-    std::string eParTypeToString(EParType type);
-
-    struct PARSymbol
-    {
-        PARSymbol()
+        enum EInstanceClass
         {
-            classMemberOffset = -1;
-            classMemberArraySize = 0;
-            instanceDataHandle.invalidate();
-            instanceDataClass = IC_Npc;
-            memset(&properties, 0, sizeof(properties));
-            /*classOffset = 0;
+            IC_Npc,
+            IC_Mission,
+            IC_Info,
+            IC_Item,
+            IC_ItemReact,
+            IC_Focus,
+            IC_Menu,
+            IC_MenuItem,
+            IC_Sfx,
+            IC_Pfx,
+            IC_MusicTheme
+        };
+
+        template <class C_Class>
+        EInstanceClass enumFromClass();
+
+        enum EParFlag
+        {
+            EParFlag_Const = 1 << 0,
+            EParFlag_Return = 1 << 1,
+            EParFlag_ClassVar = 1 << 2,
+            EParFlag_External = 1 << 3,
+            EParFlag_Merged = 1 << 4
+        };
+
+        enum EParType
+        {
+            EParType_Void = 0,
+            EParType_Float = 1,
+            EParType_Int = 2,
+            EParType_String = 3,
+            EParType_Class = 4,
+            EParType_Func = 5,
+            EParType_Prototype = 6,
+            EParType_Instance = 7
+        };
+
+        enum EParOp : uint8_t
+        {
+            EParOp_Add = 0,              // a + b
+            EParOp_Subract = 1,          // a - b
+            EParOp_Multiply = 2,         // a * b
+            EParOp_Divide = 3,           // a / b
+            EParOp_Mod = 4,              // a % b
+            EParOp_BinOr = 5,            // a | b
+            EParOp_BinAnd = 6,           // a & b
+            EParOp_Less = 7,             // a < b
+            EParOp_Greater = 8,          // a > b
+            EParOp_Assign = 9,           // a = b
+            EParOp_LogOr = 11,           // a || b
+            EParOp_LogAnd = 12,          // a && b
+            EParOp_ShiftLeft = 13,       // a << b
+            EParOp_ShiftRight = 14,      // a >> b
+            EParOp_LessOrEqual = 15,     // a <= b
+            EParOp_Equal = 16,           // a == b
+            EParOp_NotEqual = 17,        // a != b
+            EParOp_GreaterOrEqual = 18,  // a >= b
+            EParOp_AssignAdd = 19,       // a += b (a = a + b)
+            EParOp_AssignSubtract = 20,  // a -= b (a = a - b)
+            EParOp_AssignMultiply = 21,  // a *= b (a = a * b)
+            EParOp_AssignDivide = 22,    // a /= b (a = a / b)
+            EParOp_Plus = 30,            // +a
+            EParOp_Minus = 31,           // -a
+            EParOp_Not = 32,             // !a
+            EParOp_Negate = 33,          // ~a
+                                         //	EParOp_LeftBracket     = 40,    // '('
+                                         //	EParOp_RightBracket    = 41,    // ')'
+                                         //	EParOp_Semicolon       = 42,    // ';'
+                                         //	EParOp_Comma           = 43,    // ','
+                                         //	EParOp_CurlyBracket    = 44,    // '{', '}'
+                                         //	EParOp_None            = 45,
+                                         //	EParOp_Float           = 51,
+                                         //	EParOp_Var             = 52,
+                                         //	EParOp_Operator        = 53,
+            EParOp_Ret = 60,
+            EParOp_Call = 61,
+            EParOp_CallExternal = 62,
+            //	EParOp_PopInt          = 63,
+            EParOp_PushInt = 64,
+            EParOp_PushVar = 65,
+            //	EParOp_PushString      = 66,
+            EParOp_PushInstance = 67,
+            //	EParOp_PushIndex       = 68,
+            //	EParOp_PopVar          = 69,
+            EParOp_AssignString = 70,
+            EParOp_AssignStringRef = 71,
+            EParOp_AssignFunc = 72,
+            EParOp_AssignFloat = 73,
+            EParOp_AssignInstance = 74,
+            EParOp_Jump = 75,
+            EParOp_JumpIf = 76,
+            EParOp_SetInstance = 80,
+            //	EParOp_Skip            = 90,
+            //	EParOp_Label           = 91,
+            //	EParOp_Func            = 92,
+            //	EParOp_FuncEnd         = 93,
+            //	EParOp_Class           = 94,
+            //	EParOp_ClassEnd        = 95,
+            //	EParOp_Instance        = 96,
+            //	EParOp_InstanceEnd     = 97,
+            //	EParOp_String          = 98,
+            //	EParOp_Array           = 180,  // EParOp_Var + 128
+            EParOp_PushArrayVar = 245  // EParOp_PushVar + EParOp_Array
+        };
+
+        std::string eParTypeToString(EParType type);
+
+        struct PARSymbol
+        {
+            PARSymbol()
+            {
+                classMemberOffset = -1;
+                classMemberArraySize = 0;
+                instanceDataHandle.invalidate();
+                instanceDataClass = IC_Npc;
+                memset(&properties, 0, sizeof(properties));
+                /*classOffset = 0;
             address = 0;
             classMemberOffset = 0;*/
-            parent = 0xFFFFFFFF;
-        }
-
-        std::string name;
-
-        struct Properties
-        {
-            int32_t offClsRet;  // Offset (ClassVar) | Size (Class) | ReturnType (Func)
-            struct
-            {
-                uint32_t count : 12;  // Count:12, Type:4 (EParType_), Flags:6 (EParFlag_), Space: 1, Reserved:9
-                uint32_t type : 4;    // EParType_*
-                uint32_t flags : 6;   // EParFlag_*
-                uint32_t space : 1;
-                uint32_t reserved : 9;
-            } elemProps;
-
-            struct
-            {
-                uint32_t value : 19;  // Value:19, Reserved:13
-                uint32_t reserved : 13;
-            } fileIndex;
-
-            struct
-            {
-                uint32_t value : 19;  // Value:19, Reserved:13
-                uint32_t reserved : 13;
-            } lineStart;
-
-            struct
-            {
-                uint32_t value : 19;  // Value:19, Reserved:13
-                uint32_t reserved : 13;
-            } lineCount;
-
-            struct
-            {
-                uint32_t value : 24;  // Value:24, Reserved:8
-                uint32_t reserved : 8;
-            } charStart;
-
-            struct
-            {
-                uint32_t value : 24;  // Value:24, Reserved:8
-                uint32_t reserved : 8;
-            } charCount;
-
-        } properties;
-
-        bool hasEParFlag(EParFlag eParFlag)
-        {
-            return static_cast<bool>(properties.elemProps.flags & eParFlag);
-        }
-
-        bool isEParType(EParType eParType)
-        {
-            return properties.elemProps.type == eParType;
-        }
-
-        std::vector<float> floatData;
-        std::vector<int32_t> intData;
-        std::vector<std::string> strData;
-        int32_t classOffset;
-        uint32_t address;
-
-        // Defacto reflections. Offset of the class member to be able to access class members via name
-        int32_t classMemberOffset;  // Not stored in files, only valid for classes to directly write to engine memory
-        // Store array size of the class member var. 1 for scalar members. Useful for bounds checking.
-        uint32_t classMemberArraySize;  // Not stored in files, only valid for classes to directly write to engine memory
-
-        void* instanceData;  // Not stored in files, only valid for classes to directly write to engine memory
-        ZMemory::BigHandle instanceDataHandle;
-        EInstanceClass instanceDataClass;
-
-        uint32_t parent;  // 0xFFFFFFFF (-1) = none
-
-        void warnIndexOutOfBounds(size_t index, size_t size)
-        {
-            LogWarn() << "DaedalusVM: index out of range for: " << name << "[" << size << "], index = " << index;
-        }
-
-        template <class T>
-        T* getClassMember(void* baseAddr)
-        {
-            return reinterpret_cast<T*>(reinterpret_cast<char*>(baseAddr) + classMemberOffset);
-        }
-
-        int32_t& getInt(size_t idx = 0, void* baseAddr = nullptr);
-        std::string& getString(size_t idx = 0, void* baseAddr = nullptr);
-        float& getFloat(size_t idx = 0, void* baseAddr = nullptr);
-
-        template <typename T>
-        std::vector<T>& getDataContainer();
-
-        template <class T>
-        T& getValue(size_t idx = 0, void* baseAddr = nullptr)
-        {
-            bool isClassVar = this->hasEParFlag(EParFlag_ClassVar);
-            if (isClassVar)
-            {
-                bool isRegistered = classMemberOffset != -1;
-                if (!isRegistered)
-                {
-                    LogError() << "DaedalusVM: class data member not registered: " << name;
-                }
-                else if (baseAddr == nullptr)
-                {
-                    LogError() << "DaedalusVM: base address of C_Class is nullptr: " << name;
-                }
-                else if (idx >= classMemberArraySize)
-                {
-                    warnIndexOutOfBounds(idx, classMemberArraySize);
-                    LogError() << "DaedalusVM: index out of range for registered class data member: " << name;
-                }
-                else
-                {
-                    return getClassMember<T>(baseAddr)[idx];
-                }
-                //assert(false);
+                parent = 0xFFFFFFFF;
             }
-            std::vector<T>& data = getDataContainer<T>();
-            // read from symbol's data if not isClassVar or the above failed. (the latter should not happen)
-            if (data.size() <= idx)
+
+            std::string name;
+
+            struct Properties
             {
-                if (!isClassVar)  // only print error message if we did not fall through from above
-                    warnIndexOutOfBounds(idx, data.size());
-                data.resize(idx + 1);
-            }
-            return data[idx];
-        }
+                int32_t offClsRet;  // Offset (ClassVar) | Size (Class) | ReturnType (Func)
+                struct
+                {
+                    uint32_t count : 12;  // Count:12, Type:4 (EParType_), Flags:6 (EParFlag_), Space: 1, Reserved:9
+                    uint32_t type : 4;    // EParType_*
+                    uint32_t flags : 6;   // EParFlag_*
+                    uint32_t space : 1;
+                    uint32_t reserved : 9;
+                } elemProps;
 
-        void set(int32_t v, size_t idx = 0, void* baseAddr = nullptr)
-        {
-            switch (properties.elemProps.type)
+                struct
+                {
+                    uint32_t value : 19;  // Value:19, Reserved:13
+                    uint32_t reserved : 13;
+                } fileIndex;
+
+                struct
+                {
+                    uint32_t value : 19;  // Value:19, Reserved:13
+                    uint32_t reserved : 13;
+                } lineStart;
+
+                struct
+                {
+                    uint32_t value : 19;  // Value:19, Reserved:13
+                    uint32_t reserved : 13;
+                } lineCount;
+
+                struct
+                {
+                    uint32_t value : 24;  // Value:24, Reserved:8
+                    uint32_t reserved : 8;
+                } charStart;
+
+                struct
+                {
+                    uint32_t value : 24;  // Value:24, Reserved:8
+                    uint32_t reserved : 8;
+                } charCount;
+
+            } properties;
+
+            bool hasEParFlag(EParFlag eParFlag)
             {
-                case EParType_Func:
-                    address = v;
-
-                    if (baseAddr && classMemberOffset != -1)
-                        *reinterpret_cast<int32_t*>(reinterpret_cast<char*>(baseAddr) + classMemberOffset + (sizeof(int32_t) * idx)) = v;
-                    break;
-                default:
-                    assert(false);
+                return static_cast<bool>(properties.elemProps.flags & eParFlag);
             }
-        }
 
-        bool isDataSame(const PARSymbol& other) const
+            bool isEParType(EParType eParType)
+            {
+                return properties.elemProps.type == eParType;
+            }
+
+            std::vector<float> floatData;
+            std::vector<int32_t> intData;
+            std::vector<std::string> strData;
+            int32_t classOffset;
+            uint32_t address;
+
+            // Defacto reflections. Offset of the class member to be able to access class members via name
+            int32_t classMemberOffset;  // Not stored in files, only valid for classes to directly write to engine memory
+            // Store array size of the class member var. 1 for scalar members. Useful for bounds checking.
+            uint32_t classMemberArraySize;  // Not stored in files, only valid for classes to directly write to engine memory
+
+            void* instanceData;  // Not stored in files, only valid for classes to directly write to engine memory
+            ZMemory::BigHandle instanceDataHandle;
+            EInstanceClass instanceDataClass;
+
+            uint32_t parent;  // 0xFFFFFFFF (-1) = none
+
+            void warnIndexOutOfBounds(size_t index, size_t size)
+            {
+                LogWarn() << "DaedalusVM: index out of range for: " << name << "[" << size << "], index = " << index;
+            }
+
+            template <class T>
+            T* getClassMember(void* baseAddr)
+            {
+                return reinterpret_cast<T*>(reinterpret_cast<char*>(baseAddr) + classMemberOffset);
+            }
+
+            int32_t& getInt(size_t idx = 0, void* baseAddr = nullptr);
+            std::string& getString(size_t idx = 0, void* baseAddr = nullptr);
+            float& getFloat(size_t idx = 0, void* baseAddr = nullptr);
+
+            template <typename T>
+            std::vector<T>& getDataContainer();
+
+            template <class T>
+            T& getValue(size_t idx = 0, void* baseAddr = nullptr)
+            {
+                bool isClassVar = this->hasEParFlag(EParFlag_ClassVar);
+                if (isClassVar)
+                {
+                    bool isRegistered = classMemberOffset != -1;
+                    if (!isRegistered)
+                    {
+                        LogError() << "DaedalusVM: class data member not registered: " << name;
+                    }
+                    else if (baseAddr == nullptr)
+                    {
+                        LogError() << "DaedalusVM: base address of C_Class is nullptr: " << name;
+                    }
+                    else if (idx >= classMemberArraySize)
+                    {
+                        warnIndexOutOfBounds(idx, classMemberArraySize);
+                        LogError() << "DaedalusVM: index out of range for registered class data member: " << name;
+                    }
+                    else
+                    {
+                        return getClassMember<T>(baseAddr)[idx];
+                    }
+                    //assert(false);
+                }
+                std::vector<T>& data = getDataContainer<T>();
+                // read from symbol's data if not isClassVar or the above failed. (the latter should not happen)
+                if (data.size() <= idx)
+                {
+                    if (!isClassVar)  // only print error message if we did not fall through from above
+                        warnIndexOutOfBounds(idx, data.size());
+                    data.resize(idx + 1);
+                }
+                return data[idx];
+            }
+
+            void set(int32_t v, size_t idx = 0, void* baseAddr = nullptr)
+            {
+                switch (properties.elemProps.type)
+                {
+                    case EParType_Func:
+                        address = v;
+
+                        if (baseAddr && classMemberOffset != -1)
+                            *reinterpret_cast<int32_t*>(reinterpret_cast<char*>(baseAddr) + classMemberOffset + (sizeof(int32_t) * idx)) = v;
+                        break;
+                    default:
+                        assert(false);
+                }
+            }
+
+            bool isDataSame(const PARSymbol& other) const
+            {
+                return intData == other.intData && floatData == other.floatData && strData == other.strData;
+            }
+        };
+
+        struct PARSymTable
         {
-            return intData == other.intData && floatData == other.floatData && strData == other.strData;
-        }
-    };
+            std::vector<uint32_t> sortTable;
+            std::vector<PARSymbol> symbols;
+            std::unordered_map<std::string, size_t> symbolsByName;
+            std::unordered_map<size_t, size_t> functionsByAddress;
+        };
 
-    struct PARSymTable
-    {
-        std::vector<uint32_t> sortTable;
-        std::vector<PARSymbol> symbols;
-        std::unordered_map<std::string, size_t> symbolsByName;
-        std::unordered_map<size_t, size_t> functionsByAddress;
-    };
+        struct PARStack
+        {
+            size_t stackOffset;
+            size_t stackSize;
+        };
 
-    struct PARStack
-    {
-        size_t stackOffset;
-        size_t stackSize;
-    };
+        struct PARStackOpCode
+        {
+            EParOp op;
 
-    struct PARStackOpCode
-    {
-        EParOp op;
-
-        /**
+            /**
          * These are valid depending on "op"
          */
-        int32_t address;  // EParOp_Call, EParOp_Jump, EParOp_JumpIf,
-        int32_t symbol;   // EParOp_CallExternal, EParOp_PushVar, EParOp_PushInstance, EParOp_SetInstance, EParOp_PushArrayVar
-        int32_t value;    // EParOp_PushInt
-        uint8_t index;    // EParOp_PushArrayVar
+            int32_t address;  // EParOp_Call, EParOp_Jump, EParOp_JumpIf,
+            int32_t symbol;   // EParOp_CallExternal, EParOp_PushVar, EParOp_PushInstance, EParOp_SetInstance, EParOp_PushArrayVar
+            int32_t value;    // EParOp_PushInt
+            uint8_t index;    // EParOp_PushArrayVar
 
-        size_t opSize;  // Size of this operation
-    };
+            size_t opSize;  // Size of this operation
+        };
 
-    struct PARInstance
-    {
-        std::map<std::string, uint32_t> symbolsByName;
-    };
+        struct PARInstance
+        {
+            std::map<std::string, uint32_t> symbolsByName;
+        };
 
-    class DATFile
-    {
-    public:
-        DATFile();
-        DATFile(const std::string& file, bool verbose = false);
-        DATFile(const uint8_t* pData, size_t numBytes, bool verbose = false);
+        class DATFile
+        {
+        public:
+            DATFile();
+            DATFile(const std::string& file, bool verbose = false);
+            DATFile(const uint8_t* pData, size_t numBytes, bool verbose = false);
 
-        void parseFile();
+            void parseFile();
 
-        /**
+            /**
 		 * @return True, when a symbol with the given name exists
 		 */
-        bool hasSymbolName(const std::string& symName);
+            bool hasSymbolName(const std::string& symName);
 
-        /**
+            /**
 		 * @return The symbol connected to the given name
 		 */
-        PARSymbol& getSymbolByName(const std::string& symName);
-        size_t getSymbolIndexByName(const std::string& symName);
-        PARSymbol& getSymbolByIndex(size_t idx);
+            PARSymbol& getSymbolByName(const std::string& symName);
+            size_t getSymbolIndexByName(const std::string& symName);
+            PARSymbol& getSymbolByIndex(size_t idx);
 
-        /**
+            /**
 		 * @return Function symbol index that points to the given address. returns -1 if address was not found
 		 */
-        size_t getFunctionIndexByAddress(size_t address);
-        /**
+            size_t getFunctionIndexByAddress(size_t address);
+            /**
 		 * Goes through all symbols and calls the given callback for every instance of the specified class
 		 */
-        void iterateSymbolsOfClass(const std::string& className, std::function<void(size_t, PARSymbol&)> callback);
+            void iterateSymbolsOfClass(const std::string& className, std::function<void(size_t, PARSymbol&)> callback);
 
-        /**
+            /**
 		 * @return Object containing information about the opcode currently on the stack
 		 */
-        PARStackOpCode getStackOpCode(size_t pc);
+            PARStackOpCode getStackOpCode(size_t pc);
 
-        /**
+            /**
 		 * Adds a symbol and returns it's index. Note that if you change the name of this, the new symbol
 		 * won't be added to the SymbolByName-Map
 		 */
-        size_t addSymbol();
+            size_t addSymbol();
 
-        const PARSymTable& getSymTable() const { return m_SymTable; }
-        const PARStack& getStack() const { return m_Stack; }
+            const PARSymTable& getSymTable() const { return m_SymTable; }
+            const PARStack& getStack() const { return m_Stack; }
 
-        // TODO move into Utils
-        /**
+            // TODO move into Utils
+            /**
          * this overload targets non-arrays. scalars have a length of 1
          * @param scalar
          * @return
          */
-        template <class T>
-        static constexpr std::size_t arraySize(const T& scalar)
-        {
-            return 1;
-        }
+            template <class T>
+            static constexpr std::size_t arraySize(const T& scalar)
+            {
+                return 1;
+            }
 
-        // TODO move into Utils
-        /**
+            // TODO move into Utils
+            /**
          * determines the number of elements of a c-array at compiletime.
          * @param array
          * @return
          */
-        template <class T, size_t N>
-        static constexpr std::size_t arraySize(const T (&array)[N])
-        {
-            return N;
-        }
+            template <class T, size_t N>
+            static constexpr std::size_t arraySize(const T (&array)[N])
+            {
+                return N;
+            }
 
-        /**
+            /**
          * Calculates and registers the offset and array-size of the given class-data-member
          * @tparam C_Class
          * @tparam MemberClass
@@ -392,27 +394,28 @@ namespace Daedalus
          * @param obj object of class C_Class
          * @param member this variable reference must be a member of the given obj
          */
-        template <class C_Class, class MemberClass>
-        void registerMember(const std::string& symbolName, const C_Class& obj, const MemberClass& member, bool checkIfExists = false)
-        {
-            if (checkIfExists && !hasSymbolName(symbolName))
-                return;
-            auto& parSymbol = getSymbolByName(symbolName);
-            int32_t offset = static_cast<int32_t>(((char*)&member) - ((char*)&obj));
-            parSymbol.classMemberOffset = offset;
-            parSymbol.classMemberArraySize = static_cast<uint32_t>(arraySize(member));
-        }
+            template <class C_Class, class MemberClass>
+            void registerMember(const std::string& symbolName, const C_Class& obj, const MemberClass& member, bool checkIfExists = false)
+            {
+                if (checkIfExists && !hasSymbolName(symbolName))
+                    return;
+                auto& parSymbol = getSymbolByName(symbolName);
+                int32_t offset = static_cast<int32_t>(((char*)&member) - ((char*)&obj));
+                parSymbol.classMemberOffset = offset;
+                parSymbol.classMemberArraySize = static_cast<uint32_t>(arraySize(member));
+            }
 
-    private:
-        void readSymTable();
-        void readStack();
+        private:
+            void readSymTable();
+            void readStack();
 
-        ZenLoad::ZenParser m_Parser;
+            ZenLoad::ZenParser m_Parser;
 
-        PARSymTable m_SymTable;
-        PARStack m_Stack;
+            PARSymTable m_SymTable;
+            PARStack m_Stack;
 
-        bool m_Verbose;
-    };
+            bool m_Verbose;
+        };
 
-}  // namespace Daedalus
+    }  // namespace Daedalus
+}  // namespace ZenLib

--- a/daedalus/DaedalusDialogManager.cpp
+++ b/daedalus/DaedalusDialogManager.cpp
@@ -4,67 +4,71 @@
 #include "DaedalusVM.h"
 #include <utils/logger.h>
 
-using namespace Daedalus;
-using namespace GameState;
-using namespace ZenLoad;
-
-DaedalusDialogManager::DaedalusDialogManager(Daedalus::DaedalusVM& vm,
-                                             const std::string& ou_bin,
-                                             const VDFS::FileIndex& vdfsFileIndex,
-                                             std::map<size_t, std::set<size_t>>& knownInfos)
-    : m_VM(vm)
-    , m_MessageLib(ou_bin, vdfsFileIndex)
-    , m_KnownNpcInfoSymbolsByNpcSymbols(knownInfos)
+namespace ZenLib
 {
-    gatherNpcInformation();
-}
+    using namespace Daedalus;
+    using namespace GameState;
+    using namespace ZenLoad;
 
-DaedalusDialogManager::DaedalusDialogManager(Daedalus::DaedalusVM& vm,
-                                             const std::string& ou_bin,
-                                             std::map<size_t, std::set<size_t>>& knownInfos)
-    : m_VM(vm)
-    , m_MessageLib(ou_bin)
-    , m_KnownNpcInfoSymbolsByNpcSymbols(knownInfos)
-{
-    gatherNpcInformation();
-}
-
-void DaedalusDialogManager::gatherNpcInformation()
-{
-    m_VM.getDATFile().iterateSymbolsOfClass("C_Info", [&](size_t i, Daedalus::PARSymbol& s) {
-        // Create new info-object
-        InfoHandle h = m_VM.getGameState().createInfo();
-        Daedalus::GEngineClasses::C_Info& info = m_VM.getGameState().getInfo(h);
-        m_VM.initializeInstance(ZMemory::toBigHandle(h), i, Daedalus::IC_Info);
-
-        // Add to vector
-        m_NpcInfos.push_back(h);
-    });
-}
-
-void DaedalusDialogManager::setNpcInfoKnown(size_t npcInstance, size_t infoInstance)
-{
-    //LogInfo() << "He knows! (" << m_VM.getDATFile().getSymbolByIndex(npcInstance).name << " -> " << m_VM.getDATFile().getSymbolByIndex(infoInstance).name << ")!";
-    m_KnownNpcInfoSymbolsByNpcSymbols[npcInstance].insert(infoInstance);
-}
-
-std::vector<InfoHandle> DaedalusDialogManager::getInfos(NpcHandle hnpc)
-{
-    Daedalus::GEngineClasses::C_Npc& npc = m_VM.getGameState().getNpc(hnpc);
-    std::vector<InfoHandle> result;
-    for (auto& infoHandle : m_NpcInfos)
+    DaedalusDialogManager::DaedalusDialogManager(Daedalus::DaedalusVM& vm,
+                                                 const std::string& ou_bin,
+                                                 const VDFS::FileIndex& vdfsFileIndex,
+                                                 std::map<size_t, std::set<size_t>>& knownInfos)
+        : m_VM(vm)
+        , m_MessageLib(ou_bin, vdfsFileIndex)
+        , m_KnownNpcInfoSymbolsByNpcSymbols(knownInfos)
     {
-        Daedalus::GEngineClasses::C_Info& info = m_VM.getGameState().getInfo(infoHandle);
-        if (static_cast<size_t>(info.npc) == npc.instanceSymbol)
-        {
-            result.push_back(infoHandle);
-        }
+        gatherNpcInformation();
     }
-    return result;
-}
 
-bool DaedalusDialogManager::doesNpcKnowInfo(size_t npcInstance, size_t infoInstance)
-{
-    const auto& m = m_KnownNpcInfoSymbolsByNpcSymbols[npcInstance];
-    return m.find(infoInstance) != m.end();
-}
+    DaedalusDialogManager::DaedalusDialogManager(Daedalus::DaedalusVM& vm,
+                                                 const std::string& ou_bin,
+                                                 std::map<size_t, std::set<size_t>>& knownInfos)
+        : m_VM(vm)
+        , m_MessageLib(ou_bin)
+        , m_KnownNpcInfoSymbolsByNpcSymbols(knownInfos)
+    {
+        gatherNpcInformation();
+    }
+
+    void DaedalusDialogManager::gatherNpcInformation()
+    {
+        m_VM.getDATFile().iterateSymbolsOfClass("C_Info", [&](size_t i, Daedalus::PARSymbol& s)
+                                                {
+                                                    // Create new info-object
+                                                    InfoHandle h = m_VM.getGameState().createInfo();
+                                                    Daedalus::GEngineClasses::C_Info& info = m_VM.getGameState().getInfo(h);
+                                                    m_VM.initializeInstance(ZMemory::toBigHandle(h), i, Daedalus::IC_Info);
+
+                                                    // Add to vector
+                                                    m_NpcInfos.push_back(h);
+                                                });
+    }
+
+    void DaedalusDialogManager::setNpcInfoKnown(size_t npcInstance, size_t infoInstance)
+    {
+        //LogInfo() << "He knows! (" << m_VM.getDATFile().getSymbolByIndex(npcInstance).name << " -> " << m_VM.getDATFile().getSymbolByIndex(infoInstance).name << ")!";
+        m_KnownNpcInfoSymbolsByNpcSymbols[npcInstance].insert(infoInstance);
+    }
+
+    std::vector<InfoHandle> DaedalusDialogManager::getInfos(NpcHandle hnpc)
+    {
+        Daedalus::GEngineClasses::C_Npc& npc = m_VM.getGameState().getNpc(hnpc);
+        std::vector<InfoHandle> result;
+        for (auto& infoHandle : m_NpcInfos)
+        {
+            Daedalus::GEngineClasses::C_Info& info = m_VM.getGameState().getInfo(infoHandle);
+            if (static_cast<size_t>(info.npc) == npc.instanceSymbol)
+            {
+                result.push_back(infoHandle);
+            }
+        }
+        return result;
+    }
+
+    bool DaedalusDialogManager::doesNpcKnowInfo(size_t npcInstance, size_t infoInstance)
+    {
+        const auto& m = m_KnownNpcInfoSymbolsByNpcSymbols[npcInstance];
+        return m.find(infoInstance) != m.end();
+    }
+}  // namespace ZenLib

--- a/daedalus/DaedalusDialogManager.h
+++ b/daedalus/DaedalusDialogManager.h
@@ -6,88 +6,91 @@
 #include "DaedalusGameState.h"
 #include <zenload/zCCSLib.h>
 
-namespace ZenLoad
+namespace ZenLib
 {
-    struct oCMsgConversationData;
-}
-
-namespace VDFS
-{
-    class FileIndex;
-}
-
-namespace Daedalus
-{
-    class DaedalusVM;
-
-    namespace GameState
+    namespace ZenLoad
     {
-        class DaedalusDialogManager
-        {
-        public:
-            DaedalusDialogManager(Daedalus::DaedalusVM& vm,
-                                  const std::string& ou_bin,
-                                  std::map<size_t, std::set<size_t>>& knownInfos);
+        struct oCMsgConversationData;
+    }
 
-            DaedalusDialogManager(Daedalus::DaedalusVM& vm,
-                                  const std::string& ou_bin,
-                                  const VDFS::FileIndex& vdfsFileIndex,
-                                  std::map<size_t, std::set<size_t>>& knownInfos);
-            /**
+    namespace VDFS
+    {
+        class FileIndex;
+    }
+
+    namespace Daedalus
+    {
+        class DaedalusVM;
+
+        namespace GameState
+        {
+            class DaedalusDialogManager
+            {
+            public:
+                DaedalusDialogManager(Daedalus::DaedalusVM& vm,
+                                      const std::string& ou_bin,
+                                      std::map<size_t, std::set<size_t>>& knownInfos);
+
+                DaedalusDialogManager(Daedalus::DaedalusVM& vm,
+                                      const std::string& ou_bin,
+                                      const VDFS::FileIndex& vdfsFileIndex,
+                                      std::map<size_t, std::set<size_t>>& knownInfos);
+                /**
 			 * Sets the given info-instance as "known" to the given NPC-Instance
 			 */
-            void setNpcInfoKnown(size_t npcInstance, size_t infoInstance);
+                void setNpcInfoKnown(size_t npcInstance, size_t infoInstance);
 
-            /**
+                /**
              * Checks whether the given NPC knows the info passed here
              * @param npcInstance NPC to check
              * @param infoInstance Info to check
              * @return Whether the NPC knows
              */
-            bool doesNpcKnowInfo(size_t npcInstance, size_t infoInstance);
+                bool doesNpcKnowInfo(size_t npcInstance, size_t infoInstance);
 
-            /**
+                /**
              * get vector of InfoHandles for this npc
              * @param npc NPC to process infos for
              */
-            std::vector<InfoHandle> getInfos(NpcHandle npc);
+                std::vector<InfoHandle> getInfos(NpcHandle npc);
 
-            /**
+                /**
              * @return Map of NPC-Symbols -> All info they know
              */
-            const std::map<size_t, std::set<size_t>>& getKnownNPCInformation() { return m_KnownNpcInfoSymbolsByNpcSymbols; };
+                const std::map<size_t, std::set<size_t>>& getKnownNPCInformation() { return m_KnownNpcInfoSymbolsByNpcSymbols; };
 
-            /**
+                /**
              * @return MessageLib
              */
-            ZenLoad::zCCSLib& getMessageLib() { return m_MessageLib; }
+                ZenLoad::zCCSLib& getMessageLib() { return m_MessageLib; }
 
-        private:
-            /**
+            private:
+                /**
 			 * Gathers all C_Info-Instances and puts them into m_NpcInfosByNpcSymbols
 			 */
-            void gatherNpcInformation();
+                void gatherNpcInformation();
 
-            /**
+                /**
 			 * Message library
 			 */
-            ZenLoad::zCCSLib m_MessageLib;
+                ZenLoad::zCCSLib m_MessageLib;
 
-            /**
+                /**
 			 * Current daedalus VM
 			 */
-            Daedalus::DaedalusVM& m_VM;
+                Daedalus::DaedalusVM& m_VM;
 
-            /**
+                /**
 			 * vector of all C_Info handles, can't use map here (infos by npc)
              * since the VM changes C_Info.npc before talking to an ambient npc
 			 */
-            std::vector<InfoHandle> m_NpcInfos;
+                std::vector<InfoHandle> m_NpcInfos;
 
-            /**
+                /**
 			 * map of all known infoInstances by npcInstance
 			 */
-            std::map<size_t, std::set<size_t>>& m_KnownNpcInfoSymbolsByNpcSymbols;
-        };
-    }  // namespace GameState
-}  // namespace Daedalus
+                std::map<size_t, std::set<size_t>>& m_KnownNpcInfoSymbolsByNpcSymbols;
+            };
+        }  // namespace GameState
+    }      // namespace Daedalus
+}  // namespace ZenLib

--- a/daedalus/DaedalusGameState.cpp
+++ b/daedalus/DaedalusGameState.cpp
@@ -7,73 +7,79 @@
 #include "DaedalusVM.h"
 #include <utils/logger.h>
 
-using namespace ZenLoad;
-using namespace Daedalus;
-using namespace GameState;
-
-DaedalusGameState::DaedalusGameState(Daedalus::DaedalusVM& vm)
-    : m_VM(vm)
+namespace ZenLib
 {
-    // Register external lib-functions
-}
+    using namespace ZenLoad;
+    using namespace Daedalus;
+    using namespace GameState;
 
-void DaedalusGameState::registerExternals()
-{
-    bool l = false;
+    DaedalusGameState::DaedalusGameState(Daedalus::DaedalusVM& vm)
+        : m_VM(vm)
+    {
+        // Register external lib-functions
+    }
 
-    m_VM.registerExternalFunction("wld_insertitem", [=](Daedalus::DaedalusVM& vm) {
-        std::string spawnpoint = vm.popString();
-        if (l) LogInfo() << "spawnpoint: " << spawnpoint;
-        uint32_t iteminstance = vm.popDataValue();
-        if (l) LogInfo() << "iteminstance: " << iteminstance;
+    void DaedalusGameState::registerExternals()
+    {
+        bool l = false;
 
-        ItemHandle item = createItem();
-        GEngineClasses::C_Item& itemData = getItem(item);
-        vm.initializeInstance(ZMemory::toBigHandle(item), iteminstance, IC_Item);
+        m_VM.registerExternalFunction("wld_insertitem", [=](Daedalus::DaedalusVM& vm)
+                                      {
+                                          std::string spawnpoint = vm.popString();
+                                          if (l) LogInfo() << "spawnpoint: " << spawnpoint;
+                                          uint32_t iteminstance = vm.popDataValue();
+                                          if (l) LogInfo() << "iteminstance: " << iteminstance;
 
-        if (l) LogInfo() << " ##### Created item: " << itemData.name;
+                                          ItemHandle item = createItem();
+                                          GEngineClasses::C_Item& itemData = getItem(item);
+                                          vm.initializeInstance(ZMemory::toBigHandle(item), iteminstance, IC_Item);
 
-        if (m_GameExternals.wld_insertitem)
-            m_GameExternals.wld_insertitem(item);
-    });
+                                          if (l) LogInfo() << " ##### Created item: " << itemData.name;
 
-    m_VM.registerExternalFunction("createinvitem", [=](Daedalus::DaedalusVM& vm) {
-        uint32_t itemInstance = (uint32_t)vm.popDataValue();
-        if (l) LogInfo() << "itemInstance: " << itemInstance;
-        uint32_t arr_n0;
-        int32_t npc = vm.popVar(arr_n0);
+                                          if (m_GameExternals.wld_insertitem)
+                                              m_GameExternals.wld_insertitem(item);
+                                      });
 
-        NpcHandle hnpc = ZMemory::handleCast<NpcHandle>(m_VM.getDATFile().getSymbolByIndex(npc).instanceDataHandle);
+        m_VM.registerExternalFunction("createinvitem", [=](Daedalus::DaedalusVM& vm)
+                                      {
+                                          uint32_t itemInstance = (uint32_t)vm.popDataValue();
+                                          if (l) LogInfo() << "itemInstance: " << itemInstance;
+                                          uint32_t arr_n0;
+                                          int32_t npc = vm.popVar(arr_n0);
 
-        ItemHandle h = createInventoryItem(itemInstance, hnpc);
-        (void)h;
+                                          NpcHandle hnpc = ZMemory::handleCast<NpcHandle>(m_VM.getDATFile().getSymbolByIndex(npc).instanceDataHandle);
 
-        //LogInfo() << "1: " << item.name;
-        //LogInfo() << "2. " << npcData.name[0];
-        //LogInfo() << " ##### Created Inventory-Item '" << item.name << "' for NPC: " << npcData.name[0];
-    });
+                                          ItemHandle h = createInventoryItem(itemInstance, hnpc);
+                                          (void)h;
 
-    m_VM.registerExternalFunction("createinvitems", [=](Daedalus::DaedalusVM& vm) {
-        uint32_t num = (uint32_t)vm.popDataValue();
-        uint32_t itemInstance = (uint32_t)vm.popDataValue();
-        if (l) LogInfo() << "itemInstance: " << itemInstance;
-        uint32_t arr_n0;
-        int32_t npc = vm.popVar(arr_n0);
+                                          //LogInfo() << "1: " << item.name;
+                                          //LogInfo() << "2. " << npcData.name[0];
+                                          //LogInfo() << " ##### Created Inventory-Item '" << item.name << "' for NPC: " << npcData.name[0];
+                                      });
 
-        NpcHandle hnpc = ZMemory::handleCast<NpcHandle>(m_VM.getDATFile().getSymbolByIndex(npc).instanceDataHandle);
+        m_VM.registerExternalFunction("createinvitems", [=](Daedalus::DaedalusVM& vm)
+                                      {
+                                          uint32_t num = (uint32_t)vm.popDataValue();
+                                          uint32_t itemInstance = (uint32_t)vm.popDataValue();
+                                          if (l) LogInfo() << "itemInstance: " << itemInstance;
+                                          uint32_t arr_n0;
+                                          int32_t npc = vm.popVar(arr_n0);
 
-        createInventoryItem(itemInstance, hnpc, num);
+                                          NpcHandle hnpc = ZMemory::handleCast<NpcHandle>(m_VM.getDATFile().getSymbolByIndex(npc).instanceDataHandle);
 
-        //LogInfo() << "1: " << item.name;
-        //LogInfo() << "2. " << npcData.name[0];
-        //LogInfo() << " ##### Created Inventory-Item '" << item.name << "' for NPC: " << npcData.name[0];
-    });
+                                          createInventoryItem(itemInstance, hnpc, num);
 
-    m_VM.registerExternalFunction("hlp_getnpc", [=](Daedalus::DaedalusVM& vm) {
-        int32_t instancename = vm.popDataValue();
-        if (l) LogInfo() << "instancename: " << instancename;
+                                          //LogInfo() << "1: " << item.name;
+                                          //LogInfo() << "2. " << npcData.name[0];
+                                          //LogInfo() << " ##### Created Inventory-Item '" << item.name << "' for NPC: " << npcData.name[0];
+                                      });
 
-        /*if(!vm.getDATFile().getSymbolByIndex(instancename).instanceDataHandle.isValid())
+        m_VM.registerExternalFunction("hlp_getnpc", [=](Daedalus::DaedalusVM& vm)
+                                      {
+                                          int32_t instancename = vm.popDataValue();
+                                          if (l) LogInfo() << "instancename: " << instancename;
+
+                                          /*if(!vm.getDATFile().getSymbolByIndex(instancename).instanceDataHandle.isValid())
         {
 			
         }else
@@ -83,341 +89,344 @@ void DaedalusGameState::registerExternals()
                   << npcData.name[0];
         }*/
 
-        vm.setReturnVar(instancename);
-    });
+                                          vm.setReturnVar(instancename);
+                                      });
 
-    m_VM.registerExternalFunction("hlp_isvalidnpc", [=](Daedalus::DaedalusVM& vm) {
-        int32_t self = vm.popVar();
+        m_VM.registerExternalFunction("hlp_isvalidnpc", [=](Daedalus::DaedalusVM& vm)
+                                      {
+                                          int32_t self = vm.popVar();
 
-        if (vm.getDATFile().getSymbolByIndex(self).instanceDataHandle.isValid())
-        {
-            vm.setReturn(1);
-        }
-        else
-        {
-            vm.setReturn(0);
-        }
-    });
+                                          if (vm.getDATFile().getSymbolByIndex(self).instanceDataHandle.isValid())
+                                          {
+                                              vm.setReturn(1);
+                                          }
+                                          else
+                                          {
+                                              vm.setReturn(0);
+                                          }
+                                      });
 
-    m_VM.registerExternalFunction("Wld_GetDay", [=](Daedalus::DaedalusVM& vm) {
-        if (m_GameExternals.wld_GetDay)
-            vm.setReturn(m_GameExternals.wld_GetDay());
-        else
-            vm.setReturn(0);
-    });
-}
-
-Daedalus::GEngineClasses::Instance* DaedalusGameState::getByClass(ZMemory::BigHandle h, EInstanceClass instClass)
-{
-    if (!h.isValid()) return nullptr;
-
-    switch (instClass)
-    {
-        case IC_Npc:
-            return &getNpc(ZMemory::handleCast<NpcHandle>(h));
-
-        case IC_Item:
-            return &getItem(ZMemory::handleCast<ItemHandle>(h));
-
-        case IC_Mission:
-            return &getMission(ZMemory::handleCast<MissionHandle>(h));
-
-        case IC_Info:
-            return &getInfo(ZMemory::handleCast<InfoHandle>(h));
-
-        case IC_ItemReact:
-            return &getItemReact(ZMemory::handleCast<ItemReactHandle>(h));
-
-        case IC_Focus:
-            return &getFocus(ZMemory::handleCast<FocusHandle>(h));
-
-        case IC_Menu:
-            return &getMenu(ZMemory::handleCast<MenuHandle>(h));
-
-        case IC_MenuItem:
-            return &getMenuItem(ZMemory::handleCast<MenuItemHandle>(h));
-
-        case IC_Sfx:
-            return &getSfx(ZMemory::handleCast<SfxHandle>(h));
-
-        case IC_Pfx:
-            return &getPfx(ZMemory::handleCast<PfxHandle>(h));
-
-        case IC_MusicTheme:
-            return &getMusicTheme(ZMemory::handleCast<MusicThemeHandle>(h));
-
-        default:
-            return nullptr;
+        m_VM.registerExternalFunction("Wld_GetDay", [=](Daedalus::DaedalusVM& vm)
+                                      {
+                                          if (m_GameExternals.wld_GetDay)
+                                              vm.setReturn(m_GameExternals.wld_GetDay());
+                                          else
+                                              vm.setReturn(0);
+                                      });
     }
-}
 
-template <typename C_Class>
-CHandle<C_Class> DaedalusGameState::create()
-{
-    CHandle<C_Class> h = m_RegisteredObjects.get<C_Class>().createObject();
-    // important! overwrite uninitialized memory with initialized C_Class
-    get<C_Class>(h) = C_Class();
-
-    if (m_OnInstanceCreated)
-        m_OnInstanceCreated(ZMemory::toBigHandle(h), enumFromClass<C_Class>());
-
-    return h;
-}
-
-NpcHandle DaedalusGameState::createNPC()
-{
-    return create<GEngineClasses::C_Npc>();
-}
-
-ItemHandle DaedalusGameState::createItem()
-{
-    return create<GEngineClasses::C_Item>();
-}
-
-ItemReactHandle DaedalusGameState::createItemReact()
-{
-    return create<GEngineClasses::C_ItemReact>();
-}
-
-MissionHandle DaedalusGameState::createMission()
-{
-    return create<GEngineClasses::C_Mission>();
-}
-
-InfoHandle DaedalusGameState::createInfo()
-{
-    return create<GEngineClasses::C_Info>();
-}
-
-FocusHandle DaedalusGameState::createFocus()
-{
-    return create<GEngineClasses::C_Focus>();
-}
-
-SfxHandle DaedalusGameState::createSfx()
-{
-    return create<GEngineClasses::C_SFX>();
-}
-
-PfxHandle DaedalusGameState::createPfx()
-{
-    return create<GEngineClasses::C_ParticleFX>();
-}
-
-FocusHandle DaedalusGameState::createMenu()
-{
-    return create<GEngineClasses::C_Menu>();
-}
-
-FocusHandle DaedalusGameState::createMenuItem()
-{
-    return create<GEngineClasses::C_Menu_Item>();
-}
-
-MusicThemeHandle DaedalusGameState::createMusicTheme()
-{
-    return create<GEngineClasses::C_MusicTheme>();
-}
-
-ItemHandle DaedalusGameState::createInventoryItem(size_t itemSymbol, NpcHandle npc, unsigned int count)
-{
-    auto items = m_NpcInventories[npc];
-
-    // Try to find an item of this type
-    for (ItemHandle h : items)
+    Daedalus::GEngineClasses::Instance* DaedalusGameState::getByClass(ZMemory::BigHandle h, EInstanceClass instClass)
     {
+        if (!h.isValid()) return nullptr;
+
+        switch (instClass)
+        {
+            case IC_Npc:
+                return &getNpc(ZMemory::handleCast<NpcHandle>(h));
+
+            case IC_Item:
+                return &getItem(ZMemory::handleCast<ItemHandle>(h));
+
+            case IC_Mission:
+                return &getMission(ZMemory::handleCast<MissionHandle>(h));
+
+            case IC_Info:
+                return &getInfo(ZMemory::handleCast<InfoHandle>(h));
+
+            case IC_ItemReact:
+                return &getItemReact(ZMemory::handleCast<ItemReactHandle>(h));
+
+            case IC_Focus:
+                return &getFocus(ZMemory::handleCast<FocusHandle>(h));
+
+            case IC_Menu:
+                return &getMenu(ZMemory::handleCast<MenuHandle>(h));
+
+            case IC_MenuItem:
+                return &getMenuItem(ZMemory::handleCast<MenuItemHandle>(h));
+
+            case IC_Sfx:
+                return &getSfx(ZMemory::handleCast<SfxHandle>(h));
+
+            case IC_Pfx:
+                return &getPfx(ZMemory::handleCast<PfxHandle>(h));
+
+            case IC_MusicTheme:
+                return &getMusicTheme(ZMemory::handleCast<MusicThemeHandle>(h));
+
+            default:
+                return nullptr;
+        }
+    }
+
+    template <typename C_Class>
+    CHandle<C_Class> DaedalusGameState::create()
+    {
+        CHandle<C_Class> h = m_RegisteredObjects.get<C_Class>().createObject();
+        // important! overwrite uninitialized memory with initialized C_Class
+        get<C_Class>(h) = C_Class();
+
+        if (m_OnInstanceCreated)
+            m_OnInstanceCreated(ZMemory::toBigHandle(h), enumFromClass<C_Class>());
+
+        return h;
+    }
+
+    NpcHandle DaedalusGameState::createNPC()
+    {
+        return create<GEngineClasses::C_Npc>();
+    }
+
+    ItemHandle DaedalusGameState::createItem()
+    {
+        return create<GEngineClasses::C_Item>();
+    }
+
+    ItemReactHandle DaedalusGameState::createItemReact()
+    {
+        return create<GEngineClasses::C_ItemReact>();
+    }
+
+    MissionHandle DaedalusGameState::createMission()
+    {
+        return create<GEngineClasses::C_Mission>();
+    }
+
+    InfoHandle DaedalusGameState::createInfo()
+    {
+        return create<GEngineClasses::C_Info>();
+    }
+
+    FocusHandle DaedalusGameState::createFocus()
+    {
+        return create<GEngineClasses::C_Focus>();
+    }
+
+    SfxHandle DaedalusGameState::createSfx()
+    {
+        return create<GEngineClasses::C_SFX>();
+    }
+
+    PfxHandle DaedalusGameState::createPfx()
+    {
+        return create<GEngineClasses::C_ParticleFX>();
+    }
+
+    FocusHandle DaedalusGameState::createMenu()
+    {
+        return create<GEngineClasses::C_Menu>();
+    }
+
+    FocusHandle DaedalusGameState::createMenuItem()
+    {
+        return create<GEngineClasses::C_Menu_Item>();
+    }
+
+    MusicThemeHandle DaedalusGameState::createMusicTheme()
+    {
+        return create<GEngineClasses::C_MusicTheme>();
+    }
+
+    ItemHandle DaedalusGameState::createInventoryItem(size_t itemSymbol, NpcHandle npc, unsigned int count)
+    {
+        auto items = m_NpcInventories[npc];
+
+        // Try to find an item of this type
+        for (ItemHandle h : items)
+        {
+            GEngineClasses::C_Item& item = getItem(h);
+
+            // Just add to the count here
+            if (item.instanceSymbol == itemSymbol)
+            {
+                item.amount += count;
+                return h;
+            }
+        }
+
+        static int s_Tmp = 0;
+        s_Tmp++;
+
+        // Get memory for the item
+        ItemHandle h = createItem();
         GEngineClasses::C_Item& item = getItem(h);
 
-        // Just add to the count here
-        if (item.instanceSymbol == itemSymbol)
-        {
-            item.amount += count;
-            return h;
-        }
+        item.amount = count;
+
+        // Run the script-constructor
+        m_VM.initializeInstance(ZMemory::toBigHandle(h), static_cast<size_t>(itemSymbol), IC_Item);
+
+        // Put inside its inventory
+        addItemToInventory(h, npc);
+
+        return h;
     }
 
-    static int s_Tmp = 0;
-    s_Tmp++;
-
-    // Get memory for the item
-    ItemHandle h = createItem();
-    GEngineClasses::C_Item& item = getItem(h);
-
-    item.amount = count;
-
-    // Run the script-constructor
-    m_VM.initializeInstance(ZMemory::toBigHandle(h), static_cast<size_t>(itemSymbol), IC_Item);
-
-    // Put inside its inventory
-    addItemToInventory(h, npc);
-
-    return h;
-}
-
-ItemHandle DaedalusGameState::addItemToInventory(ItemHandle item, NpcHandle npc)
-{
-    auto items = m_NpcInventories[npc];
-
-    // Try to find an item of this type
-    for (ItemHandle h : items)
+    ItemHandle DaedalusGameState::addItemToInventory(ItemHandle item, NpcHandle npc)
     {
-        GEngineClasses::C_Item& i = getItem(h);
+        auto items = m_NpcInventories[npc];
 
-        // Just add to the count here
-        if (i.instanceSymbol == getItem(item).instanceSymbol)
+        // Try to find an item of this type
+        for (ItemHandle h : items)
         {
-            i.amount++;
-            return h;
-        }
-    }
+            GEngineClasses::C_Item& i = getItem(h);
 
-    m_NpcInventories[npc].push_back(item);
-
-    if (m_GameExternals.createinvitem)
-        m_GameExternals.createinvitem(item, npc);
-
-    return item;
-}
-
-bool DaedalusGameState::removeInventoryItem(size_t itemSymbol, NpcHandle npc, unsigned int count)
-{
-    for (auto it = m_NpcInventories[npc].begin(); it != m_NpcInventories[npc].end(); it++)
-    {
-        Daedalus::GEngineClasses::C_Item& item = getItem((*it));
-
-        if (item.instanceSymbol == itemSymbol)
-        {
-            item.amount -= std::min(item.amount, count);  // Handle overflow;
-
-            // Remove if count reached 0
-            if (item.amount == 0)
+            // Just add to the count here
+            if (i.instanceSymbol == getItem(item).instanceSymbol)
             {
-                removeItem(*it);
-
-                m_NpcInventories[npc].erase(it);
+                i.amount++;
+                return h;
             }
-
-            return true;
         }
+
+        m_NpcInventories[npc].push_back(item);
+
+        if (m_GameExternals.createinvitem)
+            m_GameExternals.createinvitem(item, npc);
+
+        return item;
     }
 
-    return false;
-}
+    bool DaedalusGameState::removeInventoryItem(size_t itemSymbol, NpcHandle npc, unsigned int count)
+    {
+        for (auto it = m_NpcInventories[npc].begin(); it != m_NpcInventories[npc].end(); it++)
+        {
+            Daedalus::GEngineClasses::C_Item& item = getItem((*it));
 
-NpcHandle DaedalusGameState::insertNPC(size_t instance, const std::string& waypoint)
-{
-    NpcHandle npc = createNPC();
+            if (item.instanceSymbol == itemSymbol)
+            {
+                item.amount -= std::min(item.amount, count);  // Handle overflow;
 
-    GEngineClasses::C_Npc& npcData = getNpc(npc);
-    npcData.wp = waypoint;
+                // Remove if count reached 0
+                if (item.amount == 0)
+                {
+                    removeItem(*it);
 
-    // Setup basic class linkage. This is important here, as otherwise the wld_insertnpc-callback won't be
-    // able to work properly
-    npcData.instanceSymbol = instance;
+                    m_NpcInventories[npc].erase(it);
+                }
 
-    PARSymbol& s = m_VM.getDATFile().getSymbolByIndex(instance);
-    s.instanceDataHandle = ZMemory::toBigHandle(npc);
-    s.instanceDataClass = IC_Npc;
+                return true;
+            }
+        }
 
-    if (m_GameExternals.wld_insertnpc)
-        m_GameExternals.wld_insertnpc(npc, waypoint);
+        return false;
+    }
 
-    m_VM.initializeInstance(ZMemory::toBigHandle(npc), instance, IC_Npc);
+    NpcHandle DaedalusGameState::insertNPC(size_t instance, const std::string& waypoint)
+    {
+        NpcHandle npc = createNPC();
 
-    // Init complete, notify the engine
-    if (m_GameExternals.post_wld_insertnpc)
-        m_GameExternals.post_wld_insertnpc(npc);
+        GEngineClasses::C_Npc& npcData = getNpc(npc);
+        npcData.wp = waypoint;
 
-    return npc;
-}
+        // Setup basic class linkage. This is important here, as otherwise the wld_insertnpc-callback won't be
+        // able to work properly
+        npcData.instanceSymbol = instance;
 
-NpcHandle DaedalusGameState::insertNPC(const std::string& instance, const std::string& waypoint)
-{
-    return insertNPC(m_VM.getDATFile().getSymbolIndexByName(instance), waypoint);
-}
+        PARSymbol& s = m_VM.getDATFile().getSymbolByIndex(instance);
+        s.instanceDataHandle = ZMemory::toBigHandle(npc);
+        s.instanceDataClass = IC_Npc;
 
-ItemHandle DaedalusGameState::insertItem(size_t instance)
-{
-    // Get memory for the item
-    ItemHandle h = createItem();
-    GEngineClasses::C_Item& item = getItem(h);
+        if (m_GameExternals.wld_insertnpc)
+            m_GameExternals.wld_insertnpc(npc, waypoint);
 
-    // Run the script-constructor
-    m_VM.initializeInstance(ZMemory::toBigHandle(h), static_cast<size_t>(instance), IC_Item);
+        m_VM.initializeInstance(ZMemory::toBigHandle(npc), instance, IC_Npc);
 
-    return h;
-}
+        // Init complete, notify the engine
+        if (m_GameExternals.post_wld_insertnpc)
+            m_GameExternals.post_wld_insertnpc(npc);
 
-ItemHandle DaedalusGameState::insertItem(const std::string& instance)
-{
-    return insertItem(m_VM.getDATFile().getSymbolIndexByName(instance));
-}
+        return npc;
+    }
 
-SfxHandle DaedalusGameState::insertSFX(size_t instance)
-{
-    // Get memory for the item
-    SfxHandle h = createSfx();
-    GEngineClasses::C_SFX& sfx = getSfx(h);
+    NpcHandle DaedalusGameState::insertNPC(const std::string& instance, const std::string& waypoint)
+    {
+        return insertNPC(m_VM.getDATFile().getSymbolIndexByName(instance), waypoint);
+    }
 
-    // Run the script-constructor
-    m_VM.initializeInstance(ZMemory::toBigHandle(h), static_cast<size_t>(instance), IC_Sfx);
+    ItemHandle DaedalusGameState::insertItem(size_t instance)
+    {
+        // Get memory for the item
+        ItemHandle h = createItem();
+        GEngineClasses::C_Item& item = getItem(h);
 
-    return h;
-}
+        // Run the script-constructor
+        m_VM.initializeInstance(ZMemory::toBigHandle(h), static_cast<size_t>(instance), IC_Item);
 
-SfxHandle DaedalusGameState::insertSFX(const std::string& instance)
-{
-    return insertSFX(m_VM.getDATFile().getSymbolIndexByName(instance));
-}
+        return h;
+    }
 
-MusicThemeHandle DaedalusGameState::insertMusicTheme(size_t instance)
-{
-    // Get memory for the item
-    MusicThemeHandle h = createMusicTheme();
-    GEngineClasses::C_MusicTheme& mt = getMusicTheme(h);
+    ItemHandle DaedalusGameState::insertItem(const std::string& instance)
+    {
+        return insertItem(m_VM.getDATFile().getSymbolIndexByName(instance));
+    }
 
-    // Run the script-constructor
-    m_VM.initializeInstance(ZMemory::toBigHandle(h), static_cast<size_t>(instance), IC_MusicTheme);
+    SfxHandle DaedalusGameState::insertSFX(size_t instance)
+    {
+        // Get memory for the item
+        SfxHandle h = createSfx();
+        GEngineClasses::C_SFX& sfx = getSfx(h);
 
-    return h;
-}
+        // Run the script-constructor
+        m_VM.initializeInstance(ZMemory::toBigHandle(h), static_cast<size_t>(instance), IC_Sfx);
 
-MusicThemeHandle DaedalusGameState::insertMusicTheme(const std::string& instance)
-{
-    return insertMusicTheme(m_VM.getDATFile().getSymbolIndexByName(instance));
-}
+        return h;
+    }
 
-void DaedalusGameState::removeItem(ItemHandle item)
-{
-    if (m_OnInstanceRemoved)
-        m_OnInstanceRemoved(ZMemory::toBigHandle(item), IC_Item);
+    SfxHandle DaedalusGameState::insertSFX(const std::string& instance)
+    {
+        return insertSFX(m_VM.getDATFile().getSymbolIndexByName(instance));
+    }
 
-    m_RegisteredObjects.items.removeObject(item);
-}
+    MusicThemeHandle DaedalusGameState::insertMusicTheme(size_t instance)
+    {
+        // Get memory for the item
+        MusicThemeHandle h = createMusicTheme();
+        GEngineClasses::C_MusicTheme& mt = getMusicTheme(h);
 
-void DaedalusGameState::removeMenu(MenuHandle menu)
-{
-    if (m_OnInstanceRemoved)
-        m_OnInstanceRemoved(ZMemory::toBigHandle(menu), IC_Menu);
+        // Run the script-constructor
+        m_VM.initializeInstance(ZMemory::toBigHandle(h), static_cast<size_t>(instance), IC_MusicTheme);
 
-    m_RegisteredObjects.menus.removeObject(menu);
-}
+        return h;
+    }
 
-void DaedalusGameState::removeMenuItem(MenuItemHandle menuItem)
-{
-    if (m_OnInstanceRemoved)
-        m_OnInstanceRemoved(ZMemory::toBigHandle(menuItem), IC_MenuItem);
+    MusicThemeHandle DaedalusGameState::insertMusicTheme(const std::string& instance)
+    {
+        return insertMusicTheme(m_VM.getDATFile().getSymbolIndexByName(instance));
+    }
 
-    m_RegisteredObjects.menuItems.removeObject(menuItem);
-}
+    void DaedalusGameState::removeItem(ItemHandle item)
+    {
+        if (m_OnInstanceRemoved)
+            m_OnInstanceRemoved(ZMemory::toBigHandle(item), IC_Item);
 
-void DaedalusGameState::removeNPC(NpcHandle npc)
-{
-    if (m_GameExternals.wld_removenpc)
-        m_GameExternals.wld_removenpc(npc);
+        m_RegisteredObjects.items.removeObject(item);
+    }
 
-    if (m_OnInstanceRemoved)
-        m_OnInstanceRemoved(ZMemory::toBigHandle(npc), IC_Npc);
+    void DaedalusGameState::removeMenu(MenuHandle menu)
+    {
+        if (m_OnInstanceRemoved)
+            m_OnInstanceRemoved(ZMemory::toBigHandle(menu), IC_Menu);
 
-    m_RegisteredObjects.NPCs.removeObject(npc);
-}
+        m_RegisteredObjects.menus.removeObject(menu);
+    }
+
+    void DaedalusGameState::removeMenuItem(MenuItemHandle menuItem)
+    {
+        if (m_OnInstanceRemoved)
+            m_OnInstanceRemoved(ZMemory::toBigHandle(menuItem), IC_MenuItem);
+
+        m_RegisteredObjects.menuItems.removeObject(menuItem);
+    }
+
+    void DaedalusGameState::removeNPC(NpcHandle npc)
+    {
+        if (m_GameExternals.wld_removenpc)
+            m_GameExternals.wld_removenpc(npc);
+
+        if (m_OnInstanceRemoved)
+            m_OnInstanceRemoved(ZMemory::toBigHandle(npc), IC_Npc);
+
+        m_RegisteredObjects.NPCs.removeObject(npc);
+    }
+}  // namespace ZenLib

--- a/daedalus/DaedalusGameState.h
+++ b/daedalus/DaedalusGameState.h
@@ -5,441 +5,444 @@
 #include "DaedalusStdlib.h"
 #include <utils/staticReferencedAllocator.h>
 
-namespace Daedalus
+namespace ZenLib
 {
-    class DaedalusVM;
-
-    namespace GameState
+    namespace Daedalus
     {
-        constexpr int MAX_NUM_MISC = 1024;
+        class DaedalusVM;
 
-        constexpr int MAX_NUM_NPCS = 12000;
-        constexpr int MAX_NUM_ITEMS = 12000;
-        constexpr int MAX_NUM_MISSIONS = 512;
-        constexpr int MAX_NUM_FOCUS = MAX_NUM_MISC;
-        constexpr int MAX_NUM_ITEMREACT = MAX_NUM_MISC;
-        constexpr int MAX_NUM_INFO = 16000;
-        constexpr int MAX_NUM_MENU = MAX_NUM_MISC;
-        constexpr int MAX_NUM_MENUITEM = MAX_NUM_MISC;
-        constexpr int MAX_NUM_SFX = 4096;  // G2 has 1700
-        constexpr int MAX_NUM_PFX = 1024;
-        constexpr int MAX_NUM_MUSICTHEME = 512;
+        namespace GameState
+        {
+            constexpr int MAX_NUM_MISC = 1024;
 
-        template <class T>
-        constexpr size_t MAX_NUM();
+            constexpr int MAX_NUM_NPCS = 12000;
+            constexpr int MAX_NUM_ITEMS = 12000;
+            constexpr int MAX_NUM_MISSIONS = 512;
+            constexpr int MAX_NUM_FOCUS = MAX_NUM_MISC;
+            constexpr int MAX_NUM_ITEMREACT = MAX_NUM_MISC;
+            constexpr int MAX_NUM_INFO = 16000;
+            constexpr int MAX_NUM_MENU = MAX_NUM_MISC;
+            constexpr int MAX_NUM_MENUITEM = MAX_NUM_MISC;
+            constexpr int MAX_NUM_SFX = 4096;  // G2 has 1700
+            constexpr int MAX_NUM_PFX = 1024;
+            constexpr int MAX_NUM_MUSICTHEME = 512;
 
-        template <>
-        constexpr size_t MAX_NUM<Daedalus::GEngineClasses::C_Npc>()
-        {
-            return MAX_NUM_NPCS;
-        }
-        template <>
-        constexpr size_t MAX_NUM<Daedalus::GEngineClasses::C_Item>()
-        {
-            return MAX_NUM_ITEMS;
-        }
-        template <>
-        constexpr size_t MAX_NUM<Daedalus::GEngineClasses::C_Mission>()
-        {
-            return MAX_NUM_MISSIONS;
-        }
-        template <>
-        constexpr size_t MAX_NUM<Daedalus::GEngineClasses::C_Focus>()
-        {
-            return MAX_NUM_FOCUS;
-        }
-        template <>
-        constexpr size_t MAX_NUM<Daedalus::GEngineClasses::C_ItemReact>()
-        {
-            return MAX_NUM_ITEMREACT;
-        }
-        template <>
-        constexpr size_t MAX_NUM<Daedalus::GEngineClasses::C_Info>()
-        {
-            return MAX_NUM_INFO;
-        }
-        template <>
-        constexpr size_t MAX_NUM<Daedalus::GEngineClasses::C_Menu>()
-        {
-            return MAX_NUM_MENU;
-        }
-        template <>
-        constexpr size_t MAX_NUM<Daedalus::GEngineClasses::C_Menu_Item>()
-        {
-            return MAX_NUM_MENUITEM;
-        }
-        template <>
-        constexpr size_t MAX_NUM<Daedalus::GEngineClasses::C_SFX>()
-        {
-            return MAX_NUM_SFX;
-        }
-        template <>
-        constexpr size_t MAX_NUM<Daedalus::GEngineClasses::C_ParticleFX>()
-        {
-            return MAX_NUM_PFX;
-        }
-        template <>
-        constexpr size_t MAX_NUM<Daedalus::GEngineClasses::C_MusicTheme>()
-        {
-            return MAX_NUM_MUSICTHEME;
-        }
+            template <class T>
+            constexpr size_t MAX_NUM();
 
-        template <typename C_Class>
-        using CHandle = typename ZMemory::StaticReferencedAllocator<C_Class, MAX_NUM<C_Class>()>::Handle;
-
-        typedef CHandle<Daedalus::GEngineClasses::C_Npc> NpcHandle;
-        typedef CHandle<Daedalus::GEngineClasses::C_Item> ItemHandle;
-        typedef CHandle<Daedalus::GEngineClasses::C_Mission> MissionHandle;
-        typedef CHandle<Daedalus::GEngineClasses::C_Focus> FocusHandle;
-        typedef CHandle<Daedalus::GEngineClasses::C_ItemReact> ItemReactHandle;
-        typedef CHandle<Daedalus::GEngineClasses::C_Info> InfoHandle;
-        typedef CHandle<Daedalus::GEngineClasses::C_Menu> MenuHandle;
-        typedef CHandle<Daedalus::GEngineClasses::C_Menu_Item> MenuItemHandle;
-        typedef CHandle<Daedalus::GEngineClasses::C_SFX> SfxHandle;
-        typedef CHandle<Daedalus::GEngineClasses::C_ParticleFX> PfxHandle;
-        typedef CHandle<Daedalus::GEngineClasses::C_MusicTheme> MusicThemeHandle;
-
-        struct LogTopic
-        {
-            enum ELogStatus
+            template <>
+            constexpr size_t MAX_NUM<Daedalus::GEngineClasses::C_Npc>()
             {
-                // TODO: Find the actual values for this
-                LS_Running = 1,
-                LS_Success = 2,
-                LS_Failed = 3,
-                LS_Obsolete = 4
+                return MAX_NUM_NPCS;
+            }
+            template <>
+            constexpr size_t MAX_NUM<Daedalus::GEngineClasses::C_Item>()
+            {
+                return MAX_NUM_ITEMS;
+            }
+            template <>
+            constexpr size_t MAX_NUM<Daedalus::GEngineClasses::C_Mission>()
+            {
+                return MAX_NUM_MISSIONS;
+            }
+            template <>
+            constexpr size_t MAX_NUM<Daedalus::GEngineClasses::C_Focus>()
+            {
+                return MAX_NUM_FOCUS;
+            }
+            template <>
+            constexpr size_t MAX_NUM<Daedalus::GEngineClasses::C_ItemReact>()
+            {
+                return MAX_NUM_ITEMREACT;
+            }
+            template <>
+            constexpr size_t MAX_NUM<Daedalus::GEngineClasses::C_Info>()
+            {
+                return MAX_NUM_INFO;
+            }
+            template <>
+            constexpr size_t MAX_NUM<Daedalus::GEngineClasses::C_Menu>()
+            {
+                return MAX_NUM_MENU;
+            }
+            template <>
+            constexpr size_t MAX_NUM<Daedalus::GEngineClasses::C_Menu_Item>()
+            {
+                return MAX_NUM_MENUITEM;
+            }
+            template <>
+            constexpr size_t MAX_NUM<Daedalus::GEngineClasses::C_SFX>()
+            {
+                return MAX_NUM_SFX;
+            }
+            template <>
+            constexpr size_t MAX_NUM<Daedalus::GEngineClasses::C_ParticleFX>()
+            {
+                return MAX_NUM_PFX;
+            }
+            template <>
+            constexpr size_t MAX_NUM<Daedalus::GEngineClasses::C_MusicTheme>()
+            {
+                return MAX_NUM_MUSICTHEME;
+            }
+
+            template <typename C_Class>
+            using CHandle = typename ZMemory::StaticReferencedAllocator<C_Class, MAX_NUM<C_Class>()>::Handle;
+
+            typedef CHandle<Daedalus::GEngineClasses::C_Npc> NpcHandle;
+            typedef CHandle<Daedalus::GEngineClasses::C_Item> ItemHandle;
+            typedef CHandle<Daedalus::GEngineClasses::C_Mission> MissionHandle;
+            typedef CHandle<Daedalus::GEngineClasses::C_Focus> FocusHandle;
+            typedef CHandle<Daedalus::GEngineClasses::C_ItemReact> ItemReactHandle;
+            typedef CHandle<Daedalus::GEngineClasses::C_Info> InfoHandle;
+            typedef CHandle<Daedalus::GEngineClasses::C_Menu> MenuHandle;
+            typedef CHandle<Daedalus::GEngineClasses::C_Menu_Item> MenuItemHandle;
+            typedef CHandle<Daedalus::GEngineClasses::C_SFX> SfxHandle;
+            typedef CHandle<Daedalus::GEngineClasses::C_ParticleFX> PfxHandle;
+            typedef CHandle<Daedalus::GEngineClasses::C_MusicTheme> MusicThemeHandle;
+
+            struct LogTopic
+            {
+                enum ELogStatus
+                {
+                    // TODO: Find the actual values for this
+                    LS_Running = 1,
+                    LS_Success = 2,
+                    LS_Failed = 3,
+                    LS_Obsolete = 4
+                };
+
+                enum ESection
+                {
+                    // TODO: Find the actual values for this!
+                    LT_Mission = 0,
+                    LT_Note = 1
+                };
+
+                std::vector<std::string> entries;
+
+                ELogStatus status;
+                ESection section;
             };
 
-            enum ESection
+            struct RegisteredObjects
             {
-                // TODO: Find the actual values for this!
-                LT_Mission = 0,
-                LT_Note = 1
-            };
+                template <class T, size_t n = MAX_NUM<T>()>
+                using CAllocator = ZMemory::StaticReferencedAllocator<T, n>;
 
-            std::vector<std::string> entries;
+                CAllocator<GEngineClasses::C_Npc> NPCs;
+                CAllocator<GEngineClasses::C_Item> items;
+                CAllocator<GEngineClasses::C_ItemReact> itemReacts;
+                CAllocator<GEngineClasses::C_Mission> missions;
+                CAllocator<GEngineClasses::C_Focus> focuses;
+                CAllocator<GEngineClasses::C_Info> infos;
+                CAllocator<GEngineClasses::C_Menu> menus;
+                CAllocator<GEngineClasses::C_Menu_Item> menuItems;
+                CAllocator<GEngineClasses::C_SFX> sfx;
+                CAllocator<GEngineClasses::C_ParticleFX> pfx;
+                CAllocator<GEngineClasses::C_MusicTheme> musicThemes;
 
-            ELogStatus status;
-            ESection section;
-        };
-
-        struct RegisteredObjects
-        {
-            template <class T, size_t n = MAX_NUM<T>()>
-            using CAllocator = ZMemory::StaticReferencedAllocator<T, n>;
-
-            CAllocator<GEngineClasses::C_Npc> NPCs;
-            CAllocator<GEngineClasses::C_Item> items;
-            CAllocator<GEngineClasses::C_ItemReact> itemReacts;
-            CAllocator<GEngineClasses::C_Mission> missions;
-            CAllocator<GEngineClasses::C_Focus> focuses;
-            CAllocator<GEngineClasses::C_Info> infos;
-            CAllocator<GEngineClasses::C_Menu> menus;
-            CAllocator<GEngineClasses::C_Menu_Item> menuItems;
-            CAllocator<GEngineClasses::C_SFX> sfx;
-            CAllocator<GEngineClasses::C_ParticleFX> pfx;
-            CAllocator<GEngineClasses::C_MusicTheme> musicThemes;
-
-            /**
+                /**
              * generic getter for the Engine containers NPCs, items, ...
              * @tparam C_Class i.e. C_Npc C_Item, ...
              */
-            template <class C_Class, size_t n = MAX_NUM<C_Class>()>
-            CAllocator<C_Class, n>& get()
-            {
-                C_Class::missing_template_function_spezialization;
+                template <class C_Class, size_t n = MAX_NUM<C_Class>()>
+                CAllocator<C_Class, n>& get()
+                {
+                    C_Class::missing_template_function_spezialization;
+                };
             };
-        };
 
-        /**
+            /**
          * getter spezializations
          */
-        template <>
-        inline RegisteredObjects::CAllocator<GEngineClasses::C_Npc>&
-        RegisteredObjects::get<GEngineClasses::C_Npc, MAX_NUM<GEngineClasses::C_Npc>()>()
-        {
-            return NPCs;
-        };
-        template <>
-        inline RegisteredObjects::CAllocator<GEngineClasses::C_Item>&
-        RegisteredObjects::get<GEngineClasses::C_Item, MAX_NUM<GEngineClasses::C_Item>()>()
-        {
-            return items;
-        };
-        template <>
-        inline RegisteredObjects::CAllocator<GEngineClasses::C_Mission>&
-        RegisteredObjects::get<GEngineClasses::C_Mission, MAX_NUM<GEngineClasses::C_Mission>()>()
-        {
-            return missions;
-        };
-        template <>
-        inline RegisteredObjects::CAllocator<GEngineClasses::C_Focus>&
-        RegisteredObjects::get<GEngineClasses::C_Focus, MAX_NUM<GEngineClasses::C_Focus>()>()
-        {
-            return focuses;
-        };
-        template <>
-        inline RegisteredObjects::CAllocator<GEngineClasses::C_ItemReact>&
-        RegisteredObjects::get<GEngineClasses::C_ItemReact, MAX_NUM<GEngineClasses::C_ItemReact>()>()
-        {
-            return itemReacts;
-        };
-        template <>
-        inline RegisteredObjects::CAllocator<GEngineClasses::C_Info>&
-        RegisteredObjects::get<GEngineClasses::C_Info, MAX_NUM<GEngineClasses::C_Info>()>()
-        {
-            return infos;
-        };
-        template <>
-        inline RegisteredObjects::CAllocator<GEngineClasses::C_Menu>&
-        RegisteredObjects::get<GEngineClasses::C_Menu, MAX_NUM<GEngineClasses::C_Menu>()>()
-        {
-            return menus;
-        };
-        template <>
-        inline RegisteredObjects::CAllocator<GEngineClasses::C_Menu_Item>&
-        RegisteredObjects::get<GEngineClasses::C_Menu_Item, MAX_NUM<GEngineClasses::C_Menu_Item>()>()
-        {
-            return menuItems;
-        };
-        template <>
-        inline RegisteredObjects::CAllocator<GEngineClasses::C_SFX>&
-        RegisteredObjects::get<GEngineClasses::C_SFX, MAX_NUM<GEngineClasses::C_SFX>()>()
-        {
-            return sfx;
-        };
-        template <>
-        inline RegisteredObjects::CAllocator<GEngineClasses::C_ParticleFX>&
-        RegisteredObjects::get<GEngineClasses::C_ParticleFX, MAX_NUM<GEngineClasses::C_ParticleFX>()>()
-        {
-            return pfx;
-        };
-        template <>
-        inline RegisteredObjects::CAllocator<GEngineClasses::C_MusicTheme>&
-        RegisteredObjects::get<GEngineClasses::C_MusicTheme, MAX_NUM<GEngineClasses::C_MusicTheme>()>()
-        {
-            return musicThemes;
-        };
+            template <>
+            inline RegisteredObjects::CAllocator<GEngineClasses::C_Npc>&
+            RegisteredObjects::get<GEngineClasses::C_Npc, MAX_NUM<GEngineClasses::C_Npc>()>()
+            {
+                return NPCs;
+            };
+            template <>
+            inline RegisteredObjects::CAllocator<GEngineClasses::C_Item>&
+            RegisteredObjects::get<GEngineClasses::C_Item, MAX_NUM<GEngineClasses::C_Item>()>()
+            {
+                return items;
+            };
+            template <>
+            inline RegisteredObjects::CAllocator<GEngineClasses::C_Mission>&
+            RegisteredObjects::get<GEngineClasses::C_Mission, MAX_NUM<GEngineClasses::C_Mission>()>()
+            {
+                return missions;
+            };
+            template <>
+            inline RegisteredObjects::CAllocator<GEngineClasses::C_Focus>&
+            RegisteredObjects::get<GEngineClasses::C_Focus, MAX_NUM<GEngineClasses::C_Focus>()>()
+            {
+                return focuses;
+            };
+            template <>
+            inline RegisteredObjects::CAllocator<GEngineClasses::C_ItemReact>&
+            RegisteredObjects::get<GEngineClasses::C_ItemReact, MAX_NUM<GEngineClasses::C_ItemReact>()>()
+            {
+                return itemReacts;
+            };
+            template <>
+            inline RegisteredObjects::CAllocator<GEngineClasses::C_Info>&
+            RegisteredObjects::get<GEngineClasses::C_Info, MAX_NUM<GEngineClasses::C_Info>()>()
+            {
+                return infos;
+            };
+            template <>
+            inline RegisteredObjects::CAllocator<GEngineClasses::C_Menu>&
+            RegisteredObjects::get<GEngineClasses::C_Menu, MAX_NUM<GEngineClasses::C_Menu>()>()
+            {
+                return menus;
+            };
+            template <>
+            inline RegisteredObjects::CAllocator<GEngineClasses::C_Menu_Item>&
+            RegisteredObjects::get<GEngineClasses::C_Menu_Item, MAX_NUM<GEngineClasses::C_Menu_Item>()>()
+            {
+                return menuItems;
+            };
+            template <>
+            inline RegisteredObjects::CAllocator<GEngineClasses::C_SFX>&
+            RegisteredObjects::get<GEngineClasses::C_SFX, MAX_NUM<GEngineClasses::C_SFX>()>()
+            {
+                return sfx;
+            };
+            template <>
+            inline RegisteredObjects::CAllocator<GEngineClasses::C_ParticleFX>&
+            RegisteredObjects::get<GEngineClasses::C_ParticleFX, MAX_NUM<GEngineClasses::C_ParticleFX>()>()
+            {
+                return pfx;
+            };
+            template <>
+            inline RegisteredObjects::CAllocator<GEngineClasses::C_MusicTheme>&
+            RegisteredObjects::get<GEngineClasses::C_MusicTheme, MAX_NUM<GEngineClasses::C_MusicTheme>()>()
+            {
+                return musicThemes;
+            };
 
-        /**
+            /**
 		 * Class holding the current engine-side gamestate of a daedalus-VM
          */
-        class DaedalusGameState
-        {
-        public:
-            DaedalusGameState(Daedalus::DaedalusVM& vm);
+            class DaedalusGameState
+            {
+            public:
+                DaedalusGameState(Daedalus::DaedalusVM& vm);
 
-            /**
+                /**
              * @brief registers the games externals
              */
-            void registerExternals();
+                void registerExternals();
 
-            struct GameExternals
-            {
-                // These will all be executed with the content already created
-                std::function<void(NpcHandle, std::string)> wld_insertnpc;
-                std::function<void(NpcHandle)> post_wld_insertnpc;
-                std::function<void(NpcHandle)> wld_removenpc;
-                std::function<void(ItemHandle)> wld_insertitem;
-                std::function<void(ItemHandle, NpcHandle)> createinvitem;
-                std::function<int(void)> wld_GetDay;
-                std::function<void(std::string)> log_createtopic;
-                std::function<void(std::string)> log_settopicstatus;
-                std::function<void(std::string, std::string)> log_addentry;
-            };
-            void setGameExternals(const GameExternals& ext)
-            {
-                m_GameExternals = ext;
-            }
+                struct GameExternals
+                {
+                    // These will all be executed with the content already created
+                    std::function<void(NpcHandle, std::string)> wld_insertnpc;
+                    std::function<void(NpcHandle)> post_wld_insertnpc;
+                    std::function<void(NpcHandle)> wld_removenpc;
+                    std::function<void(ItemHandle)> wld_insertitem;
+                    std::function<void(ItemHandle, NpcHandle)> createinvitem;
+                    std::function<int(void)> wld_GetDay;
+                    std::function<void(std::string)> log_createtopic;
+                    std::function<void(std::string)> log_settopicstatus;
+                    std::function<void(std::string, std::string)> log_addentry;
+                };
+                void setGameExternals(const GameExternals& ext)
+                {
+                    m_GameExternals = ext;
+                }
 
-            /**
+                /**
              * Creates a new instance of the given item first and then adds it to the given NPC
              * @param itemSymbol Symbol to create the instance of
              * @param npc NPC to give the item to
              * @param count How many to give
              * @return Newly created handle or an old one, if the item was stackable
              */
-            ItemHandle createInventoryItem(size_t itemSymbol, NpcHandle npc, unsigned int count = 1);
+                ItemHandle createInventoryItem(size_t itemSymbol, NpcHandle npc, unsigned int count = 1);
 
-            /**
+                /**
              * Adds the given item to the inventory of the given NPC
              * Note: If there already is an instance of this item and it is stackable, the old instance will
              *       be returned and the instance given in 'item' will be removed!
              * @return Handle to the item now in the inventory or an old one, if the item was stackable
              */
-            ItemHandle addItemToInventory(ItemHandle item, NpcHandle npc);
+                ItemHandle addItemToInventory(ItemHandle item, NpcHandle npc);
 
-            /**
+                /**
              * Removes one of the items matching the given instance from the NPCs inventory
              * Note: Handle will not be valid anymore if this returns true!
              * @return True, if such an instance was found and removed, false otherwise
              */
-            bool removeInventoryItem(size_t itemSymbol, NpcHandle npc, unsigned int count = 1);
+                bool removeInventoryItem(size_t itemSymbol, NpcHandle npc, unsigned int count = 1);
 
-            /**
+                /**
              * Removes the data behind the given item handle
              * @param item Item to remove
              */
-            void removeItem(ItemHandle item);
-            void removeNPC(NpcHandle npc);
-            void removeMenu(MenuHandle menu);
-            void removeMenuItem(MenuItemHandle menuItem);
+                void removeItem(ItemHandle item);
+                void removeNPC(NpcHandle npc);
+                void removeMenu(MenuHandle menu);
+                void removeMenuItem(MenuItemHandle menuItem);
 
-            /**
+                /**
              * Creates a new NPC-Instance, just as Wld_InsertNPC was called from script
              * @param instance Instance-Index of the NPC to create
              * @param waypoint Waypoint to place the newly created npc on
              * @return Handle to the script-instance created
              */
-            NpcHandle insertNPC(size_t instance, const std::string& waypoint);
-            NpcHandle insertNPC(const std::string& instance, const std::string& waypoint);
+                NpcHandle insertNPC(size_t instance, const std::string& waypoint);
+                NpcHandle insertNPC(const std::string& instance, const std::string& waypoint);
 
-            /**
+                /**
              * Creates a new item instance and initializes it (does not position it)
              * @param instance Instance to create
              * @return Handle to the created instance
              */
-            ItemHandle insertItem(size_t instance);
-            ItemHandle insertItem(const std::string& instance);
+                ItemHandle insertItem(size_t instance);
+                ItemHandle insertItem(const std::string& instance);
 
-            SfxHandle insertSFX(size_t instance);
-            SfxHandle insertSFX(const std::string& instance);
+                SfxHandle insertSFX(size_t instance);
+                SfxHandle insertSFX(const std::string& instance);
 
-            MusicThemeHandle insertMusicTheme(size_t instance);
-            MusicThemeHandle insertMusicTheme(const std::string& instance);
+                MusicThemeHandle insertMusicTheme(size_t instance);
+                MusicThemeHandle insertMusicTheme(const std::string& instance);
 
-            /**
+                /**
              * Creates scripting relevant objects
              */
-            template <typename C_Class>
-            CHandle<C_Class> create();
-            NpcHandle createNPC();
-            ItemHandle createItem();
-            ItemReactHandle createItemReact();
-            MissionHandle createMission();
-            InfoHandle createInfo();
-            FocusHandle createFocus();
-            MenuHandle createMenu();
-            MenuItemHandle createMenuItem();
-            SfxHandle createSfx();
-            PfxHandle createPfx();
-            MusicThemeHandle createMusicTheme();
+                template <typename C_Class>
+                CHandle<C_Class> create();
+                NpcHandle createNPC();
+                ItemHandle createItem();
+                ItemReactHandle createItemReact();
+                MissionHandle createMission();
+                InfoHandle createInfo();
+                FocusHandle createFocus();
+                MenuHandle createMenu();
+                MenuItemHandle createMenuItem();
+                SfxHandle createSfx();
+                PfxHandle createPfx();
+                MusicThemeHandle createMusicTheme();
 
-            /**
+                /**
              * Accessors
              */
-            template <typename C_Class>
-            inline C_Class& get(CHandle<C_Class> h)
-            {
-                return m_RegisteredObjects.get<C_Class>().getElement(h);
-            };
+                template <typename C_Class>
+                inline C_Class& get(CHandle<C_Class> h)
+                {
+                    return m_RegisteredObjects.get<C_Class>().getElement(h);
+                };
 
-            Daedalus::GEngineClasses::C_Npc& getNpc(NpcHandle h)
-            {
-                return get<Daedalus::GEngineClasses::C_Npc>(h);
-            };
+                Daedalus::GEngineClasses::C_Npc& getNpc(NpcHandle h)
+                {
+                    return get<Daedalus::GEngineClasses::C_Npc>(h);
+                };
 
-            Daedalus::GEngineClasses::C_Item& getItem(ItemHandle h)
-            {
-                return get<Daedalus::GEngineClasses::C_Item>(h);
-            };
+                Daedalus::GEngineClasses::C_Item& getItem(ItemHandle h)
+                {
+                    return get<Daedalus::GEngineClasses::C_Item>(h);
+                };
 
-            Daedalus::GEngineClasses::C_ItemReact& getItemReact(ItemReactHandle h)
-            {
-                return get<Daedalus::GEngineClasses::C_ItemReact>(h);
-            };
+                Daedalus::GEngineClasses::C_ItemReact& getItemReact(ItemReactHandle h)
+                {
+                    return get<Daedalus::GEngineClasses::C_ItemReact>(h);
+                };
 
-            Daedalus::GEngineClasses::C_Mission& getMission(MissionHandle h)
-            {
-                return get<Daedalus::GEngineClasses::C_Mission>(h);
-            };
+                Daedalus::GEngineClasses::C_Mission& getMission(MissionHandle h)
+                {
+                    return get<Daedalus::GEngineClasses::C_Mission>(h);
+                };
 
-            Daedalus::GEngineClasses::C_Focus& getFocus(FocusHandle h)
-            {
-                return get<Daedalus::GEngineClasses::C_Focus>(h);
-            };
+                Daedalus::GEngineClasses::C_Focus& getFocus(FocusHandle h)
+                {
+                    return get<Daedalus::GEngineClasses::C_Focus>(h);
+                };
 
-            Daedalus::GEngineClasses::C_Info& getInfo(InfoHandle h)
-            {
-                return get<Daedalus::GEngineClasses::C_Info>(h);
-            };
+                Daedalus::GEngineClasses::C_Info& getInfo(InfoHandle h)
+                {
+                    return get<Daedalus::GEngineClasses::C_Info>(h);
+                };
 
-            Daedalus::GEngineClasses::C_Menu& getMenu(MenuHandle h)
-            {
-                return get<Daedalus::GEngineClasses::C_Menu>(h);
-            };
+                Daedalus::GEngineClasses::C_Menu& getMenu(MenuHandle h)
+                {
+                    return get<Daedalus::GEngineClasses::C_Menu>(h);
+                };
 
-            Daedalus::GEngineClasses::C_Menu_Item& getMenuItem(MenuItemHandle h)
-            {
-                return get<Daedalus::GEngineClasses::C_Menu_Item>(h);
-            };
+                Daedalus::GEngineClasses::C_Menu_Item& getMenuItem(MenuItemHandle h)
+                {
+                    return get<Daedalus::GEngineClasses::C_Menu_Item>(h);
+                };
 
-            Daedalus::GEngineClasses::C_SFX& getSfx(SfxHandle h)
-            {
-                return get<Daedalus::GEngineClasses::C_SFX>(h);
-            };
+                Daedalus::GEngineClasses::C_SFX& getSfx(SfxHandle h)
+                {
+                    return get<Daedalus::GEngineClasses::C_SFX>(h);
+                };
 
-            Daedalus::GEngineClasses::C_ParticleFX& getPfx(PfxHandle h)
-            {
-                return get<Daedalus::GEngineClasses::C_ParticleFX>(h);
-            };
+                Daedalus::GEngineClasses::C_ParticleFX& getPfx(PfxHandle h)
+                {
+                    return get<Daedalus::GEngineClasses::C_ParticleFX>(h);
+                };
 
-            Daedalus::GEngineClasses::C_MusicTheme& getMusicTheme(MusicThemeHandle h)
-            {
-                return get<Daedalus::GEngineClasses::C_MusicTheme>(h);
-            };
+                Daedalus::GEngineClasses::C_MusicTheme& getMusicTheme(MusicThemeHandle h)
+                {
+                    return get<Daedalus::GEngineClasses::C_MusicTheme>(h);
+                };
 
-            Daedalus::GEngineClasses::Instance* getByClass(ZMemory::BigHandle h, EInstanceClass instClass);
+                Daedalus::GEngineClasses::Instance* getByClass(ZMemory::BigHandle h, EInstanceClass instClass);
 
-            RegisteredObjects& getRegisteredObjects()
-            {
-                return m_RegisteredObjects;
-            }
+                RegisteredObjects& getRegisteredObjects()
+                {
+                    return m_RegisteredObjects;
+                }
 
-            const std::list<ItemHandle>& getInventoryOf(NpcHandle npc)
-            {
-                return m_NpcInventories[npc];
-            }
+                const std::list<ItemHandle>& getInventoryOf(NpcHandle npc)
+                {
+                    return m_NpcInventories[npc];
+                }
 
-            /**
+                /**
              * @param callback Function to be called right after an instance was created
              */
-            void setOnInstanceCreatedCallback(const std::function<void(ZMemory::BigHandle, EInstanceClass)>& callback)
-            {
-                m_OnInstanceCreated = callback;
-            }
+                void setOnInstanceCreatedCallback(const std::function<void(ZMemory::BigHandle, EInstanceClass)>& callback)
+                {
+                    m_OnInstanceCreated = callback;
+                }
 
-            /**
+                /**
              * @param callback Function to be called right before the actual instance gets removed
              */
-            void setOnInstanceRemovedCallback(const std::function<void(ZMemory::BigHandle, EInstanceClass)>& callback)
-            {
-                m_OnInstanceRemoved = callback;
-            }
+                void setOnInstanceRemovedCallback(const std::function<void(ZMemory::BigHandle, EInstanceClass)>& callback)
+                {
+                    m_OnInstanceRemoved = callback;
+                }
 
-        private:
-            RegisteredObjects m_RegisteredObjects;
+            private:
+                RegisteredObjects m_RegisteredObjects;
 
-            /**
+                /**
              * Daedalus-VM this is running on
              */
-            Daedalus::DaedalusVM& m_VM;
+                Daedalus::DaedalusVM& m_VM;
 
-            /**
+                /**
              * Inventories by npc handle
              */
-            std::map<NpcHandle, std::list<ItemHandle>> m_NpcInventories;
+                std::map<NpcHandle, std::list<ItemHandle>> m_NpcInventories;
 
-            /**
+                /**
              * External-callback set by the user
              */
-            GameExternals m_GameExternals;
+                GameExternals m_GameExternals;
 
-            /**
+                /**
              * Function called when an instance was created/removed
              */
-            std::function<void(ZMemory::BigHandle, EInstanceClass)> m_OnInstanceCreated;
-            std::function<void(ZMemory::BigHandle, EInstanceClass)> m_OnInstanceRemoved;
-        };
-    }  // namespace GameState
-}  // namespace Daedalus
+                std::function<void(ZMemory::BigHandle, EInstanceClass)> m_OnInstanceCreated;
+                std::function<void(ZMemory::BigHandle, EInstanceClass)> m_OnInstanceRemoved;
+            };
+        }  // namespace GameState
+    }      // namespace Daedalus
+}  // namespace ZenLib

--- a/daedalus/DaedalusStdlib.cpp
+++ b/daedalus/DaedalusStdlib.cpp
@@ -10,366 +10,376 @@
 #define REGISTER(cname, obj, var) datFile.registerMember(cname "." #var, obj, obj.var);
 #define REGISTER_IF_EXISTS(cname, obj, var) datFile.registerMember(cname "." #var, obj, obj.var, true);
 
-void Daedalus::registerDaedalusStdLib(Daedalus::DaedalusVM& vm, bool enableVerboseLogging)
+namespace ZenLib
 {
-    bool l = enableVerboseLogging;
-
-    vm.registerExternalFunction("inttostring", [l](Daedalus::DaedalusVM& vm) {
-        int32_t x = vm.popDataValue();
-
-        vm.setReturn(std::to_string(x));
-    });
-
-    vm.registerExternalFunction("floattoint", [l](Daedalus::DaedalusVM& vm) {
-        int32_t x = vm.popDataValue();
-        float f = reinterpret_cast<float&>(x);
-        vm.setReturn(static_cast<int32_t>(f));
-    });
-
-    vm.registerExternalFunction("inttofloat", [l](Daedalus::DaedalusVM& vm) {
-        int32_t x = vm.popDataValue();
-        float f = static_cast<float>(x);
-        vm.setReturn(reinterpret_cast<int32_t&>(f));
-    });
-
-    vm.registerExternalFunction("concatstrings", [l](Daedalus::DaedalusVM& vm) {
-        std::string s2 = vm.popString();
-        std::string s1 = vm.popString();
-
-        vm.setReturn(s1 + s2);
-    });
-
-    vm.registerExternalFunction("hlp_strcmp", [l](Daedalus::DaedalusVM& vm) {
-        std::string s1 = vm.popString();
-        std::string s2 = vm.popString();
-
-        vm.setReturn(s1 == s2 ? 1 : 0);
-    });
-
-    vm.registerExternalFunction("hlp_random", [=](Daedalus::DaedalusVM& vm) {
-        int32_t n0 = vm.popDataValue();
-
-        vm.setReturn(rand() % n0);
-    });
-
-    //
-}
-
-void Daedalus::registerGothicEngineClasses(DaedalusVM& vm)
-{
-    GEngineClasses::C_Npc npc;
-    GEngineClasses::C_Focus focus;
-    GEngineClasses::C_Info info;
-    GEngineClasses::C_ItemReact itemreact;
-    GEngineClasses::C_Item item;
-    GEngineClasses::C_Spell spell;
-    GEngineClasses::C_Mission mission;
-    GEngineClasses::C_Menu menu;
-    GEngineClasses::C_Menu_Item menuItem;
-    GEngineClasses::C_SFX sfx;
-    GEngineClasses::C_ParticleFX pfx;
-    GEngineClasses::C_MusicTheme musicTheme;
-    auto& datFile = vm.getDATFile();
-
-    // the vm of the GOTHIC.DAT does not contain C_Menu and MENU.DAT's vm does not contain C_NPC
-    // so we need to register only class members of existing classes
-    auto classExists = [&vm](const std::string& className) {
-        bool exists = vm.getDATFile().hasSymbolName(className);
-        return exists && (vm.getDATFile().getSymbolByName(className).properties.elemProps.type == EParType_Class);
-    };
-
-    if (classExists("C_Npc"))
+    void Daedalus::registerDaedalusStdLib(Daedalus::DaedalusVM& vm, bool enableVerboseLogging)
     {
-        REGISTER("C_Npc", npc, id);
-        REGISTER("C_Npc", npc, name);
-        REGISTER("C_Npc", npc, slot);
-        REGISTER_IF_EXISTS("C_Npc", npc, effect);
-        REGISTER("C_Npc", npc, npcType);
-        REGISTER("C_Npc", npc, flags);
-        REGISTER("C_Npc", npc, attribute);
-        REGISTER_IF_EXISTS("C_Npc", npc, hitChance);
-        REGISTER("C_Npc", npc, protection);
-        REGISTER("C_Npc", npc, damage);
-        REGISTER("C_Npc", npc, damagetype);
-        REGISTER("C_Npc", npc, guild);
-        REGISTER("C_Npc", npc, level);
-        REGISTER("C_Npc", npc, mission);
-        REGISTER("C_Npc", npc, fight_tactic);
-        REGISTER("C_Npc", npc, weapon);
-        REGISTER("C_Npc", npc, voice);
-        REGISTER("C_Npc", npc, voicePitch);
-        REGISTER("C_Npc", npc, bodymass);
-        REGISTER("C_Npc", npc, daily_routine);
-        REGISTER("C_Npc", npc, start_aistate);
-        REGISTER("C_Npc", npc, spawnPoint);
-        REGISTER("C_Npc", npc, spawnDelay);
-        REGISTER("C_Npc", npc, senses);
-        REGISTER("C_Npc", npc, senses_range);
-        REGISTER("C_Npc", npc, aivar);
-        REGISTER("C_Npc", npc, wp);
-        REGISTER("C_Npc", npc, exp);
-        REGISTER("C_Npc", npc, exp_next);
-        REGISTER("C_Npc", npc, lp);
-        REGISTER_IF_EXISTS("C_Npc", npc, bodyStateInterruptableOverride);
-        REGISTER_IF_EXISTS("C_Npc", npc, noFocus);
+        bool l = enableVerboseLogging;
+
+        vm.registerExternalFunction("inttostring", [l](Daedalus::DaedalusVM& vm)
+                                    {
+                                        int32_t x = vm.popDataValue();
+
+                                        vm.setReturn(std::to_string(x));
+                                    });
+
+        vm.registerExternalFunction("floattoint", [l](Daedalus::DaedalusVM& vm)
+                                    {
+                                        int32_t x = vm.popDataValue();
+                                        float f = reinterpret_cast<float&>(x);
+                                        vm.setReturn(static_cast<int32_t>(f));
+                                    });
+
+        vm.registerExternalFunction("inttofloat", [l](Daedalus::DaedalusVM& vm)
+                                    {
+                                        int32_t x = vm.popDataValue();
+                                        float f = static_cast<float>(x);
+                                        vm.setReturn(reinterpret_cast<int32_t&>(f));
+                                    });
+
+        vm.registerExternalFunction("concatstrings", [l](Daedalus::DaedalusVM& vm)
+                                    {
+                                        std::string s2 = vm.popString();
+                                        std::string s1 = vm.popString();
+
+                                        vm.setReturn(s1 + s2);
+                                    });
+
+        vm.registerExternalFunction("hlp_strcmp", [l](Daedalus::DaedalusVM& vm)
+                                    {
+                                        std::string s1 = vm.popString();
+                                        std::string s2 = vm.popString();
+
+                                        vm.setReturn(s1 == s2 ? 1 : 0);
+                                    });
+
+        vm.registerExternalFunction("hlp_random", [=](Daedalus::DaedalusVM& vm)
+                                    {
+                                        int32_t n0 = vm.popDataValue();
+
+                                        vm.setReturn(rand() % n0);
+                                    });
+
+        //
     }
 
-    if (classExists("C_Focus"))
+    void Daedalus::registerGothicEngineClasses(DaedalusVM& vm)
     {
-        REGISTER("C_Focus", focus, npc_longrange);
-        REGISTER("C_Focus", focus, npc_range1);
-        REGISTER("C_Focus", focus, npc_range2);
-        REGISTER("C_Focus", focus, npc_azi);
-        REGISTER("C_Focus", focus, npc_elevdo);
-        REGISTER("C_Focus", focus, npc_elevup);
-        REGISTER("C_Focus", focus, npc_prio);
-        REGISTER("C_Focus", focus, item_range1);
-        REGISTER("C_Focus", focus, item_range2);
-        REGISTER("C_Focus", focus, item_azi);
-        REGISTER("C_Focus", focus, item_elevdo);
-        REGISTER("C_Focus", focus, item_elevup);
-        REGISTER("C_Focus", focus, item_prio);
-        REGISTER("C_Focus", focus, mob_range1);
-        REGISTER("C_Focus", focus, mob_range2);
-        REGISTER("C_Focus", focus, mob_azi);
-        REGISTER("C_Focus", focus, mob_elevdo);
-        REGISTER("C_Focus", focus, mob_elevup);
-        REGISTER("C_Focus", focus, mob_prio);
-    }
+        GEngineClasses::C_Npc npc;
+        GEngineClasses::C_Focus focus;
+        GEngineClasses::C_Info info;
+        GEngineClasses::C_ItemReact itemreact;
+        GEngineClasses::C_Item item;
+        GEngineClasses::C_Spell spell;
+        GEngineClasses::C_Mission mission;
+        GEngineClasses::C_Menu menu;
+        GEngineClasses::C_Menu_Item menuItem;
+        GEngineClasses::C_SFX sfx;
+        GEngineClasses::C_ParticleFX pfx;
+        GEngineClasses::C_MusicTheme musicTheme;
+        auto& datFile = vm.getDATFile();
 
-    if (classExists("C_Info"))
-    {
-        REGISTER("C_Info", info, npc);
-        REGISTER("C_Info", info, nr);
-        REGISTER("C_Info", info, important);
-        REGISTER("C_Info", info, condition);
-        REGISTER("C_Info", info, information);
-        REGISTER("C_Info", info, description);
-        REGISTER("C_Info", info, trade);
-        REGISTER("C_Info", info, permanent);
-    }
+        // the vm of the GOTHIC.DAT does not contain C_Menu and MENU.DAT's vm does not contain C_NPC
+        // so we need to register only class members of existing classes
+        auto classExists = [&vm](const std::string& className)
+        {
+            bool exists = vm.getDATFile().hasSymbolName(className);
+            return exists && (vm.getDATFile().getSymbolByName(className).properties.elemProps.type == EParType_Class);
+        };
 
-    if (classExists("C_ItemReact"))
-    {
-        REGISTER("C_ItemReact", itemreact, npc);
-        REGISTER("C_ItemReact", itemreact, trade_item);
-        REGISTER("C_ItemReact", itemreact, trade_amount);
-        REGISTER("C_ItemReact", itemreact, requested_cat);
-        REGISTER("C_ItemReact", itemreact, requested_item);
-        REGISTER("C_ItemReact", itemreact, requested_amount);
-        REGISTER("C_ItemReact", itemreact, reaction);
-    }
+        if (classExists("C_Npc"))
+        {
+            REGISTER("C_Npc", npc, id);
+            REGISTER("C_Npc", npc, name);
+            REGISTER("C_Npc", npc, slot);
+            REGISTER_IF_EXISTS("C_Npc", npc, effect);
+            REGISTER("C_Npc", npc, npcType);
+            REGISTER("C_Npc", npc, flags);
+            REGISTER("C_Npc", npc, attribute);
+            REGISTER_IF_EXISTS("C_Npc", npc, hitChance);
+            REGISTER("C_Npc", npc, protection);
+            REGISTER("C_Npc", npc, damage);
+            REGISTER("C_Npc", npc, damagetype);
+            REGISTER("C_Npc", npc, guild);
+            REGISTER("C_Npc", npc, level);
+            REGISTER("C_Npc", npc, mission);
+            REGISTER("C_Npc", npc, fight_tactic);
+            REGISTER("C_Npc", npc, weapon);
+            REGISTER("C_Npc", npc, voice);
+            REGISTER("C_Npc", npc, voicePitch);
+            REGISTER("C_Npc", npc, bodymass);
+            REGISTER("C_Npc", npc, daily_routine);
+            REGISTER("C_Npc", npc, start_aistate);
+            REGISTER("C_Npc", npc, spawnPoint);
+            REGISTER("C_Npc", npc, spawnDelay);
+            REGISTER("C_Npc", npc, senses);
+            REGISTER("C_Npc", npc, senses_range);
+            REGISTER("C_Npc", npc, aivar);
+            REGISTER("C_Npc", npc, wp);
+            REGISTER("C_Npc", npc, exp);
+            REGISTER("C_Npc", npc, exp_next);
+            REGISTER("C_Npc", npc, lp);
+            REGISTER_IF_EXISTS("C_Npc", npc, bodyStateInterruptableOverride);
+            REGISTER_IF_EXISTS("C_Npc", npc, noFocus);
+        }
 
-    if (classExists("C_Item"))
-    {
-        REGISTER("C_Item", item, id);
-        REGISTER("C_Item", item, name);
-        REGISTER("C_Item", item, nameID);
-        REGISTER("C_Item", item, hp);
-        REGISTER("C_Item", item, hp_max);
-        REGISTER("C_Item", item, mainflag);
-        REGISTER("C_Item", item, flags);
-        REGISTER("C_Item", item, weight);
-        REGISTER("C_Item", item, value);
-        REGISTER("C_Item", item, damageType);
-        REGISTER("C_Item", item, damageTotal);
-        REGISTER("C_Item", item, damage);
-        REGISTER("C_Item", item, wear);
-        REGISTER("C_Item", item, protection);
-        REGISTER("C_Item", item, nutrition);
-        REGISTER("C_Item", item, cond_atr);
-        REGISTER("C_Item", item, cond_value);
-        REGISTER("C_Item", item, change_atr);
-        REGISTER("C_Item", item, change_value);
-        REGISTER("C_Item", item, magic);
-        REGISTER("C_Item", item, on_equip);
-        REGISTER("C_Item", item, on_unequip);
-        REGISTER("C_Item", item, on_state);
-        REGISTER("C_Item", item, owner);
-        REGISTER("C_Item", item, ownerGuild);
-        REGISTER("C_Item", item, disguiseGuild);
-        REGISTER("C_Item", item, visual);
-        REGISTER("C_Item", item, visual_change);
-        REGISTER_IF_EXISTS("C_Item", item, effect);
-        REGISTER("C_Item", item, visual_skin);
-        REGISTER("C_Item", item, scemeName);
-        REGISTER("C_Item", item, material);
-        REGISTER("C_Item", item, munition);
-        REGISTER("C_Item", item, spell);
-        REGISTER("C_Item", item, range);
-        REGISTER("C_Item", item, mag_circle);
-        REGISTER("C_Item", item, description);
-        REGISTER("C_Item", item, text);
-        REGISTER("C_Item", item, count);
-        REGISTER_IF_EXISTS("C_Item", item, inv_zbias);
-        REGISTER_IF_EXISTS("C_Item", item, inv_rotx);
-        REGISTER_IF_EXISTS("C_Item", item, inv_roty);
-        REGISTER_IF_EXISTS("C_Item", item, inv_rotz);
-        REGISTER_IF_EXISTS("C_Item", item, inv_animate);
-    }
+        if (classExists("C_Focus"))
+        {
+            REGISTER("C_Focus", focus, npc_longrange);
+            REGISTER("C_Focus", focus, npc_range1);
+            REGISTER("C_Focus", focus, npc_range2);
+            REGISTER("C_Focus", focus, npc_azi);
+            REGISTER("C_Focus", focus, npc_elevdo);
+            REGISTER("C_Focus", focus, npc_elevup);
+            REGISTER("C_Focus", focus, npc_prio);
+            REGISTER("C_Focus", focus, item_range1);
+            REGISTER("C_Focus", focus, item_range2);
+            REGISTER("C_Focus", focus, item_azi);
+            REGISTER("C_Focus", focus, item_elevdo);
+            REGISTER("C_Focus", focus, item_elevup);
+            REGISTER("C_Focus", focus, item_prio);
+            REGISTER("C_Focus", focus, mob_range1);
+            REGISTER("C_Focus", focus, mob_range2);
+            REGISTER("C_Focus", focus, mob_azi);
+            REGISTER("C_Focus", focus, mob_elevdo);
+            REGISTER("C_Focus", focus, mob_elevup);
+            REGISTER("C_Focus", focus, mob_prio);
+        }
 
-    if (classExists("C_Spell"))
-    {
-        REGISTER_IF_EXISTS("C_Spell", spell, time_per_mana);
-        REGISTER_IF_EXISTS("C_Spell", spell, damage_per_level);
-        REGISTER_IF_EXISTS("C_Spell", spell, damageType);
-        REGISTER_IF_EXISTS("C_Spell", spell, spellType);
-        REGISTER_IF_EXISTS("C_Spell", spell, canTurnDuringInvest);
-        REGISTER_IF_EXISTS("C_Spell", spell, canChangeTargetDuringInvest);
-        REGISTER_IF_EXISTS("C_Spell", spell, isMultiEffect);
-        REGISTER_IF_EXISTS("C_Spell", spell, targetCollectAlgo);
-        REGISTER_IF_EXISTS("C_Spell", spell, targetCollectType);
-        REGISTER_IF_EXISTS("C_Spell", spell, targetCollectRange);
-        REGISTER_IF_EXISTS("C_Spell", spell, targetCollectAzi);
-        REGISTER_IF_EXISTS("C_Spell", spell, targetCollectElev);
-    };
+        if (classExists("C_Info"))
+        {
+            REGISTER("C_Info", info, npc);
+            REGISTER("C_Info", info, nr);
+            REGISTER("C_Info", info, important);
+            REGISTER("C_Info", info, condition);
+            REGISTER("C_Info", info, information);
+            REGISTER("C_Info", info, description);
+            REGISTER("C_Info", info, trade);
+            REGISTER("C_Info", info, permanent);
+        }
 
-    if (classExists("C_Mission"))
-    {
-        REGISTER("C_Mission", mission, name);
-        REGISTER("C_Mission", mission, description);
-        REGISTER("C_Mission", mission, duration);
-        REGISTER("C_Mission", mission, important);
-        REGISTER("C_Mission", mission, offerConditions);
-        REGISTER("C_Mission", mission, offer);
-        REGISTER("C_Mission", mission, successConditions);
-        REGISTER("C_Mission", mission, success);
-        REGISTER("C_Mission", mission, failureConditions);
-        REGISTER("C_Mission", mission, failure);
-        REGISTER("C_Mission", mission, obsoleteConditions);
-        REGISTER("C_Mission", mission, obsolete);
-        REGISTER("C_Mission", mission, running);
-    }
+        if (classExists("C_ItemReact"))
+        {
+            REGISTER("C_ItemReact", itemreact, npc);
+            REGISTER("C_ItemReact", itemreact, trade_item);
+            REGISTER("C_ItemReact", itemreact, trade_amount);
+            REGISTER("C_ItemReact", itemreact, requested_cat);
+            REGISTER("C_ItemReact", itemreact, requested_item);
+            REGISTER("C_ItemReact", itemreact, requested_amount);
+            REGISTER("C_ItemReact", itemreact, reaction);
+        }
 
-    if (classExists("C_Menu"))
-    {
-        REGISTER("C_Menu", menu, backPic);
-        REGISTER("C_Menu", menu, backWorld);
-        REGISTER("C_Menu", menu, posx);
-        REGISTER("C_Menu", menu, posy);
-        REGISTER("C_Menu", menu, dimx);
-        REGISTER("C_Menu", menu, dimy);
-        REGISTER("C_Menu", menu, alpha);
-        REGISTER("C_Menu", menu, musicTheme);
-        REGISTER("C_Menu", menu, eventTimerMSec);
-        REGISTER("C_Menu", menu, items);
-        REGISTER("C_Menu", menu, flags);
-        REGISTER("C_Menu", menu, defaultOutGame);
-        REGISTER("C_Menu", menu, defaultInGame);
-    }
+        if (classExists("C_Item"))
+        {
+            REGISTER("C_Item", item, id);
+            REGISTER("C_Item", item, name);
+            REGISTER("C_Item", item, nameID);
+            REGISTER("C_Item", item, hp);
+            REGISTER("C_Item", item, hp_max);
+            REGISTER("C_Item", item, mainflag);
+            REGISTER("C_Item", item, flags);
+            REGISTER("C_Item", item, weight);
+            REGISTER("C_Item", item, value);
+            REGISTER("C_Item", item, damageType);
+            REGISTER("C_Item", item, damageTotal);
+            REGISTER("C_Item", item, damage);
+            REGISTER("C_Item", item, wear);
+            REGISTER("C_Item", item, protection);
+            REGISTER("C_Item", item, nutrition);
+            REGISTER("C_Item", item, cond_atr);
+            REGISTER("C_Item", item, cond_value);
+            REGISTER("C_Item", item, change_atr);
+            REGISTER("C_Item", item, change_value);
+            REGISTER("C_Item", item, magic);
+            REGISTER("C_Item", item, on_equip);
+            REGISTER("C_Item", item, on_unequip);
+            REGISTER("C_Item", item, on_state);
+            REGISTER("C_Item", item, owner);
+            REGISTER("C_Item", item, ownerGuild);
+            REGISTER("C_Item", item, disguiseGuild);
+            REGISTER("C_Item", item, visual);
+            REGISTER("C_Item", item, visual_change);
+            REGISTER_IF_EXISTS("C_Item", item, effect);
+            REGISTER("C_Item", item, visual_skin);
+            REGISTER("C_Item", item, scemeName);
+            REGISTER("C_Item", item, material);
+            REGISTER("C_Item", item, munition);
+            REGISTER("C_Item", item, spell);
+            REGISTER("C_Item", item, range);
+            REGISTER("C_Item", item, mag_circle);
+            REGISTER("C_Item", item, description);
+            REGISTER("C_Item", item, text);
+            REGISTER("C_Item", item, count);
+            REGISTER_IF_EXISTS("C_Item", item, inv_zbias);
+            REGISTER_IF_EXISTS("C_Item", item, inv_rotx);
+            REGISTER_IF_EXISTS("C_Item", item, inv_roty);
+            REGISTER_IF_EXISTS("C_Item", item, inv_rotz);
+            REGISTER_IF_EXISTS("C_Item", item, inv_animate);
+        }
 
-    if (classExists("C_Menu_Item"))
-    {
-        REGISTER("C_Menu_Item", menuItem, fontName);
-        REGISTER("C_Menu_Item", menuItem, text);
-        REGISTER("C_Menu_Item", menuItem, backPic);
-        REGISTER("C_Menu_Item", menuItem, alphaMode);
-        REGISTER("C_Menu_Item", menuItem, alpha);
-        REGISTER("C_Menu_Item", menuItem, type);
-        REGISTER("C_Menu_Item", menuItem, onSelAction);
-        REGISTER("C_Menu_Item", menuItem, onSelAction_S);
-        REGISTER("C_Menu_Item", menuItem, onChgSetOption);
-        REGISTER("C_Menu_Item", menuItem, onChgSetOptionSection);
-        REGISTER("C_Menu_Item", menuItem, onEventAction);
-        REGISTER("C_Menu_Item", menuItem, posx);
-        REGISTER("C_Menu_Item", menuItem, posy);
-        REGISTER("C_Menu_Item", menuItem, dimx);
-        REGISTER("C_Menu_Item", menuItem, dimy);
-        REGISTER("C_Menu_Item", menuItem, sizeStartScale);
-        REGISTER("C_Menu_Item", menuItem, flags);
-        REGISTER("C_Menu_Item", menuItem, openDelayTime);
-        REGISTER("C_Menu_Item", menuItem, openDuration);
-        REGISTER("C_Menu_Item", menuItem, userfloat);
-        REGISTER("C_Menu_Item", menuItem, userString);
-        REGISTER("C_Menu_Item", menuItem, frameSizeX);
-        REGISTER("C_Menu_Item", menuItem, frameSizeY);
-        REGISTER_IF_EXISTS("C_Menu_Item", menuItem, hideIfOptionSectionSet);
-        REGISTER_IF_EXISTS("C_Menu_Item", menuItem, hideIfOptionSet);
-        REGISTER_IF_EXISTS("C_Menu_Item", menuItem, hideOnValue);
-    }
+        if (classExists("C_Spell"))
+        {
+            REGISTER_IF_EXISTS("C_Spell", spell, time_per_mana);
+            REGISTER_IF_EXISTS("C_Spell", spell, damage_per_level);
+            REGISTER_IF_EXISTS("C_Spell", spell, damageType);
+            REGISTER_IF_EXISTS("C_Spell", spell, spellType);
+            REGISTER_IF_EXISTS("C_Spell", spell, canTurnDuringInvest);
+            REGISTER_IF_EXISTS("C_Spell", spell, canChangeTargetDuringInvest);
+            REGISTER_IF_EXISTS("C_Spell", spell, isMultiEffect);
+            REGISTER_IF_EXISTS("C_Spell", spell, targetCollectAlgo);
+            REGISTER_IF_EXISTS("C_Spell", spell, targetCollectType);
+            REGISTER_IF_EXISTS("C_Spell", spell, targetCollectRange);
+            REGISTER_IF_EXISTS("C_Spell", spell, targetCollectAzi);
+            REGISTER_IF_EXISTS("C_Spell", spell, targetCollectElev);
+        };
 
-    if (classExists("C_SFX"))
-    {
-        REGISTER("C_SFX", sfx, file);
-        REGISTER("C_SFX", sfx, pitchOff);
-        REGISTER("C_SFX", sfx, pitchVar);
-        REGISTER("C_SFX", sfx, vol);
-        REGISTER("C_SFX", sfx, loop);
-        REGISTER("C_SFX", sfx, loopStartOffset);
-        REGISTER("C_SFX", sfx, loopEndOffset);
-        REGISTER("C_SFX", sfx, reverbLevel);
-        REGISTER("C_SFX", sfx, pfxName);
-    }
+        if (classExists("C_Mission"))
+        {
+            REGISTER("C_Mission", mission, name);
+            REGISTER("C_Mission", mission, description);
+            REGISTER("C_Mission", mission, duration);
+            REGISTER("C_Mission", mission, important);
+            REGISTER("C_Mission", mission, offerConditions);
+            REGISTER("C_Mission", mission, offer);
+            REGISTER("C_Mission", mission, successConditions);
+            REGISTER("C_Mission", mission, success);
+            REGISTER("C_Mission", mission, failureConditions);
+            REGISTER("C_Mission", mission, failure);
+            REGISTER("C_Mission", mission, obsoleteConditions);
+            REGISTER("C_Mission", mission, obsolete);
+            REGISTER("C_Mission", mission, running);
+        }
 
-    if (classExists("C_ParticleFX"))
-    {
-        REGISTER("C_ParticleFX", pfx, ppsValue);
-        REGISTER("C_ParticleFX", pfx, ppsScaleKeys_S);
-        REGISTER("C_ParticleFX", pfx, ppsIsLooping);
-        REGISTER("C_ParticleFX", pfx, ppsIsSmooth);
-        REGISTER("C_ParticleFX", pfx, ppsFPS);
-        REGISTER("C_ParticleFX", pfx, ppsCreateEm_S);
-        REGISTER("C_ParticleFX", pfx, ppsCreateEmDelay);
-        REGISTER("C_ParticleFX", pfx, shpType_S);
-        REGISTER("C_ParticleFX", pfx, shpFOR_S);
-        REGISTER("C_ParticleFX", pfx, shpOffsetVec_S);
-        REGISTER("C_ParticleFX", pfx, shpDistribType_S);
-        REGISTER("C_ParticleFX", pfx, shpDistribWalkSpeed);
-        REGISTER("C_ParticleFX", pfx, shpIsVolume);
-        REGISTER("C_ParticleFX", pfx, shpDim_S);
-        REGISTER("C_ParticleFX", pfx, shpMesh_S);
-        REGISTER("C_ParticleFX", pfx, shpMeshRender_B);
-        REGISTER("C_ParticleFX", pfx, shpScaleKeys_S);
-        REGISTER("C_ParticleFX", pfx, shpScaleIsLooping);
-        REGISTER("C_ParticleFX", pfx, shpScaleIsSmooth);
-        REGISTER("C_ParticleFX", pfx, shpScaleFPS);
-        REGISTER("C_ParticleFX", pfx, dirMode_S);
-        REGISTER("C_ParticleFX", pfx, dirFOR_S);
-        REGISTER("C_ParticleFX", pfx, dirModeTargetFOR_S);
-        REGISTER("C_ParticleFX", pfx, dirModeTargetPos_S);
-        REGISTER("C_ParticleFX", pfx, dirAngleHead);
-        REGISTER("C_ParticleFX", pfx, dirAngleHeadVar);
-        REGISTER("C_ParticleFX", pfx, dirAngleElev);
-        REGISTER("C_ParticleFX", pfx, dirAngleElevVar);
-        REGISTER("C_ParticleFX", pfx, velAvg);
-        REGISTER("C_ParticleFX", pfx, velVar);
-        REGISTER("C_ParticleFX", pfx, lspPartAvg);
-        REGISTER("C_ParticleFX", pfx, lspPartVar);
-        REGISTER("C_ParticleFX", pfx, flyGravity_S);
-        REGISTER("C_ParticleFX", pfx, flyCollDet_B);
-        REGISTER("C_ParticleFX", pfx, visName_S);
-        REGISTER("C_ParticleFX", pfx, visOrientation_S);
-        REGISTER("C_ParticleFX", pfx, visTexIsQuadPoly);
-        REGISTER("C_ParticleFX", pfx, visTexAniFPS);
-        REGISTER("C_ParticleFX", pfx, visTexAniIsLooping);
-        REGISTER("C_ParticleFX", pfx, visTexColorStart_S);
-        REGISTER("C_ParticleFX", pfx, visTexColorEnd_S);
-        REGISTER("C_ParticleFX", pfx, visSizeStart_S);
-        REGISTER("C_ParticleFX", pfx, visSizeEndScale);
-        REGISTER("C_ParticleFX", pfx, visAlphaFunc_S);
-        REGISTER("C_ParticleFX", pfx, visAlphaStart);
-        REGISTER("C_ParticleFX", pfx, visAlphaEnd);
-        REGISTER("C_ParticleFX", pfx, trlFadeSpeed);
-        REGISTER("C_ParticleFX", pfx, trlTexture_S);
-        REGISTER("C_ParticleFX", pfx, trlWidth);
-        REGISTER("C_ParticleFX", pfx, mrkFadeSpeed);
-        REGISTER("C_ParticleFX", pfx, mrkTexture_S);
-        REGISTER("C_ParticleFX", pfx, mrkSize);
-        REGISTER_IF_EXISTS("C_ParticleFX", pfx, flockMode);
-        REGISTER_IF_EXISTS("C_ParticleFX", pfx, flockStrength);
-        REGISTER_IF_EXISTS("C_ParticleFX", pfx, useEmittersFOR);
-        REGISTER_IF_EXISTS("C_ParticleFX", pfx, timeStartEnd_S);
-        REGISTER_IF_EXISTS("C_ParticleFX", pfx, m_bIsAmbientPFX);
-    }
+        if (classExists("C_Menu"))
+        {
+            REGISTER("C_Menu", menu, backPic);
+            REGISTER("C_Menu", menu, backWorld);
+            REGISTER("C_Menu", menu, posx);
+            REGISTER("C_Menu", menu, posy);
+            REGISTER("C_Menu", menu, dimx);
+            REGISTER("C_Menu", menu, dimy);
+            REGISTER("C_Menu", menu, alpha);
+            REGISTER("C_Menu", menu, musicTheme);
+            REGISTER("C_Menu", menu, eventTimerMSec);
+            REGISTER("C_Menu", menu, items);
+            REGISTER("C_Menu", menu, flags);
+            REGISTER("C_Menu", menu, defaultOutGame);
+            REGISTER("C_Menu", menu, defaultInGame);
+        }
 
-    if (classExists("C_MUSICTHEME"))
-    {
-        REGISTER("C_MUSICTHEME", musicTheme, file);
-        REGISTER("C_MUSICTHEME", musicTheme, vol);
-        REGISTER("C_MUSICTHEME", musicTheme, loop);
-        REGISTER("C_MUSICTHEME", musicTheme, reverbMix);
-        REGISTER("C_MUSICTHEME", musicTheme, reverbTime);
-        REGISTER("C_MUSICTHEME", musicTheme, transType);
-        REGISTER("C_MUSICTHEME", musicTheme, transSubType);
+        if (classExists("C_Menu_Item"))
+        {
+            REGISTER("C_Menu_Item", menuItem, fontName);
+            REGISTER("C_Menu_Item", menuItem, text);
+            REGISTER("C_Menu_Item", menuItem, backPic);
+            REGISTER("C_Menu_Item", menuItem, alphaMode);
+            REGISTER("C_Menu_Item", menuItem, alpha);
+            REGISTER("C_Menu_Item", menuItem, type);
+            REGISTER("C_Menu_Item", menuItem, onSelAction);
+            REGISTER("C_Menu_Item", menuItem, onSelAction_S);
+            REGISTER("C_Menu_Item", menuItem, onChgSetOption);
+            REGISTER("C_Menu_Item", menuItem, onChgSetOptionSection);
+            REGISTER("C_Menu_Item", menuItem, onEventAction);
+            REGISTER("C_Menu_Item", menuItem, posx);
+            REGISTER("C_Menu_Item", menuItem, posy);
+            REGISTER("C_Menu_Item", menuItem, dimx);
+            REGISTER("C_Menu_Item", menuItem, dimy);
+            REGISTER("C_Menu_Item", menuItem, sizeStartScale);
+            REGISTER("C_Menu_Item", menuItem, flags);
+            REGISTER("C_Menu_Item", menuItem, openDelayTime);
+            REGISTER("C_Menu_Item", menuItem, openDuration);
+            REGISTER("C_Menu_Item", menuItem, userfloat);
+            REGISTER("C_Menu_Item", menuItem, userString);
+            REGISTER("C_Menu_Item", menuItem, frameSizeX);
+            REGISTER("C_Menu_Item", menuItem, frameSizeY);
+            REGISTER_IF_EXISTS("C_Menu_Item", menuItem, hideIfOptionSectionSet);
+            REGISTER_IF_EXISTS("C_Menu_Item", menuItem, hideIfOptionSet);
+            REGISTER_IF_EXISTS("C_Menu_Item", menuItem, hideOnValue);
+        }
+
+        if (classExists("C_SFX"))
+        {
+            REGISTER("C_SFX", sfx, file);
+            REGISTER("C_SFX", sfx, pitchOff);
+            REGISTER("C_SFX", sfx, pitchVar);
+            REGISTER("C_SFX", sfx, vol);
+            REGISTER("C_SFX", sfx, loop);
+            REGISTER("C_SFX", sfx, loopStartOffset);
+            REGISTER("C_SFX", sfx, loopEndOffset);
+            REGISTER("C_SFX", sfx, reverbLevel);
+            REGISTER("C_SFX", sfx, pfxName);
+        }
+
+        if (classExists("C_ParticleFX"))
+        {
+            REGISTER("C_ParticleFX", pfx, ppsValue);
+            REGISTER("C_ParticleFX", pfx, ppsScaleKeys_S);
+            REGISTER("C_ParticleFX", pfx, ppsIsLooping);
+            REGISTER("C_ParticleFX", pfx, ppsIsSmooth);
+            REGISTER("C_ParticleFX", pfx, ppsFPS);
+            REGISTER("C_ParticleFX", pfx, ppsCreateEm_S);
+            REGISTER("C_ParticleFX", pfx, ppsCreateEmDelay);
+            REGISTER("C_ParticleFX", pfx, shpType_S);
+            REGISTER("C_ParticleFX", pfx, shpFOR_S);
+            REGISTER("C_ParticleFX", pfx, shpOffsetVec_S);
+            REGISTER("C_ParticleFX", pfx, shpDistribType_S);
+            REGISTER("C_ParticleFX", pfx, shpDistribWalkSpeed);
+            REGISTER("C_ParticleFX", pfx, shpIsVolume);
+            REGISTER("C_ParticleFX", pfx, shpDim_S);
+            REGISTER("C_ParticleFX", pfx, shpMesh_S);
+            REGISTER("C_ParticleFX", pfx, shpMeshRender_B);
+            REGISTER("C_ParticleFX", pfx, shpScaleKeys_S);
+            REGISTER("C_ParticleFX", pfx, shpScaleIsLooping);
+            REGISTER("C_ParticleFX", pfx, shpScaleIsSmooth);
+            REGISTER("C_ParticleFX", pfx, shpScaleFPS);
+            REGISTER("C_ParticleFX", pfx, dirMode_S);
+            REGISTER("C_ParticleFX", pfx, dirFOR_S);
+            REGISTER("C_ParticleFX", pfx, dirModeTargetFOR_S);
+            REGISTER("C_ParticleFX", pfx, dirModeTargetPos_S);
+            REGISTER("C_ParticleFX", pfx, dirAngleHead);
+            REGISTER("C_ParticleFX", pfx, dirAngleHeadVar);
+            REGISTER("C_ParticleFX", pfx, dirAngleElev);
+            REGISTER("C_ParticleFX", pfx, dirAngleElevVar);
+            REGISTER("C_ParticleFX", pfx, velAvg);
+            REGISTER("C_ParticleFX", pfx, velVar);
+            REGISTER("C_ParticleFX", pfx, lspPartAvg);
+            REGISTER("C_ParticleFX", pfx, lspPartVar);
+            REGISTER("C_ParticleFX", pfx, flyGravity_S);
+            REGISTER("C_ParticleFX", pfx, flyCollDet_B);
+            REGISTER("C_ParticleFX", pfx, visName_S);
+            REGISTER("C_ParticleFX", pfx, visOrientation_S);
+            REGISTER("C_ParticleFX", pfx, visTexIsQuadPoly);
+            REGISTER("C_ParticleFX", pfx, visTexAniFPS);
+            REGISTER("C_ParticleFX", pfx, visTexAniIsLooping);
+            REGISTER("C_ParticleFX", pfx, visTexColorStart_S);
+            REGISTER("C_ParticleFX", pfx, visTexColorEnd_S);
+            REGISTER("C_ParticleFX", pfx, visSizeStart_S);
+            REGISTER("C_ParticleFX", pfx, visSizeEndScale);
+            REGISTER("C_ParticleFX", pfx, visAlphaFunc_S);
+            REGISTER("C_ParticleFX", pfx, visAlphaStart);
+            REGISTER("C_ParticleFX", pfx, visAlphaEnd);
+            REGISTER("C_ParticleFX", pfx, trlFadeSpeed);
+            REGISTER("C_ParticleFX", pfx, trlTexture_S);
+            REGISTER("C_ParticleFX", pfx, trlWidth);
+            REGISTER("C_ParticleFX", pfx, mrkFadeSpeed);
+            REGISTER("C_ParticleFX", pfx, mrkTexture_S);
+            REGISTER("C_ParticleFX", pfx, mrkSize);
+            REGISTER_IF_EXISTS("C_ParticleFX", pfx, flockMode);
+            REGISTER_IF_EXISTS("C_ParticleFX", pfx, flockStrength);
+            REGISTER_IF_EXISTS("C_ParticleFX", pfx, useEmittersFOR);
+            REGISTER_IF_EXISTS("C_ParticleFX", pfx, timeStartEnd_S);
+            REGISTER_IF_EXISTS("C_ParticleFX", pfx, m_bIsAmbientPFX);
+        }
+
+        if (classExists("C_MUSICTHEME"))
+        {
+            REGISTER("C_MUSICTHEME", musicTheme, file);
+            REGISTER("C_MUSICTHEME", musicTheme, vol);
+            REGISTER("C_MUSICTHEME", musicTheme, loop);
+            REGISTER("C_MUSICTHEME", musicTheme, reverbMix);
+            REGISTER("C_MUSICTHEME", musicTheme, reverbTime);
+            REGISTER("C_MUSICTHEME", musicTheme, transType);
+            REGISTER("C_MUSICTHEME", musicTheme, transSubType);
+        }
     }
-}
+}  // namespace ZenLib

--- a/daedalus/DaedalusStdlib.h
+++ b/daedalus/DaedalusStdlib.h
@@ -5,725 +5,728 @@
 #include <string>
 #include <vector>
 
-namespace Daedalus
+namespace ZenLib
 {
-    class DaedalusVM;
+    namespace Daedalus
+    {
+        class DaedalusVM;
 
-    /**
+        /**
 	 * Basic gametype. Needed for registering C_Class members and sky configuration in REGoth
 	 */
-    enum class GameType
-    {
-        GT_Gothic1,
-        GT_Gothic2
-    };
-
-    namespace GEngineClasses
-    {
-        const int MAX_CHAPTER = 5;
-        const int MAX_MISSIONS = 5;
-        const int MAX_HITCHANCE = 5;
-        const int ATR_INDEX_MAX = 8;
-        const int ITM_TEXT_MAX = 6;
-
-        const int DAM_INDEX_BARRIER = 0;  //				 nur der Vollstandigkeit und Transparenz wegen hier definiert ( _NICHT_ verwenden )
-        const int DAM_INDEX_BLUNT = DAM_INDEX_BARRIER + 1;
-        const int DAM_INDEX_EDGE = DAM_INDEX_BLUNT + 1;
-        const int DAM_INDEX_FIRE = DAM_INDEX_EDGE + 1;
-        const int DAM_INDEX_FLY = DAM_INDEX_FIRE + 1;
-        const int DAM_INDEX_MAGIC = DAM_INDEX_FLY + 1;
-        const int DAM_INDEX_POINT = DAM_INDEX_MAGIC + 1;
-        const int DAM_INDEX_FALL = DAM_INDEX_POINT +
-                                   1;  //				 nur der Vollstandigkeit und Transparenz wegen hier definiert ( _NICHT_ verwenden )
-        const int DAM_INDEX_MAX = DAM_INDEX_FALL + 1;
-
-        const int PROT_BARRIER = DAM_INDEX_BARRIER;
-        const int PROT_BLUNT = DAM_INDEX_BLUNT;
-        const int PROT_EDGE = DAM_INDEX_EDGE;
-        const int PROT_FIRE = DAM_INDEX_FIRE;
-        const int PROT_FLY = DAM_INDEX_FLY;
-        const int PROT_MAGIC = DAM_INDEX_MAGIC;
-        const int PROT_POINT = DAM_INDEX_POINT;
-        const int PROT_FALL = DAM_INDEX_FALL;
-        const int PROT_INDEX_MAX = DAM_INDEX_MAX;
-
-        // Music transition types
-        enum ETransitionType
+        enum class GameType
         {
-            TRANSITION_TYPE_NONE = 1,
-            TRANSITION_TYPE_GROOVE = 2,
-            TRANSITION_TYPE_FILL = 3,
-            TRANSITION_TYPE_BREAK = 4,
-            TRANSITION_TYPE_INTRO = 5,
-            TRANSITION_TYPE_END = 6,
-            TRANSITION_TYPE_ENDANDINTRO = 7
+            GT_Gothic1,
+            GT_Gothic2
         };
 
-        enum ESubTransitionType
+        namespace GEngineClasses
         {
-            TRANSITION_SUB_TYPE_IMMEDIATE = 1,
-            TRANSITION_SUB_TYPE_BEAT = 2,
-            TRANSITION_SUB_TYPE_MEASURE = 3
-        };
+            const int MAX_CHAPTER = 5;
+            const int MAX_MISSIONS = 5;
+            const int MAX_HITCHANCE = 5;
+            const int ATR_INDEX_MAX = 8;
+            const int ITM_TEXT_MAX = 6;
 
-        namespace MenuConstants
-        {
-            const int MAX_USERSTRINGS = 10;
-            const int MAX_ITEMS = 150;
-            const int MAX_EVENTS = 10;
-            const int MAX_SEL_ACTIONS = 5;
-            const int MAX_USERVARS = 4;
-            const int SEL_EVENT_UNDEF = 0;
+            const int DAM_INDEX_BARRIER = 0;  //				 nur der Vollstandigkeit und Transparenz wegen hier definiert ( _NICHT_ verwenden )
+            const int DAM_INDEX_BLUNT = DAM_INDEX_BARRIER + 1;
+            const int DAM_INDEX_EDGE = DAM_INDEX_BLUNT + 1;
+            const int DAM_INDEX_FIRE = DAM_INDEX_EDGE + 1;
+            const int DAM_INDEX_FLY = DAM_INDEX_FIRE + 1;
+            const int DAM_INDEX_MAGIC = DAM_INDEX_FLY + 1;
+            const int DAM_INDEX_POINT = DAM_INDEX_MAGIC + 1;
+            const int DAM_INDEX_FALL = DAM_INDEX_POINT +
+                                       1;  //				 nur der Vollstandigkeit und Transparenz wegen hier definiert ( _NICHT_ verwenden )
+            const int DAM_INDEX_MAX = DAM_INDEX_FALL + 1;
 
-            enum ESelEvent
+            const int PROT_BARRIER = DAM_INDEX_BARRIER;
+            const int PROT_BLUNT = DAM_INDEX_BLUNT;
+            const int PROT_EDGE = DAM_INDEX_EDGE;
+            const int PROT_FIRE = DAM_INDEX_FIRE;
+            const int PROT_FLY = DAM_INDEX_FLY;
+            const int PROT_MAGIC = DAM_INDEX_MAGIC;
+            const int PROT_POINT = DAM_INDEX_POINT;
+            const int PROT_FALL = DAM_INDEX_FALL;
+            const int PROT_INDEX_MAX = DAM_INDEX_MAX;
+
+            // Music transition types
+            enum ETransitionType
             {
-                SEL_EVENT_EXECUTE = 1,
-                SEL_EVENT_CHANGED = 2,
-                SEL_EVENT_LEAVE = 3,
-                SEL_EVENT_TIMER = 4,
-                SEL_EVENT_CLOSE = 5,
-                SEL_EVENT_INIT = 6,
-                SEL_EVENT_SEL_PREV = 7,
-                SEL_EVENT_SEL_NEXT = 8,
+                TRANSITION_TYPE_NONE = 1,
+                TRANSITION_TYPE_GROOVE = 2,
+                TRANSITION_TYPE_FILL = 3,
+                TRANSITION_TYPE_BREAK = 4,
+                TRANSITION_TYPE_INTRO = 5,
+                TRANSITION_TYPE_END = 6,
+                TRANSITION_TYPE_ENDANDINTRO = 7
             };
 
-            enum ESelAction
+            enum ESubTransitionType
             {
-                SEL_ACTION_UNDEF = 0,
-                SEL_ACTION_BACK = 1,
-                SEL_ACTION_STARTMENU = 2,
-                SEL_ACTION_STARTITEM = 3,
-                SEL_ACTION_CLOSE = 4,
-                SEL_ACTION_CONCOMMANDS = 5,
-                SEL_ACTION_PLAY_SOUND = 6,
-                SEL_ACTION_EXECCOMMANDS = 7,
+                TRANSITION_SUB_TYPE_IMMEDIATE = 1,
+                TRANSITION_SUB_TYPE_BEAT = 2,
+                TRANSITION_SUB_TYPE_MEASURE = 3
             };
-        }  // namespace MenuConstants
 
-        struct Instance
-        {
-            Instance()
+            namespace MenuConstants
             {
-                userPtr = nullptr;
-                instanceSymbol = 0;
-            }
+                const int MAX_USERSTRINGS = 10;
+                const int MAX_ITEMS = 150;
+                const int MAX_EVENTS = 10;
+                const int MAX_SEL_ACTIONS = 5;
+                const int MAX_USERVARS = 4;
+                const int SEL_EVENT_UNDEF = 0;
 
-            size_t instanceSymbol;
+                enum ESelEvent
+                {
+                    SEL_EVENT_EXECUTE = 1,
+                    SEL_EVENT_CHANGED = 2,
+                    SEL_EVENT_LEAVE = 3,
+                    SEL_EVENT_TIMER = 4,
+                    SEL_EVENT_CLOSE = 5,
+                    SEL_EVENT_INIT = 6,
+                    SEL_EVENT_SEL_PREV = 7,
+                    SEL_EVENT_SEL_NEXT = 8,
+                };
 
-            /**
+                enum ESelAction
+                {
+                    SEL_ACTION_UNDEF = 0,
+                    SEL_ACTION_BACK = 1,
+                    SEL_ACTION_STARTMENU = 2,
+                    SEL_ACTION_STARTITEM = 3,
+                    SEL_ACTION_CLOSE = 4,
+                    SEL_ACTION_CONCOMMANDS = 5,
+                    SEL_ACTION_PLAY_SOUND = 6,
+                    SEL_ACTION_EXECCOMMANDS = 7,
+                };
+            }  // namespace MenuConstants
+
+            struct Instance
+            {
+                Instance()
+                {
+                    userPtr = nullptr;
+                    instanceSymbol = 0;
+                }
+
+                size_t instanceSymbol;
+
+                /**
              * Space for the user to save something. Will not be touched at all by ZenLib.
              * Note: This is set to nullptr after creation.
              */
-            void* userPtr;
-        };
-
-        struct C_ParticleFX : Instance
-        {
-            // 1) Emitter: zeitliches  Austoss-Verhalten, particles-per-second
-            float ppsValue;
-            std::string ppsScaleKeys_S;
-            int32_t ppsIsLooping;
-            int32_t ppsIsSmooth;
-            float ppsFPS;
-            std::string ppsCreateEm_S;
-            float ppsCreateEmDelay;
-
-            // 2) Emitter: raeumliches Austoss-Verhalten
-            std::string shpType_S;  //	"point, line, box, circle, sphere, mesh"
-            std::string shpFOR_S;   //	"object,world"
-            std::string shpOffsetVec_S;
-            std::string shpDistribType_S;  //	"RAND, UNIFORM, WALK"
-            float shpDistribWalkSpeed;
-            int32_t shpIsVolume;
-            std::string shpDim_S;   //	"", "30", "10 20 30", "30", "30", "" //	line: nur 1 Dimension !=0 // shape Dimensions
-            std::string shpMesh_S;  //	"cross.3ds"
-            int32_t shpMeshRender_B;
-            std::string shpScaleKeys_S;  //	"[1.0] [0.8 0.9 0.2] [1.0]"
-            int32_t shpScaleIsLooping;
-            int32_t shpScaleIsSmooth;
-            float shpScaleFPS;
-
-            // 3) Partikel: Start Richtung/Speed:
-            std::string dirMode_S;  //	"DIR, TARGET, MESH_POLY"
-            std::string dirFOR_S;   //	"OBJECT, WORLD"
-            std::string dirModeTargetFOR_S;
-            std::string dirModeTargetPos_S;  //	"30 23 67"
-            float dirAngleHead;
-            float dirAngleHeadVar;
-            float dirAngleElev;
-            float dirAngleElevVar;
-            float velAvg;
-            float velVar;
-
-            // 4) Partikel: Lebensdauer
-            float lspPartAvg;
-            float lspPartVar;
-
-            // 5) Partikel: Flugverhalten (gravity, nicht-linear?, mesh-selfRot?,..)
-            // grav: a) nur Y, b) XYZ, c) auf Ziel zu steuern
-            // std::string  flyMode_S;								//	"LINEAR, LIN_SINUS,.."
-            // flyMeshSelfRotSpeedMin, flyMeshSelfRotSpeedMax
-            std::string flyGravity_S;
-            int32_t flyCollDet_B;
-
-            // 6) Partikel: Visualisierung
-            std::string visName_S;         //	"NAME_V0_A0.TGA/.3DS"	(Variation, Animation)
-            std::string visOrientation_S;  //	"NONE, VELO"
-            int32_t visTexIsQuadPoly;      //	0=triMesh, 1=quadMesh
-            float visTexAniFPS;
-            int32_t visTexAniIsLooping;  //	0=oneShot, 1=looping
-            // color		(nur Tex, lifeSpan-Sync)
-            std::string visTexColorStart_S;
-            std::string visTexColorEnd_S;
-            // size-ani		(nur Tex, lifeSpan-Sync)
-            std::string visSizeStart_S;
-            float visSizeEndScale;
-            // alpha		(lifeSpan-Sync)
-            std::string visAlphaFunc_S;
-            float visAlphaStart;
-            float visAlphaEnd;
-
-            // 7) misc effects
-
-            // trail
-            float trlFadeSpeed;
-            std::string trlTexture_S;
-            float trlWidth;
-
-            // marks
-            float mrkFadeSpeed;
-            std::string mrkTexture_S;
-            float mrkSize;
-
-            // flocking
-            std::string flockMode;
-            float flockStrength;
-
-            // local frame of reference override
-            // calculates the position of the particles each frame relative to the emitters pos/rot
-            // can be expensive
-            // WARNING: in comb with flyCollDet_B this can be a performance-hog deluxe
-            int32_t useEmittersFOR;
-
-            // optional you can set a valid timeperiod in which this pfx should be rendered (e.g. "8 22": should be rendererd from 8 to 22 o clock")
-            std::string timeStartEnd_S;
-
-            // with the next setting you can define weather this pfx is an ambient pfx, thus can be disabled in the gothic.ini with the value [ENGINE]/noAmbientPFX
-            int32_t m_bIsAmbientPFX;
-        };
-
-        struct C_Menu : Instance
-        {
-            enum EFlags : int32_t
-            {
-                MENU_OVERTOP = 1,
-                MENU_EXCLUSIVE = 2,
-                MENU_NOANI = 4,
-                MENU_DONTSCALE_DIM = 8,
-                MENU_DONTSCALE_POS = 16,
-                MENU_ALIGN_CENTER = 32,
-                MENU_SHOW_INFO = 64,
+                void* userPtr;
             };
 
-            C_Menu()
+            struct C_ParticleFX : Instance
             {
-                posx = 0;
-                posy = 0;
-                alpha = 0;
-                eventTimerMSec = 0;
-                flags = 0;
-                defaultOutGame = 0;
-                defaultInGame = 0;
-            }
+                // 1) Emitter: zeitliches  Austoss-Verhalten, particles-per-second
+                float ppsValue;
+                std::string ppsScaleKeys_S;
+                int32_t ppsIsLooping;
+                int32_t ppsIsSmooth;
+                float ppsFPS;
+                std::string ppsCreateEm_S;
+                float ppsCreateEmDelay;
 
-            std::string backPic;
-            std::string backWorld;
-            int32_t posx, posy;
-            int32_t dimx, dimy;
-            int32_t alpha;
-            std::string musicTheme;
-            int32_t eventTimerMSec;
-            std::string items[MenuConstants::MAX_ITEMS];
-            int32_t flags;
-            int32_t defaultOutGame;
-            int32_t defaultInGame;
-        };
+                // 2) Emitter: raeumliches Austoss-Verhalten
+                std::string shpType_S;  //	"point, line, box, circle, sphere, mesh"
+                std::string shpFOR_S;   //	"object,world"
+                std::string shpOffsetVec_S;
+                std::string shpDistribType_S;  //	"RAND, UNIFORM, WALK"
+                float shpDistribWalkSpeed;
+                int32_t shpIsVolume;
+                std::string shpDim_S;   //	"", "30", "10 20 30", "30", "30", "" //	line: nur 1 Dimension !=0 // shape Dimensions
+                std::string shpMesh_S;  //	"cross.3ds"
+                int32_t shpMeshRender_B;
+                std::string shpScaleKeys_S;  //	"[1.0] [0.8 0.9 0.2] [1.0]"
+                int32_t shpScaleIsLooping;
+                int32_t shpScaleIsSmooth;
+                float shpScaleFPS;
 
-        struct C_Menu_Item : Instance
-        {
-            enum EFlags : int32_t
-            {
-                IT_CHROMAKEYED = 1,
-                IT_TRANSPARENT = 2,
-                IT_SELECTABLE = 4,
-                IT_MOVEABLE = 8,
-                IT_TXT_CENTER = 16,
-                IT_DISABLED = 32,
-                IT_FADE = 64,
-                IT_EFFECTS_NEXT = 128,
-                IT_ONLY_OUT_GAME = 256,
-                IT_ONLY_IN_GAME = 512,
-                IT_PERF_OPTION = 1024,
-                IT_MULTILINE = 2048,
-                IT_NEEDS_APPLY = 4096,
-                IT_NEEDS_RESTART = 8192,
-                IT_EXTENDED_MENU = 16384,
+                // 3) Partikel: Start Richtung/Speed:
+                std::string dirMode_S;  //	"DIR, TARGET, MESH_POLY"
+                std::string dirFOR_S;   //	"OBJECT, WORLD"
+                std::string dirModeTargetFOR_S;
+                std::string dirModeTargetPos_S;  //	"30 23 67"
+                float dirAngleHead;
+                float dirAngleHeadVar;
+                float dirAngleElev;
+                float dirAngleElevVar;
+                float velAvg;
+                float velVar;
+
+                // 4) Partikel: Lebensdauer
+                float lspPartAvg;
+                float lspPartVar;
+
+                // 5) Partikel: Flugverhalten (gravity, nicht-linear?, mesh-selfRot?,..)
+                // grav: a) nur Y, b) XYZ, c) auf Ziel zu steuern
+                // std::string  flyMode_S;								//	"LINEAR, LIN_SINUS,.."
+                // flyMeshSelfRotSpeedMin, flyMeshSelfRotSpeedMax
+                std::string flyGravity_S;
+                int32_t flyCollDet_B;
+
+                // 6) Partikel: Visualisierung
+                std::string visName_S;         //	"NAME_V0_A0.TGA/.3DS"	(Variation, Animation)
+                std::string visOrientation_S;  //	"NONE, VELO"
+                int32_t visTexIsQuadPoly;      //	0=triMesh, 1=quadMesh
+                float visTexAniFPS;
+                int32_t visTexAniIsLooping;  //	0=oneShot, 1=looping
+                // color		(nur Tex, lifeSpan-Sync)
+                std::string visTexColorStart_S;
+                std::string visTexColorEnd_S;
+                // size-ani		(nur Tex, lifeSpan-Sync)
+                std::string visSizeStart_S;
+                float visSizeEndScale;
+                // alpha		(lifeSpan-Sync)
+                std::string visAlphaFunc_S;
+                float visAlphaStart;
+                float visAlphaEnd;
+
+                // 7) misc effects
+
+                // trail
+                float trlFadeSpeed;
+                std::string trlTexture_S;
+                float trlWidth;
+
+                // marks
+                float mrkFadeSpeed;
+                std::string mrkTexture_S;
+                float mrkSize;
+
+                // flocking
+                std::string flockMode;
+                float flockStrength;
+
+                // local frame of reference override
+                // calculates the position of the particles each frame relative to the emitters pos/rot
+                // can be expensive
+                // WARNING: in comb with flyCollDet_B this can be a performance-hog deluxe
+                int32_t useEmittersFOR;
+
+                // optional you can set a valid timeperiod in which this pfx should be rendered (e.g. "8 22": should be rendererd from 8 to 22 o clock")
+                std::string timeStartEnd_S;
+
+                // with the next setting you can define weather this pfx is an ambient pfx, thus can be disabled in the gothic.ini with the value [ENGINE]/noAmbientPFX
+                int32_t m_bIsAmbientPFX;
             };
 
-            enum EType : int32_t
+            struct C_Menu : Instance
             {
-                MENU_ITEM_UNDEF = 0,
-                MENU_ITEM_TEXT = 1,
-                MENU_ITEM_SLIDER = 2,
-                MENU_ITEM_INPUT = 3,
-                MENU_ITEM_CURSOR = 4,
-                MENU_ITEM_CHOICEBOX = 5,
-                MENU_ITEM_BUTTON = 6,
-                MENU_ITEM_LISTBOX = 7,
+                enum EFlags : int32_t
+                {
+                    MENU_OVERTOP = 1,
+                    MENU_EXCLUSIVE = 2,
+                    MENU_NOANI = 4,
+                    MENU_DONTSCALE_DIM = 8,
+                    MENU_DONTSCALE_POS = 16,
+                    MENU_ALIGN_CENTER = 32,
+                    MENU_SHOW_INFO = 64,
+                };
+
+                C_Menu()
+                {
+                    posx = 0;
+                    posy = 0;
+                    alpha = 0;
+                    eventTimerMSec = 0;
+                    flags = 0;
+                    defaultOutGame = 0;
+                    defaultInGame = 0;
+                }
+
+                std::string backPic;
+                std::string backWorld;
+                int32_t posx, posy;
+                int32_t dimx, dimy;
+                int32_t alpha;
+                std::string musicTheme;
+                int32_t eventTimerMSec;
+                std::string items[MenuConstants::MAX_ITEMS];
+                int32_t flags;
+                int32_t defaultOutGame;
+                int32_t defaultInGame;
             };
 
-            C_Menu_Item()
+            struct C_Menu_Item : Instance
             {
-                alpha = 0;
-                type = 0;
-                memset(onSelAction, 0, sizeof(onSelAction));
-                memset(onEventAction, 0, sizeof(onEventAction));
-                posx = 0;
-                posy = 0;
-                dimx = 0;
-                dimy = 0;
-                sizeStartScale = 0.0f;
-                flags = 0;
-                openDelayTime = 0;
-                openDuration = 0;
-                memset(userfloat, 0, sizeof(userfloat));
-                frameSizeX = 0;
-                frameSizeY = 0;
-                hideOnValue = 0;
-            }
+                enum EFlags : int32_t
+                {
+                    IT_CHROMAKEYED = 1,
+                    IT_TRANSPARENT = 2,
+                    IT_SELECTABLE = 4,
+                    IT_MOVEABLE = 8,
+                    IT_TXT_CENTER = 16,
+                    IT_DISABLED = 32,
+                    IT_FADE = 64,
+                    IT_EFFECTS_NEXT = 128,
+                    IT_ONLY_OUT_GAME = 256,
+                    IT_ONLY_IN_GAME = 512,
+                    IT_PERF_OPTION = 1024,
+                    IT_MULTILINE = 2048,
+                    IT_NEEDS_APPLY = 4096,
+                    IT_NEEDS_RESTART = 8192,
+                    IT_EXTENDED_MENU = 16384,
+                };
 
-            std::string fontName;
-            std::string text[MenuConstants::MAX_USERSTRINGS];
-            std::string backPic;
-            std::string alphaMode;
-            int32_t alpha;
-            int32_t type;
-            int32_t onSelAction[MenuConstants::MAX_SEL_ACTIONS];
-            std::string onSelAction_S[MenuConstants::MAX_SEL_ACTIONS];
-            std::string onChgSetOption;
-            std::string onChgSetOptionSection;
+                enum EType : int32_t
+                {
+                    MENU_ITEM_UNDEF = 0,
+                    MENU_ITEM_TEXT = 1,
+                    MENU_ITEM_SLIDER = 2,
+                    MENU_ITEM_INPUT = 3,
+                    MENU_ITEM_CURSOR = 4,
+                    MENU_ITEM_CHOICEBOX = 5,
+                    MENU_ITEM_BUTTON = 6,
+                    MENU_ITEM_LISTBOX = 7,
+                };
 
-            int32_t onEventAction[MenuConstants::MAX_EVENTS];
-            int32_t posx, posy;
-            int32_t dimx, dimy;  // -1 = AUTODETECT (FONTWISE)
-            float sizeStartScale;
-            int32_t flags;
-            float openDelayTime;
-            float openDuration;
-            float userfloat[MenuConstants::MAX_USERVARS];
-            std::string userString[MenuConstants::MAX_USERVARS];
-            int32_t frameSizeX;
-            int32_t frameSizeY;
-            std::string hideIfOptionSectionSet;
-            std::string hideIfOptionSet;
-            int32_t hideOnValue;
-        };
+                C_Menu_Item()
+                {
+                    alpha = 0;
+                    type = 0;
+                    memset(onSelAction, 0, sizeof(onSelAction));
+                    memset(onEventAction, 0, sizeof(onEventAction));
+                    posx = 0;
+                    posy = 0;
+                    dimx = 0;
+                    dimy = 0;
+                    sizeStartScale = 0.0f;
+                    flags = 0;
+                    openDelayTime = 0;
+                    openDuration = 0;
+                    memset(userfloat, 0, sizeof(userfloat));
+                    frameSizeX = 0;
+                    frameSizeY = 0;
+                    hideOnValue = 0;
+                }
 
-        struct C_Npc : Instance
-        {
-            enum EAttributes : int32_t
-            {
-                EATR_HITPOINTS = 0,
-                EATR_HITPOINTSMAX = 1,
-                EATR_MANA = 2,
-                EATR_MANAMAX = 3,
-                EATR_STRENGTH = 4,
-                EATR_DEXTERITY = 5,
-                EATR_REGENERATEHP = 6,
-                EATR_REGENERATEMANA = 7,
+                std::string fontName;
+                std::string text[MenuConstants::MAX_USERSTRINGS];
+                std::string backPic;
+                std::string alphaMode;
+                int32_t alpha;
+                int32_t type;
+                int32_t onSelAction[MenuConstants::MAX_SEL_ACTIONS];
+                std::string onSelAction_S[MenuConstants::MAX_SEL_ACTIONS];
+                std::string onChgSetOption;
+                std::string onChgSetOptionSection;
 
-                EATR_MAX = 8
+                int32_t onEventAction[MenuConstants::MAX_EVENTS];
+                int32_t posx, posy;
+                int32_t dimx, dimy;  // -1 = AUTODETECT (FONTWISE)
+                float sizeStartScale;
+                int32_t flags;
+                float openDelayTime;
+                float openDuration;
+                float userfloat[MenuConstants::MAX_USERVARS];
+                std::string userString[MenuConstants::MAX_USERVARS];
+                int32_t frameSizeX;
+                int32_t frameSizeY;
+                std::string hideIfOptionSectionSet;
+                std::string hideIfOptionSet;
+                int32_t hideOnValue;
             };
 
-            enum ENPCFlag : int32_t
+            struct C_Npc : Instance
             {
-                EFLAG_NONE = 0,
-                EFLAG_FRIENDS = 1 << 0,
-                EFLAG_IMMORTAL = 1 << 1,
-                EFLAG_GHOST = 1 << 2,
-                EFLAG_PROTECTED = 1 << 10,
+                enum EAttributes : int32_t
+                {
+                    EATR_HITPOINTS = 0,
+                    EATR_HITPOINTSMAX = 1,
+                    EATR_MANA = 2,
+                    EATR_MANAMAX = 3,
+                    EATR_STRENGTH = 4,
+                    EATR_DEXTERITY = 5,
+                    EATR_REGENERATEHP = 6,
+                    EATR_REGENERATEMANA = 7,
+
+                    EATR_MAX = 8
+                };
+
+                enum ENPCFlag : int32_t
+                {
+                    EFLAG_NONE = 0,
+                    EFLAG_FRIENDS = 1 << 0,
+                    EFLAG_IMMORTAL = 1 << 1,
+                    EFLAG_GHOST = 1 << 2,
+                    EFLAG_PROTECTED = 1 << 10,
+                };
+
+                C_Npc()
+                {
+                    id = 0;
+                    npcType = 0;
+                    flags = EFLAG_NONE;
+                    memset(attribute, 0, sizeof(attribute));
+                    memset(hitChance, 0, sizeof(hitChance));
+                    memset(protection, 0, sizeof(protection));
+                    memset(damage, 0, sizeof(damage));
+                    memset(mission, 0, sizeof(mission));
+                    damagetype = 0;
+                    guild = 0;
+                    level = 0;
+                    fight_tactic = 0;
+                    weapon = 0;
+                    voice = 0;
+                    voicePitch = 0;
+                    bodymass = 0;
+                    daily_routine = 0;
+                    start_aistate = 0;
+                    spawnDelay = 0;
+                    senses = 0;
+                    senses_range = 0;
+                    memset(aivar, 0, sizeof(aivar));
+                    exp = 0;
+                    exp_next = 0;
+                    lp = 0;
+                    bodyStateInterruptableOverride = 0;
+                    noFocus = 0;
+                }
+
+                int32_t id;
+                std::string name[5];
+                std::string slot;
+                std::string effect;
+                int32_t npcType;
+                ENPCFlag flags;
+                int32_t attribute[EATR_MAX];
+                int32_t hitChance[MAX_HITCHANCE];
+                int32_t protection[PROT_INDEX_MAX];
+                int32_t damage[DAM_INDEX_MAX];
+                int32_t damagetype;
+                int32_t guild, level;
+                uint32_t mission[MAX_MISSIONS];
+                int32_t fight_tactic;
+                int32_t weapon;
+
+                int32_t voice;
+                int32_t voicePitch;
+                int32_t bodymass;
+                uint32_t daily_routine;
+                uint32_t start_aistate;
+
+                // **********************
+                // Spawn
+                // **********************
+                std::string spawnPoint;
+                int32_t spawnDelay;
+
+                // **********************
+                // SENSES
+                // **********************
+                int32_t senses;
+                int32_t senses_range;
+
+                // **********************
+                // Feel free to use
+                // **********************
+                int32_t aivar[100];
+                std::string wp;
+
+                // **********************
+                // Experience dependant
+                // **********************
+                int32_t exp;
+                int32_t exp_next;
+                int32_t lp;
+
+                // If this is set to TRUE, the Npc can't be interrupted in any action (e.g. BS_FLAG_INTERRUPTABLE for anis is being ignored)
+                int32_t bodyStateInterruptableOverride;
+                // if "noFocus" is set to TRUE, the focus name and health bar will not be drawn of this nsc (hi, stefan!)
+                int32_t noFocus;
             };
 
-            C_Npc()
+            struct C_Mission : Instance
             {
-                id = 0;
-                npcType = 0;
-                flags = EFLAG_NONE;
-                memset(attribute, 0, sizeof(attribute));
-                memset(hitChance, 0, sizeof(hitChance));
-                memset(protection, 0, sizeof(protection));
-                memset(damage, 0, sizeof(damage));
-                memset(mission, 0, sizeof(mission));
-                damagetype = 0;
-                guild = 0;
-                level = 0;
-                fight_tactic = 0;
-                weapon = 0;
-                voice = 0;
-                voicePitch = 0;
-                bodymass = 0;
-                daily_routine = 0;
-                start_aistate = 0;
-                spawnDelay = 0;
-                senses = 0;
-                senses_range = 0;
-                memset(aivar, 0, sizeof(aivar));
-                exp = 0;
-                exp_next = 0;
-                lp = 0;
-                bodyStateInterruptableOverride = 0;
-                noFocus = 0;
-            }
+                std::string name;  //	Name des Auftrages
+                std::string description;
+                int32_t duration;  //	Max. Dauer in Tageszeiten
+                int32_t important;
 
-            int32_t id;
-            std::string name[5];
-            std::string slot;
-            std::string effect;
-            int32_t npcType;
-            ENPCFlag flags;
-            int32_t attribute[EATR_MAX];
-            int32_t hitChance[MAX_HITCHANCE];
-            int32_t protection[PROT_INDEX_MAX];
-            int32_t damage[DAM_INDEX_MAX];
-            int32_t damagetype;
-            int32_t guild, level;
-            uint32_t mission[MAX_MISSIONS];
-            int32_t fight_tactic;
-            int32_t weapon;
-
-            int32_t voice;
-            int32_t voicePitch;
-            int32_t bodymass;
-            uint32_t daily_routine;
-            uint32_t start_aistate;
-
-            // **********************
-            // Spawn
-            // **********************
-            std::string spawnPoint;
-            int32_t spawnDelay;
-
-            // **********************
-            // SENSES
-            // **********************
-            int32_t senses;
-            int32_t senses_range;
-
-            // **********************
-            // Feel free to use
-            // **********************
-            int32_t aivar[100];
-            std::string wp;
-
-            // **********************
-            // Experience dependant
-            // **********************
-            int32_t exp;
-            int32_t exp_next;
-            int32_t lp;
-
-            // If this is set to TRUE, the Npc can't be interrupted in any action (e.g. BS_FLAG_INTERRUPTABLE for anis is being ignored)
-            int32_t bodyStateInterruptableOverride;
-            // if "noFocus" is set to TRUE, the focus name and health bar will not be drawn of this nsc (hi, stefan!)
-            int32_t noFocus;
-        };
-
-        struct C_Mission : Instance
-        {
-            std::string name;  //	Name des Auftrages
-            std::string description;
-            int32_t duration;  //	Max. Dauer in Tageszeiten
-            int32_t important;
-
-            uint32_t offerConditions;
-            uint32_t offer;
-            uint32_t successConditions;
-            uint32_t success;
-            uint32_t failureConditions;
-            uint32_t failure;
-            uint32_t obsoleteConditions;
-            uint32_t obsolete;
-            uint32_t running;
-        };
-
-        struct C_Item : Instance
-        {
-            // Categories, found in the "mainflag"-field
-            enum Categories
-            {
-                ITM_CAT_NONE = 1 << 0,
-                ITM_CAT_NF = 1 << 1,
-                ITM_CAT_FF = 1 << 2,
-                ITM_CAT_MUN = 1 << 3,
-                ITM_CAT_ARMOR = 1 << 4,
-                ITM_CAT_FOOD = 1 << 5,
-                ITM_CAT_DOCS = 1 << 6,
-                ITM_CAT_POTION = 1 << 7,
-                ITM_CAT_LIGHT = 1 << 8,
-                ITM_CAT_RUNE = 1 << 9,
-                ITM_CAT_MAGIC = 1 << 31,
-                ITM_CAT_EQUIPABLE = ITM_CAT_NF | ITM_CAT_FF | ITM_CAT_ARMOR | ITM_CAT_RUNE | ITM_CAT_MAGIC,
+                uint32_t offerConditions;
+                uint32_t offer;
+                uint32_t successConditions;
+                uint32_t success;
+                uint32_t failureConditions;
+                uint32_t failure;
+                uint32_t obsoleteConditions;
+                uint32_t obsolete;
+                uint32_t running;
             };
 
-            enum Flags
+            struct C_Item : Instance
             {
-                ITEM_DAG = 1 << 13,       //  Dagger
-                ITEM_SWD = 1 << 14,       //	Waffe wird wie ein Schwert behandelt
-                ITEM_AXE = 1 << 15,       //	Waffe wird wie eine Axt behandelt
-                ITEM_2HD_SWD = 1 << 16,   //	Waffe wird wie ein Zweihänder behandelt
-                ITEM_2HD_AXE = 1 << 17,   //	Waffe wird wie eine Streitaxt behandelt
-                ITEM_BOW = 1 << 19,       //	Waffe wird wie ein Bogen behandelt
-                ITEM_CROSSBOW = 1 << 20,  //	Waffe wird wie eine Armbrust behandelt
-                ITEM_AMULET = 1 << 22,
-                ITEM_RING = 1 << 11,
-                ITEM_BELT = 1 << 24,
-                ITEM_MISSION = 1 << 12,
+                // Categories, found in the "mainflag"-field
+                enum Categories
+                {
+                    ITM_CAT_NONE = 1 << 0,
+                    ITM_CAT_NF = 1 << 1,
+                    ITM_CAT_FF = 1 << 2,
+                    ITM_CAT_MUN = 1 << 3,
+                    ITM_CAT_ARMOR = 1 << 4,
+                    ITM_CAT_FOOD = 1 << 5,
+                    ITM_CAT_DOCS = 1 << 6,
+                    ITM_CAT_POTION = 1 << 7,
+                    ITM_CAT_LIGHT = 1 << 8,
+                    ITM_CAT_RUNE = 1 << 9,
+                    ITM_CAT_MAGIC = 1 << 31,
+                    ITM_CAT_EQUIPABLE = ITM_CAT_NF | ITM_CAT_FF | ITM_CAT_ARMOR | ITM_CAT_RUNE | ITM_CAT_MAGIC,
+                };
+
+                enum Flags
+                {
+                    ITEM_DAG = 1 << 13,       //  Dagger
+                    ITEM_SWD = 1 << 14,       //	Waffe wird wie ein Schwert behandelt
+                    ITEM_AXE = 1 << 15,       //	Waffe wird wie eine Axt behandelt
+                    ITEM_2HD_SWD = 1 << 16,   //	Waffe wird wie ein Zweihänder behandelt
+                    ITEM_2HD_AXE = 1 << 17,   //	Waffe wird wie eine Streitaxt behandelt
+                    ITEM_BOW = 1 << 19,       //	Waffe wird wie ein Bogen behandelt
+                    ITEM_CROSSBOW = 1 << 20,  //	Waffe wird wie eine Armbrust behandelt
+                    ITEM_AMULET = 1 << 22,
+                    ITEM_RING = 1 << 11,
+                    ITEM_BELT = 1 << 24,
+                    ITEM_MISSION = 1 << 12,
+                };
+
+                C_Item()
+                    : on_state{}
+                    , count{}
+                    , cond_atr{}
+                    , cond_value{}
+                    , change_atr{}
+                    , change_value{}
+                    , protection{}
+                    , damage{}
+                {
+                    id = 0;
+                    hp = 0;
+                    hp_max = 0;
+                    mainflag = 0;
+                    flags = 0;
+                    weight = 0;
+                    value = 0;
+                    damageType = 0;
+                    damageTotal = 0;
+                    wear = 0;
+                    nutrition = 0;
+                    magic = 0;
+                    on_equip = 0;
+                    on_unequip = 0;
+                    owner = 0;
+                    ownerGuild = 0;
+                    disguiseGuild = 0;
+                    visual_skin = 0;
+                    material = 0;
+                    munition = 0;
+                    spell = 0;
+                    range = 0;
+                    mag_circle = 0;
+                    inv_zbias = 0;
+                    inv_rotx = 0;
+                    inv_roty = 0;
+                    inv_rotz = 0;
+                    inv_animate = 0;
+                    amount = 0;
+                }
+
+                // Für alle Items
+                int32_t id;
+                std::string name, nameID;
+                int32_t hp, hp_max;
+
+                int32_t mainflag, flags;  //	Hauptflag und weitere Flags
+                int32_t weight, value;
+
+                // Für Waffen
+                int32_t damageType;  //	Welche Schadensarten
+                int32_t damageTotal;
+                int32_t damage[DAM_INDEX_MAX];
+
+                // Für Rüstungen
+                int32_t wear;
+                int32_t protection[PROT_INDEX_MAX];
+
+                // Für Nahrung
+                int32_t nutrition;  //	HP-Steigerung bei Nahrung
+
+                // Benötigte Attribute zum Benutzen des Items
+                enum
+                {
+                    COND_ATR_MAX = 3
+                };
+                int32_t cond_atr[COND_ATR_MAX];
+                int32_t cond_value[COND_ATR_MAX];
+
+                // Attribute, die bei anlegen des Items verändert werden
+                enum
+                {
+                    CHANGE_ATR_MAX = 3
+                };
+                int32_t change_atr[CHANGE_ATR_MAX];
+                int32_t change_value[CHANGE_ATR_MAX];
+
+                // Parserfunktionen
+                uint32_t magic;       //	Parserfunktion zum "Magie Header"
+                uint32_t on_equip;    //	Parserfunktion, wenn Item equipped wird.
+                uint32_t on_unequip;  //	Parserfunktion, wenn Item unequipped wird.
+                uint32_t on_state[4];
+
+                // Besitzer
+                uint32_t owner;         //	Besitzer : Instanz-Name
+                int32_t ownerGuild;     //	Besitzer : Gilde
+                int32_t disguiseGuild;  //	Zur Schau getragene Gilde durch Verkleidung
+
+                // Die 3DS-Datei
+                std::string visual;
+
+                // Veränderung des NSC-Meshes beim Anlegen dieses Gegenstandes
+                std::string visual_change;  //	ASC - File
+                std::string effect;
+                int32_t visual_skin;
+
+                std::string scemeName;
+                int32_t material;
+                // std::string	pfx								;		//	Magic Weapon PFX
+                int32_t munition;  //	Instance of Munition
+
+                int32_t spell;
+                int32_t range;
+
+                int32_t mag_circle;
+
+                std::string description;
+                std::string text[ITM_TEXT_MAX];
+                int32_t count[ITM_TEXT_MAX];
+
+                // inventory darstellungs geschichten, wird nur benutzt, falls von 0 abweichend
+                int32_t inv_zbias;    //  wie weit ist das item im inventory richtung far plane verschoben (integer scale 100=1)
+                int32_t inv_rotx;     //  wieviel grad um die x achse ist das item im inv gedreht
+                int32_t inv_roty;     //  wieviel grad um die y achse ist das item im inv gedreht
+                int32_t inv_rotz;     //  wieviel grad um die z achse ist das item im inv gedreht
+                int32_t inv_animate;  //  soll das item in inv rotiert werden
+
+                // REGoth member, number of items
+                uint32_t amount;
             };
 
-            C_Item()
-                : on_state{}
-                , count{}
-                , cond_atr{}
-                , cond_value{}
-                , change_atr{}
-                , change_value{}
-                , protection{}
-                , damage{}
+            struct C_Focus : Instance
             {
-                id = 0;
-                hp = 0;
-                hp_max = 0;
-                mainflag = 0;
-                flags = 0;
-                weight = 0;
-                value = 0;
-                damageType = 0;
-                damageTotal = 0;
-                wear = 0;
-                nutrition = 0;
-                magic = 0;
-                on_equip = 0;
-                on_unequip = 0;
-                owner = 0;
-                ownerGuild = 0;
-                disguiseGuild = 0;
-                visual_skin = 0;
-                material = 0;
-                munition = 0;
-                spell = 0;
-                range = 0;
-                mag_circle = 0;
-                inv_zbias = 0;
-                inv_rotx = 0;
-                inv_roty = 0;
-                inv_rotz = 0;
-                inv_animate = 0;
-                amount = 0;
-            }
+                /// für NSCs
+                float npc_longrange;           //	Zurufweite	( 20 m )
+                float npc_range1, npc_range2;  //	Reichweite
+                float npc_azi;                 //	Azimuth		( Seitenwinkel )
+                float npc_elevdo, npc_elevup;  //	Elevation	( Höhenwinkel  )
+                int32_t npc_prio;              //	Priorität
 
-            // Für alle Items
-            int32_t id;
-            std::string name, nameID;
-            int32_t hp, hp_max;
+                /// für ITEMs
+                float item_range1, item_range2;  //	Reichweite
+                float item_azi;                  //	Azimuth		( Seitenwinkel )
+                float item_elevdo, item_elevup;  //	Elevation	( Höhenwinkel  )
+                int32_t item_prio;               //	Priorität
 
-            int32_t mainflag, flags;  //	Hauptflag und weitere Flags
-            int32_t weight, value;
-
-            // Für Waffen
-            int32_t damageType;  //	Welche Schadensarten
-            int32_t damageTotal;
-            int32_t damage[DAM_INDEX_MAX];
-
-            // Für Rüstungen
-            int32_t wear;
-            int32_t protection[PROT_INDEX_MAX];
-
-            // Für Nahrung
-            int32_t nutrition;  //	HP-Steigerung bei Nahrung
-
-            // Benötigte Attribute zum Benutzen des Items
-            enum
-            {
-                COND_ATR_MAX = 3
+                /// für MOBs
+                float mob_range1, mob_range2;  //	Reichweite
+                float mob_azi;                 //	Azimuth		( Seitenwinkel )
+                float mob_elevdo, mob_elevup;  //	Elevation	( Höhenwinkel  )
+                int32_t mob_prio;              //	Priorität
             };
-            int32_t cond_atr[COND_ATR_MAX];
-            int32_t cond_value[COND_ATR_MAX];
 
-            // Attribute, die bei anlegen des Items verändert werden
-            enum
+            struct SubChoice
             {
-                CHANGE_ATR_MAX = 3
+                std::string text;
+                uint32_t functionSym;
             };
-            int32_t change_atr[CHANGE_ATR_MAX];
-            int32_t change_value[CHANGE_ATR_MAX];
 
-            // Parserfunktionen
-            uint32_t magic;       //	Parserfunktion zum "Magie Header"
-            uint32_t on_equip;    //	Parserfunktion, wenn Item equipped wird.
-            uint32_t on_unequip;  //	Parserfunktion, wenn Item unequipped wird.
-            uint32_t on_state[4];
-
-            // Besitzer
-            uint32_t owner;         //	Besitzer : Instanz-Name
-            int32_t ownerGuild;     //	Besitzer : Gilde
-            int32_t disguiseGuild;  //	Zur Schau getragene Gilde durch Verkleidung
-
-            // Die 3DS-Datei
-            std::string visual;
-
-            // Veränderung des NSC-Meshes beim Anlegen dieses Gegenstandes
-            std::string visual_change;  //	ASC - File
-            std::string effect;
-            int32_t visual_skin;
-
-            std::string scemeName;
-            int32_t material;
-            // std::string	pfx								;		//	Magic Weapon PFX
-            int32_t munition;  //	Instance of Munition
-
-            int32_t spell;
-            int32_t range;
-
-            int32_t mag_circle;
-
-            std::string description;
-            std::string text[ITM_TEXT_MAX];
-            int32_t count[ITM_TEXT_MAX];
-
-            // inventory darstellungs geschichten, wird nur benutzt, falls von 0 abweichend
-            int32_t inv_zbias;    //  wie weit ist das item im inventory richtung far plane verschoben (integer scale 100=1)
-            int32_t inv_rotx;     //  wieviel grad um die x achse ist das item im inv gedreht
-            int32_t inv_roty;     //  wieviel grad um die y achse ist das item im inv gedreht
-            int32_t inv_rotz;     //  wieviel grad um die z achse ist das item im inv gedreht
-            int32_t inv_animate;  //  soll das item in inv rotiert werden
-
-            // REGoth member, number of items
-            uint32_t amount;
-        };
-
-        struct C_Focus : Instance
-        {
-            /// für NSCs
-            float npc_longrange;           //	Zurufweite	( 20 m )
-            float npc_range1, npc_range2;  //	Reichweite
-            float npc_azi;                 //	Azimuth		( Seitenwinkel )
-            float npc_elevdo, npc_elevup;  //	Elevation	( Höhenwinkel  )
-            int32_t npc_prio;              //	Priorität
-
-            /// für ITEMs
-            float item_range1, item_range2;  //	Reichweite
-            float item_azi;                  //	Azimuth		( Seitenwinkel )
-            float item_elevdo, item_elevup;  //	Elevation	( Höhenwinkel  )
-            int32_t item_prio;               //	Priorität
-
-            /// für MOBs
-            float mob_range1, mob_range2;  //	Reichweite
-            float mob_azi;                 //	Azimuth		( Seitenwinkel )
-            float mob_elevdo, mob_elevup;  //	Elevation	( Höhenwinkel  )
-            int32_t mob_prio;              //	Priorität
-        };
-
-        struct SubChoice
-        {
-            std::string text;
-            uint32_t functionSym;
-        };
-
-        struct C_Info : Instance
-        {
-            // important, permanent and nr are optional in scripts, so we must to set a default value
-            C_Info()=default;
-            int32_t npc=0;
-            int32_t nr=0;
-            int32_t important=0;  //	Wichtig Flag -> ansprechen
-            uint32_t condition=0;
-            uint32_t information=0;
-            std::string description;
-            int32_t trade=0; // bool32-flag
-            int32_t permanent=0;
-            std::vector<SubChoice> subChoices;
-            void addChoice(const SubChoice& subChoice)
+            struct C_Info : Instance
             {
-                subChoices.insert(subChoices.begin(), subChoice);
-            }
-            void removeChoice(std::size_t index)
+                // important, permanent and nr are optional in scripts, so we must to set a default value
+                C_Info() = default;
+                int32_t npc = 0;
+                int32_t nr = 0;
+                int32_t important = 0;  //	Wichtig Flag -> ansprechen
+                uint32_t condition = 0;
+                uint32_t information = 0;
+                std::string description;
+                int32_t trade = 0;  // bool32-flag
+                int32_t permanent = 0;
+                std::vector<SubChoice> subChoices;
+                void addChoice(const SubChoice& subChoice)
+                {
+                    subChoices.insert(subChoices.begin(), subChoice);
+                }
+                void removeChoice(std::size_t index)
+                {
+                    subChoices.erase(subChoices.begin() + index);
+                }
+            };
+
+            struct C_Spell : Instance
             {
-                subChoices.erase(subChoices.begin() + index);
-            }
-        };
+                float time_per_mana;       // Zeit pro investierten Manapunkt (ms)
+                int32_t damage_per_level;  // Schaden pro Level
+                int32_t damageType;        // CAN BE ONLY ONE DAMAGE TYPE
+                int32_t spellType;         // Good, Neutral or Bad
+                int32_t canTurnDuringInvest;
+                int32_t canChangeTargetDuringInvest;
+                int32_t isMultiEffect;  // Effect Class is oCVisFX_MultiTarget if set to 1 (e.g. the effect can have multiple trajectorys (massdeath)
+                int32_t targetCollectAlgo;
+                int32_t targetCollectType;
+                int32_t targetCollectRange;
+                int32_t targetCollectAzi;
+                int32_t targetCollectElev;
+            };
 
-        struct C_Spell : Instance
-        {
-            float time_per_mana;       // Zeit pro investierten Manapunkt (ms)
-            int32_t damage_per_level;  // Schaden pro Level
-            int32_t damageType;        // CAN BE ONLY ONE DAMAGE TYPE
-            int32_t spellType;         // Good, Neutral or Bad
-            int32_t canTurnDuringInvest;
-            int32_t canChangeTargetDuringInvest;
-            int32_t isMultiEffect;  // Effect Class is oCVisFX_MultiTarget if set to 1 (e.g. the effect can have multiple trajectorys (massdeath)
-            int32_t targetCollectAlgo;
-            int32_t targetCollectType;
-            int32_t targetCollectRange;
-            int32_t targetCollectAzi;
-            int32_t targetCollectElev;
-        };
+            struct C_ItemReact : Instance
+            {
+                int32_t npc;
+                int32_t trade_item;
+                int32_t trade_amount;
+                int32_t requested_cat;
+                int32_t requested_item;
+                int32_t requested_amount;
+                uint32_t reaction;
+            };
 
-        struct C_ItemReact : Instance
-        {
-            int32_t npc;
-            int32_t trade_item;
-            int32_t trade_amount;
-            int32_t requested_cat;
-            int32_t requested_item;
-            int32_t requested_amount;
-            uint32_t reaction;
-        };
+            struct C_SFX : Instance
+            {
+                std::string file;
+                // pitch offset in semi-tones
+                int32_t pitchOff = 0;
+                // semitone variance
+                int32_t pitchVar = 0;
+                // 0 .. 127
+                int32_t vol = 64;
+                int32_t loop = 0;
+                int32_t loopStartOffset = 0;
+                int32_t loopEndOffset = 0;
+                float reverbLevel = 0.0f;
+                std::string pfxName;
+            };
 
-        struct C_SFX : Instance
-        {
-            std::string file;
-            // pitch offset in semi-tones
-            int32_t pitchOff = 0;
-            // semitone variance
-            int32_t pitchVar = 0;
-            // 0 .. 127
-            int32_t vol = 64;
-            int32_t loop = 0;
-            int32_t loopStartOffset = 0;
-            int32_t loopEndOffset = 0;
-            float reverbLevel = 0.0f;
-            std::string pfxName;
-        };
+            struct C_MusicTheme : Instance
+            {
+                std::string file;
+                float vol;
+                int32_t loop;
+                float reverbMix;
+                float reverbTime;
+                int32_t transType;
+                int32_t transSubType;
+            };
+        }  // namespace GEngineClasses
 
-        struct C_MusicTheme : Instance
-        {
-            std::string file;
-            float vol;
-            int32_t loop;
-            float reverbMix;
-            float reverbTime;
-            int32_t transType;
-            int32_t transSubType;
-        };
-    }  // namespace GEngineClasses
-
-    /**
+        /**
      * @brief Implements some generic script-externals
      */
-    void registerDaedalusStdLib(DaedalusVM& vm, bool enableVerboseLogging = false);
+        void registerDaedalusStdLib(DaedalusVM& vm, bool enableVerboseLogging = false);
 
-    /**
+        /**
      * @brief Links the classes known to the engine to the VM.
      */
-    void registerGothicEngineClasses(DaedalusVM& vm);
-}  // namespace Daedalus
+        void registerGothicEngineClasses(DaedalusVM& vm);
+    }  // namespace Daedalus
+}  // namespace ZenLib

--- a/daedalus/DaedalusVM.cpp
+++ b/daedalus/DaedalusVM.cpp
@@ -9,739 +9,742 @@
 
 #define STACKIFY(x) static_cast<int32_t>(x)
 
-extern std::map<int, const char*> OP_MAP;
-
-const int NUM_FAKE_STRING_SYMBOLS = 5;
-
-using namespace ZenLoad;
-using namespace Daedalus;
-
-DaedalusVM::DaedalusVM(const std::string& file, bool registerZenLibExternals)
-    : m_GameState(*this)
+namespace ZenLib
 {
-    m_PC = 0;
-    m_DATFile = Daedalus::DATFile(file);
+    extern std::map<int, const char*> OP_MAP;
 
-    initializeFromLoadedDAT(registerZenLibExternals);
-}
+    const int NUM_FAKE_STRING_SYMBOLS = 5;
 
-DaedalusVM::DaedalusVM(const uint8_t* pDATFileData, size_t numBytes, bool registerZenLibExternals)
-    : m_GameState(*this)
-{
-    m_PC = 0;
-    m_DATFile = Daedalus::DATFile(pDATFileData, numBytes);
+    using namespace ZenLoad;
+    using namespace Daedalus;
 
-    initializeFromLoadedDAT(registerZenLibExternals);
-}
-
-void DaedalusVM::initializeFromLoadedDAT(bool registerZenLibExternals)
-{
-    // Make fake-strings
-    for (size_t i = 0; i < NUM_FAKE_STRING_SYMBOLS; i++)
+    DaedalusVM::DaedalusVM(const std::string& file, bool registerZenLibExternals)
+        : m_GameState(*this)
     {
-        auto symIndex = m_DATFile.addSymbol();
-        // make sure there is enough space for 1 string
-        m_DATFile.getSymbolByIndex(symIndex).strData.resize(1);
-        m_FakeStringSymbols.push(symIndex);
+        m_PC = 0;
+        m_DATFile = Daedalus::DATFile(file);
+
+        initializeFromLoadedDAT(registerZenLibExternals);
     }
 
-    // REGoth: don't register ZenLib externals
-    if (registerZenLibExternals)
-        m_GameState.registerExternals();
-
-    m_CurrentInstanceHandle.invalidate();
-}
-
-bool DaedalusVM::doStack(bool verbose)
-{
-    static bool log = verbose;
-    size_t oldPC = m_PC;
-    PARStackOpCode op = getCurrentInstruction();
-
-    int32_t a;
-    int32_t b;
-    uint32_t arr, arr2;
-    int32_t* addr;
-    std::string *straddr, *straddr2;
-    static PARSymbol s;
-    PARSymbol& sym = s;
-    PARSymbol& sym2 = s;
-
-    if (log) LogInfo() << oldPC << ": " << OP_MAP[op.op];
-
-    switch (op.op)
+    DaedalusVM::DaedalusVM(const uint8_t* pDATFileData, size_t numBytes, bool registerZenLibExternals)
+        : m_GameState(*this)
     {
-        case EParOp_Add:
-            pushInt(popDataValue() + popDataValue());
-            break;
-        case EParOp_Subract:
-            pushInt(popDataValue() - popDataValue());
-            break;
-        case EParOp_Multiply:
-            pushInt(popDataValue() * popDataValue());
-            break;
-        case EParOp_Divide:
-            pushInt(popDataValue() / popDataValue());
-            break;
-        case EParOp_Mod:
-            pushInt(popDataValue() % popDataValue());
-            break;
-        case EParOp_BinOr:
-            pushInt(popDataValue() | popDataValue());
-            break;
-        case EParOp_BinAnd:
-            pushInt(popDataValue() & popDataValue());
-            break;
-        case EParOp_Less:
-            pushInt(popDataValue() < popDataValue() ? 1 : 0);
-            break;
-        case EParOp_Greater:
-            pushInt(popDataValue() > popDataValue() ? 1 : 0);
-            break;
+        m_PC = 0;
+        m_DATFile = Daedalus::DATFile(pDATFileData, numBytes);
 
-        case EParOp_AssignFunc:
-            /*a = popVar(arr);
+        initializeFromLoadedDAT(registerZenLibExternals);
+    }
+
+    void DaedalusVM::initializeFromLoadedDAT(bool registerZenLibExternals)
+    {
+        // Make fake-strings
+        for (size_t i = 0; i < NUM_FAKE_STRING_SYMBOLS; i++)
+        {
+            auto symIndex = m_DATFile.addSymbol();
+            // make sure there is enough space for 1 string
+            m_DATFile.getSymbolByIndex(symIndex).strData.resize(1);
+            m_FakeStringSymbols.push(symIndex);
+        }
+
+        // REGoth: don't register ZenLib externals
+        if (registerZenLibExternals)
+            m_GameState.registerExternals();
+
+        m_CurrentInstanceHandle.invalidate();
+    }
+
+    bool DaedalusVM::doStack(bool verbose)
+    {
+        static bool log = verbose;
+        size_t oldPC = m_PC;
+        PARStackOpCode op = getCurrentInstruction();
+
+        int32_t a;
+        int32_t b;
+        uint32_t arr, arr2;
+        int32_t* addr;
+        std::string *straddr, *straddr2;
+        static PARSymbol s;
+        PARSymbol& sym = s;
+        PARSymbol& sym2 = s;
+
+        if (log) LogInfo() << oldPC << ": " << OP_MAP[op.op];
+
+        switch (op.op)
+        {
+            case EParOp_Add:
+                pushInt(popDataValue() + popDataValue());
+                break;
+            case EParOp_Subract:
+                pushInt(popDataValue() - popDataValue());
+                break;
+            case EParOp_Multiply:
+                pushInt(popDataValue() * popDataValue());
+                break;
+            case EParOp_Divide:
+                pushInt(popDataValue() / popDataValue());
+                break;
+            case EParOp_Mod:
+                pushInt(popDataValue() % popDataValue());
+                break;
+            case EParOp_BinOr:
+                pushInt(popDataValue() | popDataValue());
+                break;
+            case EParOp_BinAnd:
+                pushInt(popDataValue() & popDataValue());
+                break;
+            case EParOp_Less:
+                pushInt(popDataValue() < popDataValue() ? 1 : 0);
+                break;
+            case EParOp_Greater:
+                pushInt(popDataValue() > popDataValue() ? 1 : 0);
+                break;
+
+            case EParOp_AssignFunc:
+                /*a = popVar(arr);
             b = popDataValue();
 
             sym2 = m_DATFile.getSymbolByIndex(b);
             m_DATFile.getSymbolByIndex(a).set(sym2.address, 0, getCurrentInstanceDataPtr());
             break;*/
 
-        case EParOp_Assign:
-        {
-            a = popVar(arr);
-            if (log) LogInfo() << " - a: " << a << ", arr: " << arr;
-            b = popDataValue();
+            case EParOp_Assign:
+            {
+                a = popVar(arr);
+                if (log) LogInfo() << " - a: " << a << ", arr: " << arr;
+                b = popDataValue();
 
-            int32_t& aInt = m_DATFile.getSymbolByIndex(a).getInt(arr, getCurrentInstanceDataPtr());
-            if (log) LogInfo() << " - " << aInt << " -> " << b;
-            aInt = b;
+                int32_t& aInt = m_DATFile.getSymbolByIndex(a).getInt(arr, getCurrentInstanceDataPtr());
+                if (log) LogInfo() << " - " << aInt << " -> " << b;
+                aInt = b;
 
-            if (m_OnSymbolValueChanged)
-                m_OnSymbolValueChanged((unsigned)a, EParOp_Assign);
+                if (m_OnSymbolValueChanged)
+                    m_OnSymbolValueChanged((unsigned)a, EParOp_Assign);
 
-            break;
-        }
-        case EParOp_LogOr:
-            // Note: This can't be done in one line because the second pop might not be executed,
-            // due to c++'s short-circuit evaluation
-            a = popDataValue();
-            b = popDataValue();
-            pushInt(a || b ? 1 : 0);
-            break;
-        case EParOp_LogAnd:
-            // Note: This can't be done in one line because the second pop might not be executed,
-            // due to c++'s short-circuit evaluation
-            a = popDataValue();
-            b = popDataValue();
-            pushInt(a && b ? 1 : 0);
-            break;
-        case EParOp_ShiftLeft:
-            pushInt(popDataValue() << popDataValue());
-            break;
-        case EParOp_ShiftRight:
-            pushInt(popDataValue() << popDataValue());
-            break;
-        case EParOp_LessOrEqual:
-            pushInt(popDataValue() <= popDataValue() ? 1 : 0);
-            break;
-        case EParOp_Equal:
-            pushInt(popDataValue() == popDataValue() ? 1 : 0);
-            break;
-        case EParOp_NotEqual:
-            pushInt(popDataValue() != popDataValue() ? 1 : 0);
-            break;
-        case EParOp_GreaterOrEqual:
-            pushInt(popDataValue() >= popDataValue() ? 1 : 0);
-            break;
-        case EParOp_AssignAdd:
-            a = popVar(arr);
-            addr = &m_DATFile.getSymbolByIndex(a).getInt(arr, getCurrentInstanceDataPtr());
-            *addr += popDataValue();
+                break;
+            }
+            case EParOp_LogOr:
+                // Note: This can't be done in one line because the second pop might not be executed,
+                // due to c++'s short-circuit evaluation
+                a = popDataValue();
+                b = popDataValue();
+                pushInt(a || b ? 1 : 0);
+                break;
+            case EParOp_LogAnd:
+                // Note: This can't be done in one line because the second pop might not be executed,
+                // due to c++'s short-circuit evaluation
+                a = popDataValue();
+                b = popDataValue();
+                pushInt(a && b ? 1 : 0);
+                break;
+            case EParOp_ShiftLeft:
+                pushInt(popDataValue() << popDataValue());
+                break;
+            case EParOp_ShiftRight:
+                pushInt(popDataValue() << popDataValue());
+                break;
+            case EParOp_LessOrEqual:
+                pushInt(popDataValue() <= popDataValue() ? 1 : 0);
+                break;
+            case EParOp_Equal:
+                pushInt(popDataValue() == popDataValue() ? 1 : 0);
+                break;
+            case EParOp_NotEqual:
+                pushInt(popDataValue() != popDataValue() ? 1 : 0);
+                break;
+            case EParOp_GreaterOrEqual:
+                pushInt(popDataValue() >= popDataValue() ? 1 : 0);
+                break;
+            case EParOp_AssignAdd:
+                a = popVar(arr);
+                addr = &m_DATFile.getSymbolByIndex(a).getInt(arr, getCurrentInstanceDataPtr());
+                *addr += popDataValue();
 
-            if (m_OnSymbolValueChanged)
-                m_OnSymbolValueChanged((unsigned)a, EParOp_AssignAdd);
-            break;
-        case EParOp_AssignSubtract:
-            a = popVar(arr);
-            addr = &m_DATFile.getSymbolByIndex(a).getInt(arr, getCurrentInstanceDataPtr());
-            *addr -= popDataValue();
+                if (m_OnSymbolValueChanged)
+                    m_OnSymbolValueChanged((unsigned)a, EParOp_AssignAdd);
+                break;
+            case EParOp_AssignSubtract:
+                a = popVar(arr);
+                addr = &m_DATFile.getSymbolByIndex(a).getInt(arr, getCurrentInstanceDataPtr());
+                *addr -= popDataValue();
 
-            if (m_OnSymbolValueChanged)
-                m_OnSymbolValueChanged((unsigned)a, EParOp_AssignSubtract);
-            break;
-        case EParOp_AssignMultiply:
-            a = popVar(arr);
-            addr = &m_DATFile.getSymbolByIndex(a).getInt(arr, getCurrentInstanceDataPtr());
-            *addr *= popDataValue();
+                if (m_OnSymbolValueChanged)
+                    m_OnSymbolValueChanged((unsigned)a, EParOp_AssignSubtract);
+                break;
+            case EParOp_AssignMultiply:
+                a = popVar(arr);
+                addr = &m_DATFile.getSymbolByIndex(a).getInt(arr, getCurrentInstanceDataPtr());
+                *addr *= popDataValue();
 
-            if (m_OnSymbolValueChanged)
-                m_OnSymbolValueChanged((unsigned)a, EParOp_AssignMultiply);
-            break;
-        case EParOp_AssignDivide:
-            a = popVar(arr);
-            addr = &m_DATFile.getSymbolByIndex(a).getInt(arr, getCurrentInstanceDataPtr());
-            *addr /= popDataValue();
+                if (m_OnSymbolValueChanged)
+                    m_OnSymbolValueChanged((unsigned)a, EParOp_AssignMultiply);
+                break;
+            case EParOp_AssignDivide:
+                a = popVar(arr);
+                addr = &m_DATFile.getSymbolByIndex(a).getInt(arr, getCurrentInstanceDataPtr());
+                *addr /= popDataValue();
 
-            if (m_OnSymbolValueChanged)
-                m_OnSymbolValueChanged((unsigned)a, EParOp_AssignDivide);
-            break;
-        case EParOp_Plus:
-            pushInt(+popDataValue());
-            break;
-        case EParOp_Minus:
-            pushInt(-popDataValue());
-            break;
-        case EParOp_Not:
-            pushInt(!popDataValue());
-            break;
-        case EParOp_Negate:
-            pushInt(~popDataValue());
-            break;
-        case EParOp_Ret:
-            /*if(m_RetStack.empty())
+                if (m_OnSymbolValueChanged)
+                    m_OnSymbolValueChanged((unsigned)a, EParOp_AssignDivide);
+                break;
+            case EParOp_Plus:
+                pushInt(+popDataValue());
+                break;
+            case EParOp_Minus:
+                pushInt(-popDataValue());
+                break;
+            case EParOp_Not:
+                pushInt(!popDataValue());
+                break;
+            case EParOp_Negate:
+                pushInt(~popDataValue());
+                break;
+            case EParOp_Ret:
+                /*if(m_RetStack.empty())
                 return false; // Program ended
 
             m_PC = static_cast<uint32_t>(m_RetStack.top());
             m_RetStack.pop();
             m_CallStack.pop_back();*/
-            return false;
-            break;
-        case EParOp_Call:
-        {
-            if (log) LogInfo() << oldPC << " - CALL: " << op.address;
+                return false;
+                break;
+            case EParOp_Call:
+            {
+                if (log) LogInfo() << oldPC << " - CALL: " << op.address;
 
-            /*m_RetStack.push(m_PC);
+                /*m_RetStack.push(m_PC);
 			m_PC = (size_t)op.address;
 
 			m_CallStack.push_back((size_t)op.address);*/
 
-            ZMemory::BigHandle currentInstanceHandle = m_CurrentInstanceHandle;
-            EInstanceClass currentInstanceClass = m_CurrentInstanceClass;
-            size_t PC = m_PC;
+                ZMemory::BigHandle currentInstanceHandle = m_CurrentInstanceHandle;
+                EInstanceClass currentInstanceClass = m_CurrentInstanceClass;
+                size_t PC = m_PC;
 
-            setProgramCounter((size_t)op.address);
-            {
-                CallStackFrame frame(*this, op.address, CallStackFrame::Address);
-                while (doStack())
-                    ;
+                setProgramCounter((size_t)op.address);
+                {
+                    CallStackFrame frame(*this, op.address, CallStackFrame::Address);
+                    while (doStack())
+                        ;
+                }
+
+                m_PC = PC;
+                m_CurrentInstanceHandle = currentInstanceHandle;
+                m_CurrentInstanceClass = currentInstanceClass;
             }
+            break;
 
-            m_PC = PC;
-            m_CurrentInstanceHandle = currentInstanceHandle;
-            m_CurrentInstanceClass = currentInstanceClass;
-        }
-        break;
-
-        case EParOp_CallExternal:
-        {
-            auto it = m_ExternalsByIndex.find(op.symbol);
-
-            ZMemory::BigHandle currentInstanceHandle = m_CurrentInstanceHandle;
-            EInstanceClass currentInstanceClass = m_CurrentInstanceClass;
-            size_t PC = m_PC;
-
-            if (log) LogInfo() << " - Function: " << m_DATFile.getSymbolByIndex(op.symbol).name;
-            if (it != m_ExternalsByIndex.end())
+            case EParOp_CallExternal:
             {
-                if (m_OnExternalCalled)
-                    m_OnExternalCalled((unsigned)op.symbol);
+                auto it = m_ExternalsByIndex.find(op.symbol);
+
+                ZMemory::BigHandle currentInstanceHandle = m_CurrentInstanceHandle;
+                EInstanceClass currentInstanceClass = m_CurrentInstanceClass;
+                size_t PC = m_PC;
+
+                if (log) LogInfo() << " - Function: " << m_DATFile.getSymbolByIndex(op.symbol).name;
+                if (it != m_ExternalsByIndex.end())
+                {
+                    if (m_OnExternalCalled)
+                        m_OnExternalCalled((unsigned)op.symbol);
+
+                    {
+                        CallStackFrame frame(*this, op.symbol, CallStackFrame::SymbolIndex);
+                        (*it).second(*this);
+                    }
+                }
+
+                m_PC = PC;
+                m_CurrentInstanceHandle = currentInstanceHandle;
+                m_CurrentInstanceClass = currentInstanceClass;
+            }
+            break;
+
+            case EParOp_PushInt:
+                pushInt(op.value);
+                if (log) LogInfo() << " - " << op.value;
+                break;
+            case EParOp_PushVar:
+                pushVar(op.symbol);
+
+                if (log)
+                {
+                    // Push second time just for debugging
+                    pushVar(op.symbol);
+                    LogInfo() << " - [" << op.symbol << "] " << m_DATFile.getSymbolByIndex(op.symbol).name << ": " << popDataValue();
+                }
+                break;
+            case EParOp_PushInstance:
+                pushVar(op.symbol);
+                if (log) LogInfo() << " - [" << op.symbol << "] " << m_DATFile.getSymbolByIndex(op.symbol).name << ", Handle: " << m_DATFile.getSymbolByIndex(op.symbol).instanceDataHandle.index;
+                break;  //TODO: Not sure about this
+            case EParOp_AssignString:
+                a = popVar(arr);
+                b = popVar(arr2);
+
+                if (b == -1)
+                {
+                    LogWarn() << "EParOp_AssignString failed! Invalid value for 'b'!";
+                    break;
+                }
+
+                sym = m_DATFile.getSymbolByIndex(a);
+                straddr = &m_DATFile.getSymbolByIndex(a).getString(arr, getCurrentInstanceDataPtr());
 
                 {
-                    CallStackFrame frame(*this, op.symbol, CallStackFrame::SymbolIndex);
-                    (*it).second(*this);
+                    //std::string s1 = *straddr;
+                    std::string s2 = m_DATFile.getSymbolByIndex(b).getString(arr2, getCurrentInstanceDataPtr());
+
+                    //LogInfo() << "s1 (" << sym.name << "): " << s1 << " s2: " << s2;
+
+                    *straddr = s2;
                 }
-            }
 
-            m_PC = PC;
-            m_CurrentInstanceHandle = currentInstanceHandle;
-            m_CurrentInstanceClass = currentInstanceClass;
-        }
-        break;
+                if (m_OnSymbolValueChanged)
+                    m_OnSymbolValueChanged((unsigned)a, EParOp_AssignString);
 
-        case EParOp_PushInt:
-            pushInt(op.value);
-            if (log) LogInfo() << " - " << op.value;
-            break;
-        case EParOp_PushVar:
-            pushVar(op.symbol);
-
-            if (log)
-            {
-                // Push second time just for debugging
-                pushVar(op.symbol);
-                LogInfo() << " - [" << op.symbol << "] " << m_DATFile.getSymbolByIndex(op.symbol).name << ": " << popDataValue();
-            }
-            break;
-        case EParOp_PushInstance:
-            pushVar(op.symbol);
-            if (log) LogInfo() << " - [" << op.symbol << "] " << m_DATFile.getSymbolByIndex(op.symbol).name << ", Handle: " << m_DATFile.getSymbolByIndex(op.symbol).instanceDataHandle.index;
-            break;  //TODO: Not sure about this
-        case EParOp_AssignString:
-            a = popVar(arr);
-            b = popVar(arr2);
-
-            if (b == -1)
-            {
-                LogWarn() << "EParOp_AssignString failed! Invalid value for 'b'!";
+                //LogInfo() << "We're fine!";
+                //if(log) LogInfo() << " - " << a << ", " << b << ": " << *m_DATFile.getSymbolByIndex(b).getStrAddr(arr2, getCurrentInstanceDataPtr());
                 break;
-            }
+            case EParOp_AssignStringRef:
+                LogError() << "EParOp_AssignStringRef not implemented!";
+                break;
 
-            sym = m_DATFile.getSymbolByIndex(a);
-            straddr = &m_DATFile.getSymbolByIndex(a).getString(arr, getCurrentInstanceDataPtr());
-
+            case EParOp_AssignFloat:
             {
-                //std::string s1 = *straddr;
-                std::string s2 = m_DATFile.getSymbolByIndex(b).getString(arr2, getCurrentInstanceDataPtr());
+                a = popVar(arr);
+                float b = popFloatValue();
+                {
+                    float& aFloat = m_DATFile.getSymbolByIndex(a).getFloat(arr, getCurrentInstanceDataPtr());
+                    aFloat = b;
+                }
 
-                //LogInfo() << "s1 (" << sym.name << "): " << s1 << " s2: " << s2;
-
-                *straddr = s2;
+                if (m_OnSymbolValueChanged)
+                    m_OnSymbolValueChanged((unsigned)a, EParOp_AssignFloat);
             }
-
-            if (m_OnSymbolValueChanged)
-                m_OnSymbolValueChanged((unsigned)a, EParOp_AssignString);
-
-            //LogInfo() << "We're fine!";
-            //if(log) LogInfo() << " - " << a << ", " << b << ": " << *m_DATFile.getSymbolByIndex(b).getStrAddr(arr2, getCurrentInstanceDataPtr());
-            break;
-        case EParOp_AssignStringRef:
-            LogError() << "EParOp_AssignStringRef not implemented!";
             break;
 
-        case EParOp_AssignFloat:
-        {
-            a = popVar(arr);
-            float b = popFloatValue();
-            {
-                float& aFloat = m_DATFile.getSymbolByIndex(a).getFloat(arr, getCurrentInstanceDataPtr());
-                aFloat = b;
-            }
+            case EParOp_AssignInstance:
+                a = popVar();
+                b = popVar();
 
-            if (m_OnSymbolValueChanged)
-                m_OnSymbolValueChanged((unsigned)a, EParOp_AssignFloat);
-        }
-        break;
+                m_DATFile.getSymbolByIndex(a).instanceDataHandle = m_DATFile.getSymbolByIndex(b).instanceDataHandle;
+                m_DATFile.getSymbolByIndex(a).instanceDataClass = m_DATFile.getSymbolByIndex(b).instanceDataClass;
 
-        case EParOp_AssignInstance:
-            a = popVar();
-            b = popVar();
+                //sym.classOffset = sym2.classOffset;
+                //sym.instanceData = sym2.instanceData;
 
-            m_DATFile.getSymbolByIndex(a).instanceDataHandle = m_DATFile.getSymbolByIndex(b).instanceDataHandle;
-            m_DATFile.getSymbolByIndex(a).instanceDataClass = m_DATFile.getSymbolByIndex(b).instanceDataClass;
+                if (log) LogInfo() << "AssignInstance: a=" << a << ", b=" << b;
+                if (log) LogInfo() << " - [" << a << "] " << m_DATFile.getSymbolByIndex(a).name << ", addr: " << m_DATFile.getSymbolByIndex(a).instanceDataHandle.index;
 
-            //sym.classOffset = sym2.classOffset;
-            //sym.instanceData = sym2.instanceData;
+                if (m_OnSymbolValueChanged)
+                    m_OnSymbolValueChanged((unsigned)a, EParOp_AssignInstance);
+                break;
 
-            if (log) LogInfo() << "AssignInstance: a=" << a << ", b=" << b;
-            if (log) LogInfo() << " - [" << a << "] " << m_DATFile.getSymbolByIndex(a).name << ", addr: " << m_DATFile.getSymbolByIndex(a).instanceDataHandle.index;
-
-            if (m_OnSymbolValueChanged)
-                m_OnSymbolValueChanged((unsigned)a, EParOp_AssignInstance);
-            break;
-
-        case EParOp_Jump:
-            m_PC = op.address;
-            break;
-
-        case EParOp_JumpIf:
-            a = popDataValue();
-            if (!a)  // TODO: They seem to jump at 0, rather than 1
+            case EParOp_Jump:
                 m_PC = op.address;
+                break;
 
-            if (log) LogInfo() << " - " << a << ", " << oldPC << " -> " << m_PC;
-            break;
+            case EParOp_JumpIf:
+                a = popDataValue();
+                if (!a)  // TODO: They seem to jump at 0, rather than 1
+                    m_PC = op.address;
 
-        case EParOp_SetInstance:
-            m_CurrentInstance = op.symbol;
-            if (log) LogInfo() << " - [" << op.symbol << "] " << m_DATFile.getSymbolByIndex(op.symbol).name;
+                if (log) LogInfo() << " - " << a << ", " << oldPC << " -> " << m_PC;
+                break;
 
-            setCurrentInstance(op.symbol);
-            break;
-        case EParOp_PushArrayVar:
-            pushVar(STACKIFY(op.symbol), op.index);
-            if (log) LogInfo() << " - [" << op.symbol << "] " << m_DATFile.getSymbolByIndex(op.symbol).name << ", Index:" << (int)op.index;
-            break;
+            case EParOp_SetInstance:
+                m_CurrentInstance = op.symbol;
+                if (log) LogInfo() << " - [" << op.symbol << "] " << m_DATFile.getSymbolByIndex(op.symbol).name;
+
+                setCurrentInstance(op.symbol);
+                break;
+            case EParOp_PushArrayVar:
+                pushVar(STACKIFY(op.symbol), op.index);
+                if (log) LogInfo() << " - [" << op.symbol << "] " << m_DATFile.getSymbolByIndex(op.symbol).name << ", Index:" << (int)op.index;
+                break;
+        }
+
+        return true;
     }
 
-    return true;
-}
-
-PARStackOpCode DaedalusVM::getCurrentInstruction()
-{
-    PARStackOpCode op = m_DATFile.getStackOpCode(m_PC);
-    m_PC += op.opSize;
-
-    return op;
-}
-
-void DaedalusVM::setProgramCounter(uint32_t target)
-{
-    m_PC = target;
-}
-
-void DaedalusVM::registerExternalFunction(const std::string& symName, const std::function<void(DaedalusVM&)>& fn)
-{
-    if (m_DATFile.hasSymbolName(symName))
+    PARStackOpCode DaedalusVM::getCurrentInstruction()
     {
-        size_t s = m_DATFile.getSymbolIndexByName(symName);
-        m_ExternalsByIndex[s] = fn;
+        PARStackOpCode op = m_DATFile.getStackOpCode(m_PC);
+        m_PC += op.opSize;
+
+        return op;
     }
-}
 
-void DaedalusVM::pushInt(uint32_t value)
-{
-    m_Stack.push(value);
-    m_Stack.push(EParOp_PushInt);
-}
-
-void DaedalusVM::pushInt(int32_t value)
-{
-    pushInt(static_cast<uint32_t>(value));
-}
-
-template <typename T>
-T DaedalusVM::popDataValue()
-{
-    // Default behavior of the ZenGin is to pop a 0, if nothing is on the stack.
-    if (m_Stack.empty())
-        return static_cast<T>(0);
-
-    uint32_t tok = m_Stack.top();
-    m_Stack.pop();  // Pop token
-
-    uint32_t v = m_Stack.top();
-    m_Stack.pop();  // Pop value
-
-    uint32_t arrIdx = 0;
-    switch (tok)
+    void DaedalusVM::setProgramCounter(uint32_t target)
     {
-        case EParOp_PushInt:
-            return reinterpret_cast<T&>(v);  // reinterpret as float for T=float
+        m_PC = target;
+    }
 
-        case EParOp_PushVar:
-            arrIdx = m_Stack.top();
-            m_Stack.pop();  // Pop array index
-            return m_DATFile.getSymbolByIndex(v).getValue<T>(arrIdx, getCurrentInstanceDataPtr());
+    void DaedalusVM::registerExternalFunction(const std::string& symName, const std::function<void(DaedalusVM&)>& fn)
+    {
+        if (m_DATFile.hasSymbolName(symName))
+        {
+            size_t s = m_DATFile.getSymbolIndexByName(symName);
+            m_ExternalsByIndex[s] = fn;
+        }
+    }
 
-        default:
+    void DaedalusVM::pushInt(uint32_t value)
+    {
+        m_Stack.push(value);
+        m_Stack.push(EParOp_PushInt);
+    }
+
+    void DaedalusVM::pushInt(int32_t value)
+    {
+        pushInt(static_cast<uint32_t>(value));
+    }
+
+    template <typename T>
+    T DaedalusVM::popDataValue()
+    {
+        // Default behavior of the ZenGin is to pop a 0, if nothing is on the stack.
+        if (m_Stack.empty())
             return static_cast<T>(0);
+
+        uint32_t tok = m_Stack.top();
+        m_Stack.pop();  // Pop token
+
+        uint32_t v = m_Stack.top();
+        m_Stack.pop();  // Pop value
+
+        uint32_t arrIdx = 0;
+        switch (tok)
+        {
+            case EParOp_PushInt:
+                return reinterpret_cast<T&>(v);  // reinterpret as float for T=float
+
+            case EParOp_PushVar:
+                arrIdx = m_Stack.top();
+                m_Stack.pop();  // Pop array index
+                return m_DATFile.getSymbolByIndex(v).getValue<T>(arrIdx, getCurrentInstanceDataPtr());
+
+            default:
+                return static_cast<T>(0);
+        }
     }
-}
 
-void DaedalusVM::pushVar(size_t index, uint32_t arrIdx)
-{
-    m_Stack.push(arrIdx);
-    m_Stack.push(static_cast<int32_t>(index));
-    m_Stack.push(EParOp_PushVar);
-}
-
-uint32_t DaedalusVM::popVar(uint32_t& arrIdx)
-{
-    if (m_Stack.empty())
-        return 0;
-
-    // Stack:
-    //  - Token
-    //  - Var-Index
-    //  - Array-Index
-
-    uint32_t tok = static_cast<uint32_t>(m_Stack.top());
-    m_Stack.pop();
-
-    uint32_t v = static_cast<uint32_t>(m_Stack.top());
-    switch (tok)
+    void DaedalusVM::pushVar(size_t index, uint32_t arrIdx)
     {
-        case EParOp_PushVar:
-            m_Stack.pop();
-
-            arrIdx = static_cast<uint32_t>(m_Stack.top());
-            m_Stack.pop();
-            break;
-
-        case EParOp_PushInt:
-            // popVar and popInt don't seem to be right in some cases
-            m_Stack.pop();
-            arrIdx = 0;
-            break;
-
-        default:
-            return 0xFFFFFFFF;
+        m_Stack.push(arrIdx);
+        m_Stack.push(static_cast<int32_t>(index));
+        m_Stack.push(EParOp_PushVar);
     }
 
-    return v;
-}
-
-std::string DaedalusVM::popString(bool toUpper)
-{
-    uint32_t arr;
-    uint32_t idx = popVar(arr);
-
-    std::string s = m_DATFile.getSymbolByIndex(idx).getString(arr, getCurrentInstanceDataPtr());
-
-    if (toUpper)
-        std::transform(s.begin(), s.end(), s.begin(), ::toupper);
-
-    return s;
-}
-
-void DaedalusVM::setReturn(int32_t v)
-{
-    pushInt(v);
-}
-
-void DaedalusVM::setReturn(const std::string& v)
-{
-    pushString(v);
-}
-
-void DaedalusVM::setReturn(float f)
-{
-    pushInt(reinterpret_cast<int32_t&>(f));
-}
-
-void DaedalusVM::setReturnVar(int32_t v)
-{
-    pushVar(STACKIFY(v));
-}
-
-float DaedalusVM::popFloatValue()
-{
-    return popDataValue<float>();
-}
-
-void DaedalusVM::pushVar(const std::string& symName)
-{
-    size_t idx = m_DATFile.getSymbolIndexByName(symName);
-    pushVar(idx);
-}
-
-void DaedalusVM::pushString(const std::string& str)
-{
-    size_t symIdx = m_FakeStringSymbols.front();
-    Daedalus::PARSymbol& s = m_DATFile.getSymbolByIndex(symIdx);
-    m_FakeStringSymbols.push(m_FakeStringSymbols.front());
-    m_FakeStringSymbols.pop();
-
-    s.getString(0) = str;
-
-    pushVar(symIdx, 0);
-}
-
-void DaedalusVM::setInstance(const std::string& instSymbol, ZMemory::BigHandle h, EInstanceClass instanceClass)
-{
-    PARSymbol& s = m_DATFile.getSymbolByName(instSymbol);
-    s.instanceDataHandle = ZMemory::toBigHandle(h);
-    s.instanceDataClass = instanceClass;
-}
-
-void DaedalusVM::initializeInstance(ZMemory::BigHandle instance, size_t symIdx, EInstanceClass classIdx)
-{
-    pushState();
-
-    PARSymbol& s = m_DATFile.getSymbolByIndex(symIdx);
-
-    // Enter address into instance-symbol
-    s.instanceDataHandle = instance;
-    s.instanceDataClass = classIdx;
-
-    ZMemory::BigHandle currentInstanceHandle = m_CurrentInstanceHandle;
-    EInstanceClass currentInstanceClass = m_CurrentInstanceClass;
-
-    setCurrentInstance(symIdx);
-
-    PARSymbol selfCpy;
-    bool selfExists = m_DATFile.hasSymbolName("self");
-    // Particle and Menu VM do not have a self symbol
-    if (selfExists)
+    uint32_t DaedalusVM::popVar(uint32_t& arrIdx)
     {
-        selfCpy = m_DATFile.getSymbolByName("self");  // Copy of "self"-symbol
-        // Set self
-        setInstance("self", instance, classIdx);
+        if (m_Stack.empty())
+            return 0;
+
+        // Stack:
+        //  - Token
+        //  - Var-Index
+        //  - Array-Index
+
+        uint32_t tok = static_cast<uint32_t>(m_Stack.top());
+        m_Stack.pop();
+
+        uint32_t v = static_cast<uint32_t>(m_Stack.top());
+        switch (tok)
+        {
+            case EParOp_PushVar:
+                m_Stack.pop();
+
+                arrIdx = static_cast<uint32_t>(m_Stack.top());
+                m_Stack.pop();
+                break;
+
+            case EParOp_PushInt:
+                // popVar and popInt don't seem to be right in some cases
+                m_Stack.pop();
+                arrIdx = 0;
+                break;
+
+            default:
+                return 0xFFFFFFFF;
+        }
+
+        return v;
     }
 
-    // Place the assigning symbol into the instance
-    GEngineClasses::Instance* instData = m_GameState.getByClass(instance, classIdx);
-    instData->instanceSymbol = symIdx;
-
-    // Run script code to initialize the object
-    runFunctionBySymIndex(symIdx);
-
-    if (selfExists)
-        m_DATFile.getSymbolByName("self") = selfCpy;
-
-    // Reset state
-    //m_DATFile.getSymbolByName("SELF").instanceDataHandle = oldSelfInstance;
-    //m_DATFile.getSymbolByName("SELF").instanceDataClass = oldSelfClass;
-    m_CurrentInstanceHandle = currentInstanceHandle;
-    m_CurrentInstanceClass = currentInstanceClass;
-
-    popState();
-}
-
-void DaedalusVM::setCurrentInstance(size_t symIdx)
-{
-    m_CurrentInstance = symIdx;
-    m_CurrentInstanceHandle = m_DATFile.getSymbolByIndex(symIdx).instanceDataHandle;
-    m_CurrentInstanceClass = m_DATFile.getSymbolByIndex(symIdx).instanceDataClass;
-}
-
-void* DaedalusVM::getCurrentInstanceDataPtr()
-{
-    return m_GameState.getByClass(m_CurrentInstanceHandle, m_CurrentInstanceClass);
-}
-
-void DaedalusVM::pushState()
-{
-    return;
-    VMState s;
-    s.m_CurrentInstanceClass = m_CurrentInstanceClass;
-    s.m_CurrentInstanceHandle = m_CurrentInstanceHandle;
-    s.m_PC = m_PC;
-    s.m_Stack = m_Stack;
-    s.m_Self = m_DATFile.getSymbolByName("self");
-    // s.m_CallStack = m_CallStack;
-
-    m_PC = 0;
-    m_Stack = std::stack<uint32_t>();
-    m_CurrentInstanceHandle.invalidate();
-    m_CallStack.clear();
-
-    m_StateStack.push(s);
-}
-
-void DaedalusVM::popState()
-{
-    return;
-    m_PC = m_StateStack.top().m_PC;
-    m_Stack = m_StateStack.top().m_Stack;
-    // m_CallStack = m_StateStack.top().m_CallStack;
-
-    m_CurrentInstanceHandle = m_StateStack.top().m_CurrentInstanceHandle;
-    m_CurrentInstanceClass = m_StateStack.top().m_CurrentInstanceClass;
-
-    m_DATFile.getSymbolByName("self") = m_StateStack.top().m_Self;
-
-    m_StateStack.pop();
-}
-
-std::vector<std::string> DaedalusVM::getCallStack()
-{
-    std::vector<std::string> symbolNames;
-    for (auto& functionInfo : m_CallStack)
+    std::string DaedalusVM::popString(bool toUpper)
     {
-        symbolNames.push_back(nameFromFunctionInfo(functionInfo));
+        uint32_t arr;
+        uint32_t idx = popVar(arr);
+
+        std::string s = m_DATFile.getSymbolByIndex(idx).getString(arr, getCurrentInstanceDataPtr());
+
+        if (toUpper)
+            std::transform(s.begin(), s.end(), s.begin(), ::toupper);
+
+        return s;
     }
-    std::reverse(symbolNames.begin(), symbolNames.end());
-    return symbolNames;
-}
 
-void DaedalusVM::prepareRunFunction()
-{
-    // Clean the VM for this run
-    pushState();
-}
+    void DaedalusVM::setReturn(int32_t v)
+    {
+        pushInt(v);
+    }
 
-int32_t DaedalusVM::runFunctionBySymIndex(size_t symIdx, bool clearDataStack)
-{
-    if (clearDataStack)
+    void DaedalusVM::setReturn(const std::string& v)
+    {
+        pushString(v);
+    }
+
+    void DaedalusVM::setReturn(float f)
+    {
+        pushInt(reinterpret_cast<int32_t&>(f));
+    }
+
+    void DaedalusVM::setReturnVar(int32_t v)
+    {
+        pushVar(STACKIFY(v));
+    }
+
+    float DaedalusVM::popFloatValue()
+    {
+        return popDataValue<float>();
+    }
+
+    void DaedalusVM::pushVar(const std::string& symName)
+    {
+        size_t idx = m_DATFile.getSymbolIndexByName(symName);
+        pushVar(idx);
+    }
+
+    void DaedalusVM::pushString(const std::string& str)
+    {
+        size_t symIdx = m_FakeStringSymbols.front();
+        Daedalus::PARSymbol& s = m_DATFile.getSymbolByIndex(symIdx);
+        m_FakeStringSymbols.push(m_FakeStringSymbols.front());
+        m_FakeStringSymbols.pop();
+
+        s.getString(0) = str;
+
+        pushVar(symIdx, 0);
+    }
+
+    void DaedalusVM::setInstance(const std::string& instSymbol, ZMemory::BigHandle h, EInstanceClass instanceClass)
+    {
+        PARSymbol& s = m_DATFile.getSymbolByName(instSymbol);
+        s.instanceDataHandle = ZMemory::toBigHandle(h);
+        s.instanceDataClass = instanceClass;
+    }
+
+    void DaedalusVM::initializeInstance(ZMemory::BigHandle instance, size_t symIdx, EInstanceClass classIdx)
+    {
+        pushState();
+
+        PARSymbol& s = m_DATFile.getSymbolByIndex(symIdx);
+
+        // Enter address into instance-symbol
+        s.instanceDataHandle = instance;
+        s.instanceDataClass = classIdx;
+
+        ZMemory::BigHandle currentInstanceHandle = m_CurrentInstanceHandle;
+        EInstanceClass currentInstanceClass = m_CurrentInstanceClass;
+
+        setCurrentInstance(symIdx);
+
+        PARSymbol selfCpy;
+        bool selfExists = m_DATFile.hasSymbolName("self");
+        // Particle and Menu VM do not have a self symbol
+        if (selfExists)
+        {
+            selfCpy = m_DATFile.getSymbolByName("self");  // Copy of "self"-symbol
+            // Set self
+            setInstance("self", instance, classIdx);
+        }
+
+        // Place the assigning symbol into the instance
+        GEngineClasses::Instance* instData = m_GameState.getByClass(instance, classIdx);
+        instData->instanceSymbol = symIdx;
+
+        // Run script code to initialize the object
+        runFunctionBySymIndex(symIdx);
+
+        if (selfExists)
+            m_DATFile.getSymbolByName("self") = selfCpy;
+
+        // Reset state
+        //m_DATFile.getSymbolByName("SELF").instanceDataHandle = oldSelfInstance;
+        //m_DATFile.getSymbolByName("SELF").instanceDataClass = oldSelfClass;
+        m_CurrentInstanceHandle = currentInstanceHandle;
+        m_CurrentInstanceClass = currentInstanceClass;
+
+        popState();
+    }
+
+    void DaedalusVM::setCurrentInstance(size_t symIdx)
+    {
+        m_CurrentInstance = symIdx;
+        m_CurrentInstanceHandle = m_DATFile.getSymbolByIndex(symIdx).instanceDataHandle;
+        m_CurrentInstanceClass = m_DATFile.getSymbolByIndex(symIdx).instanceDataClass;
+    }
+
+    void* DaedalusVM::getCurrentInstanceDataPtr()
+    {
+        return m_GameState.getByClass(m_CurrentInstanceHandle, m_CurrentInstanceClass);
+    }
+
+    void DaedalusVM::pushState()
+    {
+        return;
+        VMState s;
+        s.m_CurrentInstanceClass = m_CurrentInstanceClass;
+        s.m_CurrentInstanceHandle = m_CurrentInstanceHandle;
+        s.m_PC = m_PC;
+        s.m_Stack = m_Stack;
+        s.m_Self = m_DATFile.getSymbolByName("self");
+        // s.m_CallStack = m_CallStack;
+
+        m_PC = 0;
         m_Stack = std::stack<uint32_t>();
+        m_CurrentInstanceHandle.invalidate();
+        m_CallStack.clear();
 
-    CallStackFrame frame(*this, symIdx, CallStackFrame::SymbolIndex);
-    auto& functionSymbol = getDATFile().getSymbolByIndex(symIdx);
-    auto& address = functionSymbol.address;
-    if (address == 0)
-        return -1;
-
-    // Place the call-operation
-    setProgramCounter(address);
-    // Execute the instructions
-    while (doStack())
-        ;
-
-    int32_t ret = 0;
-
-    if (functionSymbol.hasEParFlag(EParFlag_Return))
-    {
-        // Only pop if the VM didn't mess up
-        if (!isStackEmpty())
-            ret = popDataValue();  // TODO handle vars?
-        else
-        {
-            // too many warnings for now. Dialog conditions omit default value (0)
-            //LogWarn() << "DaedalusVM: function " << functionSymbol.name << " forgot to push a return value";
-        }
+        m_StateStack.push(s);
     }
 
-    if (!m_Stack.empty())
+    void DaedalusVM::popState()
     {
-        // too many warnings for now. need a Daedalus compiler that pops unused expressions
-        // LogWarn() << "DaedalusVM: stack not empty (" + std::to_string(m_Stack.size()) + ") after function " << functionSymbol.name;
+        return;
+        m_PC = m_StateStack.top().m_PC;
+        m_Stack = m_StateStack.top().m_Stack;
+        // m_CallStack = m_StateStack.top().m_CallStack;
+
+        m_CurrentInstanceHandle = m_StateStack.top().m_CurrentInstanceHandle;
+        m_CurrentInstanceClass = m_StateStack.top().m_CurrentInstanceClass;
+
+        m_DATFile.getSymbolByName("self") = m_StateStack.top().m_Self;
+
+        m_StateStack.pop();
     }
 
-    // Restore to previous VM-State
-    popState();
-    return ret;
-}
-
-std::string DaedalusVM::nameFromFunctionInfo(DaedalusVM::CallStackFrame::FunctionInfo functionInfo)
-{
-    switch (functionInfo.second)
+    std::vector<std::string> DaedalusVM::getCallStack()
     {
-        case CallStackFrame::SymbolIndex:
+        std::vector<std::string> symbolNames;
+        for (auto& functionInfo : m_CallStack)
         {
-            auto functionSymbolIndex = functionInfo.first;
-            return getDATFile().getSymbolByIndex(functionSymbolIndex).name;
+            symbolNames.push_back(nameFromFunctionInfo(functionInfo));
         }
-        case CallStackFrame::Address:
+        std::reverse(symbolNames.begin(), symbolNames.end());
+        return symbolNames;
+    }
+
+    void DaedalusVM::prepareRunFunction()
+    {
+        // Clean the VM for this run
+        pushState();
+    }
+
+    int32_t DaedalusVM::runFunctionBySymIndex(size_t symIdx, bool clearDataStack)
+    {
+        if (clearDataStack)
+            m_Stack = std::stack<uint32_t>();
+
+        CallStackFrame frame(*this, symIdx, CallStackFrame::SymbolIndex);
+        auto& functionSymbol = getDATFile().getSymbolByIndex(symIdx);
+        auto& address = functionSymbol.address;
+        if (address == 0)
+            return -1;
+
+        // Place the call-operation
+        setProgramCounter(address);
+        // Execute the instructions
+        while (doStack())
+            ;
+
+        int32_t ret = 0;
+
+        if (functionSymbol.hasEParFlag(EParFlag_Return))
         {
-            auto address = functionInfo.first;
-            auto functionSymbolIndex = getDATFile().getFunctionIndexByAddress(address);
-            if (functionSymbolIndex != static_cast<size_t>(-1))
+            // Only pop if the VM didn't mess up
+            if (!isStackEmpty())
+                ret = popDataValue();  // TODO handle vars?
+            else
+            {
+                // too many warnings for now. Dialog conditions omit default value (0)
+                //LogWarn() << "DaedalusVM: function " << functionSymbol.name << " forgot to push a return value";
+            }
+        }
+
+        if (!m_Stack.empty())
+        {
+            // too many warnings for now. need a Daedalus compiler that pops unused expressions
+            // LogWarn() << "DaedalusVM: stack not empty (" + std::to_string(m_Stack.size()) + ") after function " << functionSymbol.name;
+        }
+
+        // Restore to previous VM-State
+        popState();
+        return ret;
+    }
+
+    std::string DaedalusVM::nameFromFunctionInfo(DaedalusVM::CallStackFrame::FunctionInfo functionInfo)
+    {
+        switch (functionInfo.second)
+        {
+            case CallStackFrame::SymbolIndex:
+            {
+                auto functionSymbolIndex = functionInfo.first;
                 return getDATFile().getSymbolByIndex(functionSymbolIndex).name;
+            }
+            case CallStackFrame::Address:
+            {
+                auto address = functionInfo.first;
+                auto functionSymbolIndex = getDATFile().getFunctionIndexByAddress(address);
+                if (functionSymbolIndex != static_cast<size_t>(-1))
+                    return getDATFile().getSymbolByIndex(functionSymbolIndex).name;
+            }
         }
+        return "unknown function with address: " + std::to_string(functionInfo.first);
     }
-    return "unknown function with address: " + std::to_string(functionInfo.first);
-}
 
-DaedalusVM::CallStackFrame::CallStackFrame(DaedalusVM& vm, size_t addressOrIndex, AddressType addrType, bool xmlLogging)
-    : vm(vm)
-    , m_XmlLogging(xmlLogging)
-{
-    // entering function
-    vm.m_CallStack.emplace_back(addressOrIndex, addrType);
-
-    // m_XmlLogging = true;
-    if (m_XmlLogging)
+    DaedalusVM::CallStackFrame::CallStackFrame(DaedalusVM& vm, size_t addressOrIndex, AddressType addrType, bool xmlLogging)
+        : vm(vm)
+        , m_XmlLogging(xmlLogging)
     {
-        auto current = vm.nameFromFunctionInfo(vm.m_CallStack.back());
-        LogInfo() << indent(-1) << '<' << current << '>';
-        ;
-        /*
+        // entering function
+        vm.m_CallStack.emplace_back(addressOrIndex, addrType);
+
+        // m_XmlLogging = true;
+        if (m_XmlLogging)
+        {
+            auto current = vm.nameFromFunctionInfo(vm.m_CallStack.back());
+            LogInfo() << indent(-1) << '<' << current << '>';
+            ;
+            /*
         LogInfo() << indent() << "data stack size = " << vm.m_Stack.size();
          */
+        }
     }
-}
 
-DaedalusVM::CallStackFrame::~CallStackFrame()
-{
-    // leaving function
-    if (m_XmlLogging)
+    DaedalusVM::CallStackFrame::~CallStackFrame()
     {
-        auto current = vm.nameFromFunctionInfo(vm.m_CallStack.back());
-        /*
+        // leaving function
+        if (m_XmlLogging)
+        {
+            auto current = vm.nameFromFunctionInfo(vm.m_CallStack.back());
+            /*
         LogInfo() << indent() << "data stack size = " << vm.m_Stack.size();
         if (vm.m_Stack.size() > 3) // a var is the largest possible object (size=3). A function can only return one thing
         {
             LogInfo() << indent() << "suspicious increase of data stack in function " << current;
         }
         */
-        LogInfo() << indent(-1) << "</" << current << '>';
+            LogInfo() << indent(-1) << "</" << current << '>';
+        }
+        vm.m_CallStack.pop_back();
     }
-    vm.m_CallStack.pop_back();
-}
 
-std::string DaedalusVM::CallStackFrame::indent(int add)
-{
-    return std::string(vm.m_CallStack.size() + add, '\t');
-}
+    std::string DaedalusVM::CallStackFrame::indent(int add)
+    {
+        return std::string(vm.m_CallStack.size() + add, '\t');
+    }
+}  // namespace ZenLib

--- a/daedalus/DaedalusVM.h
+++ b/daedalus/DaedalusVM.h
@@ -8,238 +8,241 @@
 #include "DaedalusGameState.h"
 #include "DaedalusStdlib.h"
 
-namespace Daedalus
+namespace ZenLib
 {
-    class DaedalusVM
+    namespace Daedalus
     {
-    public:
-        DaedalusVM(const std::string& file, bool registerZenLibExternals = false);
-        DaedalusVM(const uint8_t* pDATFileData, size_t numBytes, bool registerZenLibExternals = false);
+        class DaedalusVM
+        {
+        public:
+            DaedalusVM(const std::string& file, bool registerZenLibExternals = false);
+            DaedalusVM(const uint8_t* pDATFileData, size_t numBytes, bool registerZenLibExternals = false);
 
-        /**
+            /**
          * @brief Performs a single instruction on the stack
          * @return True, if the program should continue, false if the end was reached
          */
-        bool doStack(bool verbose = false);
+            bool doStack(bool verbose = false);
 
-        /**
+            /**
          * @brief Pops an operation from the stack and modifies the program-counter
          */
-        PARStackOpCode getCurrentInstruction();
+            PARStackOpCode getCurrentInstruction();
 
-        /**
+            /**
          * Saves the state of the VM and prepares it for a call to runFunction.
          * You can push function arguments after this call.
          */
-        void prepareRunFunction();
+            void prepareRunFunction();
 
-        /**
+            /**
          * Runs a complete function with the arguments given by pushing onto the stack
          * Note: Must be prepared first, using prepareRunFunction.
          * @param symIdx Symbol-index of the function to call
          * @param clearDataStack indicates whether any leftovers from previous runs should be removed (default=true)
          * @return value returned by the function
          */
-        int32_t runFunctionBySymIndex(size_t symIdx, bool clearDataStack = true);
+            int32_t runFunctionBySymIndex(size_t symIdx, bool clearDataStack = true);
 
-        /**
+            /**
          * @brief sets the program counter
          */
-        void setProgramCounter(uint32_t target);
+            void setProgramCounter(uint32_t target);
 
-        /**
+            /**
          * @brief Clears the debug-callstack
          */
-        void clearCallStack() { m_CallStack.clear(); }
+            void clearCallStack() { m_CallStack.clear(); }
 
-        /**
+            /**
          * @brief Registers an External-Function to the VM
          */
-        void registerExternalFunction(const std::string& symName, const std::function<void(DaedalusVM&)>& fn);
+            void registerExternalFunction(const std::string& symName, const std::function<void(DaedalusVM&)>& fn);
 
-        /**
+            /**
          * @brief Pushes an int to the stack
          */
-        void pushInt(uint32_t value);
-        void pushInt(int32_t value);
-        void pushVar(size_t index, uint32_t arrIdx = 0);
-        void pushVar(const std::string& symName);
-        void pushString(const std::string& str);
+            void pushInt(uint32_t value);
+            void pushInt(int32_t value);
+            void pushVar(size_t index, uint32_t arrIdx = 0);
+            void pushVar(const std::string& symName);
+            void pushString(const std::string& str);
 
-        void setReturn(int32_t v);
-        void setReturn(const std::string& v);
-        void setReturn(float f);
-        void setReturnVar(int32_t v);
+            void setReturn(int32_t v);
+            void setReturn(const std::string& v);
+            void setReturn(float f);
+            void setReturnVar(int32_t v);
 
-        /**
+            /**
          * Pushes/Pops the whole state (PC and RetStack)
          */
-        void pushState();
-        void popState();
+            void pushState();
+            void popState();
 
-        /**
+            /**
          * @brief Pops an int from the stack
          */
-        template <typename T = int32_t>
-        T popDataValue();
-        float popFloatValue();
-        uint32_t popVar()
-        {
-            uint32_t arr;
-            return popVar(arr);
-        }
-        uint32_t popVar(uint32_t& arrIdx);
-        std::string popString(bool toUpper = false);
+            template <typename T = int32_t>
+            T popDataValue();
+            float popFloatValue();
+            uint32_t popVar()
+            {
+                uint32_t arr;
+                return popVar(arr);
+            }
+            uint32_t popVar(uint32_t& arrIdx);
+            std::string popString(bool toUpper = false);
 
-        /**
+            /**
          * @brief Sets the datapointer for the given instance-symbol
          */
-        void setInstance(const std::string& instSymbol, ZMemory::BigHandle h, EInstanceClass instanceClass);
-        void setCurrentInstance(size_t symIdx);
+            void setInstance(const std::string& instSymbol, ZMemory::BigHandle h, EInstanceClass instanceClass);
+            void setCurrentInstance(size_t symIdx);
 
-        /**
+            /**
           * @brief Initializes the given instance by script
           * @param instance Allocated instance of the right type
           * @param symIdx Script-Symbol of the instance to initialize
           */
-        void initializeInstance(ZMemory::BigHandle instance, size_t symIdx, EInstanceClass classIdx);
+            void initializeInstance(ZMemory::BigHandle instance, size_t symIdx, EInstanceClass classIdx);
 
-        /**
+            /**
          * @return all instances of the given class
          */
-        std::set<void*> getRegisteredInstancesOf(EInstanceClass classIdx) { return std::set<void*>(); }
+            std::set<void*> getRegisteredInstancesOf(EInstanceClass classIdx) { return std::set<void*>(); }
 
-        /**
+            /**
          * @return The currently registered instance-data pointer
          */
-        void* getCurrentInstanceDataPtr();
-        EInstanceClass getCurrentInstanceClass() { return m_CurrentInstanceClass; }
-        ZMemory::BigHandle getCurrentInstanceHandle() { return m_CurrentInstanceHandle; }
+            void* getCurrentInstanceDataPtr();
+            EInstanceClass getCurrentInstanceClass() { return m_CurrentInstanceClass; }
+            ZMemory::BigHandle getCurrentInstanceHandle() { return m_CurrentInstanceHandle; }
 
-        /**
+            /**
          * @brief Returns the DAT-File this VM runs on
          */
-        DATFile& getDATFile() { return m_DATFile; }
+            DATFile& getDATFile() { return m_DATFile; }
 
-        /**
+            /**
          * @brief returns the gamestate
          */
-        GameState::DaedalusGameState& getGameState() { return m_GameState; }
+            GameState::DaedalusGameState& getGameState() { return m_GameState; }
 
-        /**
+            /**
          * @return Whether the stack is currently empty
          */
-        bool isStackEmpty() { return m_Stack.empty(); }
+            bool isStackEmpty() { return m_Stack.empty(); }
 
-        /**
+            /**
          * @return Callstack in text-form
          */
-        std::vector<std::string> getCallStack();
+            std::vector<std::string> getCallStack();
 
-        /**
+            /**
          * @param callback Function called when a symbol changed its value
          */
-        void setOnSymbolValueChangedCallback(const std::function<void(unsigned, EParOp)>& callback)
-        {
-            m_OnSymbolValueChanged = callback;
-        }
+            void setOnSymbolValueChangedCallback(const std::function<void(unsigned, EParOp)>& callback)
+            {
+                m_OnSymbolValueChanged = callback;
+            }
 
-        /**
+            /**
          * Called right before an external call gets triggered. At this moment, parameters pushed to the stack
          * are still there
          * @param callback Function to call
          */
-        void setOnExternalCalledCallback(const std::function<void(unsigned)>& callback)
-        {
-            m_OnExternalCalled = callback;
-        }
+            void setOnExternalCalledCallback(const std::function<void(unsigned)>& callback)
+            {
+                m_OnExternalCalled = callback;
+            }
 
-    private:
-        /**
+        private:
+            /**
          * Initialize the VM from the currently loaded DAT-File
          */
-        void initializeFromLoadedDAT(bool registerZenLibExternals);
+            void initializeFromLoadedDAT(bool registerZenLibExternals);
 
-        /**
+            /**
          * pushing/popping FunctionInfo to the debug callstack using RAII concept
          * can be used to keep track of ALL function calls
          */
-        class CallStackFrame
-        {
-        public:
-            enum AddressType
+            class CallStackFrame
             {
-                Address,
-                SymbolIndex
+            public:
+                enum AddressType
+                {
+                    Address,
+                    SymbolIndex
+                };
+                using FunctionInfo = std::pair<size_t, CallStackFrame::AddressType>;
+
+                CallStackFrame(DaedalusVM& vm, size_t addressOrIndex, AddressType addrType, bool xmlLogging = false);
+                ~CallStackFrame();
+                std::string indent(int add = 0);
+
+            private:
+                DaedalusVM& vm;
+                bool m_XmlLogging;
             };
-            using FunctionInfo = std::pair<size_t, CallStackFrame::AddressType>;
 
-            CallStackFrame(DaedalusVM& vm, size_t addressOrIndex, AddressType addrType, bool xmlLogging = false);
-            ~CallStackFrame();
-            std::string indent(int add = 0);
+            DATFile m_DATFile;
 
-        private:
-            DaedalusVM& vm;
-            bool m_XmlLogging;
-        };
-
-        DATFile m_DATFile;
-
-        /**
+            /**
          * @brief Program counter
          */
-        size_t m_PC;
-
-        std::stack<uint32_t> m_Stack;
-        // contains pairs of FunctionInfo, Debugging only
-        std::vector<CallStackFrame::FunctionInfo> m_CallStack;
-
-        std::string nameFromFunctionInfo(CallStackFrame::FunctionInfo functionInfo);
-
-        /**
-         * @brief External functions mapped by their symbols index value
-         */
-        std::unordered_map<size_t, std::function<void(DaedalusVM&)>> m_ExternalsByIndex;
-
-        /**
-         * @brief instance set by SetInstance
-         */
-        size_t m_CurrentInstance;
-        ZMemory::BigHandle m_CurrentInstanceHandle;
-        EInstanceClass m_CurrentInstanceClass;
-
-        /**
-         * @brief Temporary string symbols for general purpose use
-         */
-        std::queue<size_t> m_FakeStringSymbols;
-
-        /**
-         * @brief Map of all created instances by their class index
-         */
-        std::map<EInstanceClass, std::set<void*>> m_RegisteredInstances;
-
-        /**
-         * @brief current state of the game
-         */
-        GameState::DaedalusGameState m_GameState;
-
-        struct VMState
-        {
-            ZMemory::BigHandle m_CurrentInstanceHandle;
-            EInstanceClass m_CurrentInstanceClass;
             size_t m_PC;
 
             std::stack<uint32_t> m_Stack;
-            std::vector<size_t> m_CallStack;
+            // contains pairs of FunctionInfo, Debugging only
+            std::vector<CallStackFrame::FunctionInfo> m_CallStack;
 
-            PARSymbol m_Self;
-        };
-        std::stack<VMState> m_StateStack;
+            std::string nameFromFunctionInfo(CallStackFrame::FunctionInfo functionInfo);
 
-        /**
+            /**
+         * @brief External functions mapped by their symbols index value
+         */
+            std::unordered_map<size_t, std::function<void(DaedalusVM&)>> m_ExternalsByIndex;
+
+            /**
+         * @brief instance set by SetInstance
+         */
+            size_t m_CurrentInstance;
+            ZMemory::BigHandle m_CurrentInstanceHandle;
+            EInstanceClass m_CurrentInstanceClass;
+
+            /**
+         * @brief Temporary string symbols for general purpose use
+         */
+            std::queue<size_t> m_FakeStringSymbols;
+
+            /**
+         * @brief Map of all created instances by their class index
+         */
+            std::map<EInstanceClass, std::set<void*>> m_RegisteredInstances;
+
+            /**
+         * @brief current state of the game
+         */
+            GameState::DaedalusGameState m_GameState;
+
+            struct VMState
+            {
+                ZMemory::BigHandle m_CurrentInstanceHandle;
+                EInstanceClass m_CurrentInstanceClass;
+                size_t m_PC;
+
+                std::stack<uint32_t> m_Stack;
+                std::vector<size_t> m_CallStack;
+
+                PARSymbol m_Self;
+            };
+            std::stack<VMState> m_StateStack;
+
+            /**
          * Callback for when a symbol-value changed/External got called
          */
-        std::function<void(unsigned, EParOp)> m_OnSymbolValueChanged;
-        std::function<void(unsigned)> m_OnExternalCalled;
-    };
-}  // namespace Daedalus
+            std::function<void(unsigned, EParOp)> m_OnSymbolValueChanged;
+            std::function<void(unsigned)> m_OnExternalCalled;
+        };
+    }  // namespace Daedalus
+}  // namespace ZenLib

--- a/samples/content_load.cpp
+++ b/samples/content_load.cpp
@@ -3,6 +3,8 @@
 #include <utils/export.h>
 #include <iostream>
 
+using namespace ZenLib;
+
 /**
  * ----------------------------- main ------------------------------
  */

--- a/samples/dat_load.cpp
+++ b/samples/dat_load.cpp
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <algorithm>
 
+using namespace ZenLib;
 using namespace Daedalus;
 
 bool listFunctions = false;

--- a/samples/ou_load.cpp
+++ b/samples/ou_load.cpp
@@ -3,6 +3,8 @@
 #include <iostream>
 #include <utils/logger.h>
 
+using namespace ZenLib;
+
 /**
  * ----------------------------- main ------------------------------
  */

--- a/samples/vdf_unpack.cpp
+++ b/samples/vdf_unpack.cpp
@@ -1,6 +1,8 @@
 #include <iostream>
 #include <vdfs/fileIndex.h>
 
+using namespace ZenLib;
+
 /**
  * Utility function to write data to disk
  */

--- a/samples/zen_load.cpp
+++ b/samples/zen_load.cpp
@@ -4,6 +4,8 @@
 #include <zenload/zCMesh.h>
 #include <zenload/zenParser.h>
 
+using namespace ZenLib;
+
 /**
  * Recursive function to list some data about the zen-file
  */

--- a/utils/alignment.h
+++ b/utils/alignment.h
@@ -6,31 +6,34 @@
 #include <emscripten.h>
 #endif
 
-namespace Utils
+namespace ZenLib
 {
+    namespace Utils
+    {
 #if EMSCRIPTEN
-    typedef emscripten_align1_int unaligned_int32;
-    typedef emscripten_align1_short unaligned_int16;
-    typedef emscripten_align1_float unaligned_float;
+        typedef emscripten_align1_int unaligned_int32;
+        typedef emscripten_align1_short unaligned_int16;
+        typedef emscripten_align1_float unaligned_float;
 #else
-    typedef int32_t unaligned_int32;
-    typedef int16_t unaligned_int16;
-    typedef float unaligned_float;
+        typedef int32_t unaligned_int32;
+        typedef int16_t unaligned_int16;
+        typedef float unaligned_float;
 #endif
-    /**
+        /**
 	 * @brief performs an unaligned memory-access
 	 */
-    template <typename T>
-    static void getUnaligned(T* dst, const void* src)
-    {
-        memcpy(dst, src, sizeof(T));
-    }
+        template <typename T>
+        static void getUnaligned(T* dst, const void* src)
+        {
+            memcpy(dst, src, sizeof(T));
+        }
 
-    template <typename T>
-    void unalignedRead(T& dst, const void*& src)
-    {
-        getUnaligned(&dst, src);
-        uint8_t*& ptr = ((uint8_t*&)src);
-        ptr += sizeof(T);
-    }
-}  // namespace Utils
+        template <typename T>
+        void unalignedRead(T& dst, const void*& src)
+        {
+            getUnaligned(&dst, src);
+            uint8_t*& ptr = ((uint8_t*&)src);
+            ptr += sizeof(T);
+        }
+    }  // namespace Utils
+}  // namespace ZenLib

--- a/utils/export.h
+++ b/utils/export.h
@@ -1,85 +1,88 @@
 #pragma once
 #include <zenload/zTypes.h>
 
-namespace Utils
+namespace ZenLib
 {
-    /**
+    namespace Utils
+    {
+        /**
      * Exports the given packed-mesh structure into a wavefront-OBJ-file
      * @param mesh Mesh to export
      * @param file Target OBJ-File
      * @param name Name of the object to export
      * @return Whether the export succeeded
      */
-    inline bool exportPackedMeshToObj(ZenLoad::PackedMesh& mesh, const std::string& file, const std::string& name = "Object")
-    {
-        FILE* f = fopen(file.c_str(), "w");
-
-        if (!f)
-            return false;
-
-        fputs("# File exported by ZenLib\n", f);
-        fputs(("o " + name + "\n").c_str(), f);
-
-        // Write positions
-        for (auto& v : mesh.vertices)
+        inline bool exportPackedMeshToObj(ZenLoad::PackedMesh& mesh, const std::string& file, const std::string& name = "Object")
         {
-            fputs(("v " + std::to_string(v.Position.x) + " " + std::to_string(v.Position.y) + " " + std::to_string(v.Position.z) + "\n").c_str(), f);
-        }
+            FILE* f = fopen(file.c_str(), "w");
 
-        // Write texture coords
-        for (auto& v : mesh.vertices)
-        {
-            fputs(("v " + std::to_string(v.TexCoord.x) + " " + std::to_string(v.TexCoord.y) + "\n").c_str(), f);
-        }
+            if (!f)
+                return false;
 
-        // Write normals
-        for (auto& v : mesh.vertices)
-        {
-            fputs(("v " + std::to_string(v.Normal.x) + " " + std::to_string(v.Normal.y) + " " + std::to_string(v.Normal.z) + "\n").c_str(), f);
-        }
+            fputs("# File exported by ZenLib\n", f);
+            fputs(("o " + name + "\n").c_str(), f);
 
-        fputs("s off\n", f);
-
-        // Write faces
-        for (auto& s : mesh.subMeshes)
-        {
-            fputs(("g " + s.material.matName + "\n").c_str(), f);
-            fputs(("usemtl " + s.material.matName + "\n").c_str(), f);
-
-            for (size_t i = 0; i < s.indices.size(); i += 3)
+            // Write positions
+            for (auto& v : mesh.vertices)
             {
-                uint32_t idx[] = {s.indices[i], s.indices[i + 1], s.indices[i + 2]};
-                std::string f1 = std::to_string(idx[0] + 1) + "/" + std::to_string(idx[0] + 1) + "/" + std::to_string(idx[0] + 1);
-                std::string f2 = std::to_string(idx[1] + 1) + "/" + std::to_string(idx[1] + 1) + "/" + std::to_string(idx[1] + 1);
-                std::string f3 = std::to_string(idx[2] + 1) + "/" + std::to_string(idx[2] + 1) + "/" + std::to_string(idx[2] + 1);
-
-                fputs(("f " + f1 + " " + f2 + " " + f3 + "\n").c_str(), f);
+                fputs(("v " + std::to_string(v.Position.x) + " " + std::to_string(v.Position.y) + " " + std::to_string(v.Position.z) + "\n").c_str(), f);
             }
+
+            // Write texture coords
+            for (auto& v : mesh.vertices)
+            {
+                fputs(("v " + std::to_string(v.TexCoord.x) + " " + std::to_string(v.TexCoord.y) + "\n").c_str(), f);
+            }
+
+            // Write normals
+            for (auto& v : mesh.vertices)
+            {
+                fputs(("v " + std::to_string(v.Normal.x) + " " + std::to_string(v.Normal.y) + " " + std::to_string(v.Normal.z) + "\n").c_str(), f);
+            }
+
+            fputs("s off\n", f);
+
+            // Write faces
+            for (auto& s : mesh.subMeshes)
+            {
+                fputs(("g " + s.material.matName + "\n").c_str(), f);
+                fputs(("usemtl " + s.material.matName + "\n").c_str(), f);
+
+                for (size_t i = 0; i < s.indices.size(); i += 3)
+                {
+                    uint32_t idx[] = {s.indices[i], s.indices[i + 1], s.indices[i + 2]};
+                    std::string f1 = std::to_string(idx[0] + 1) + "/" + std::to_string(idx[0] + 1) + "/" + std::to_string(idx[0] + 1);
+                    std::string f2 = std::to_string(idx[1] + 1) + "/" + std::to_string(idx[1] + 1) + "/" + std::to_string(idx[1] + 1);
+                    std::string f3 = std::to_string(idx[2] + 1) + "/" + std::to_string(idx[2] + 1) + "/" + std::to_string(idx[2] + 1);
+
+                    fputs(("f " + f1 + " " + f2 + " " + f3 + "\n").c_str(), f);
+                }
+            }
+
+            // Write mtl
+            FILE* mf = fopen((file + ".mtl").c_str(), "w");
+
+            if (!mf)
+                return false;
+
+            for (auto& s : mesh.subMeshes)
+            {
+                fputs(("newmtl " + s.material.matName + "\n").c_str(), mf);
+
+                fputs(("map_Kd " + s.material.texture + "\n").c_str(), mf);
+
+                ZMath::float4 color;
+                color.fromABGR8(s.material.color);
+
+                fputs(("Kd " + std::to_string(color.x) + " " + std::to_string(color.y) + " " + std::to_string(color.z) + "\n").c_str(), mf);
+                fputs(("Ka " + std::to_string(color.x) + " " + std::to_string(color.y) + " " + std::to_string(color.z) + "\n").c_str(), mf);
+
+                fputs("\n", mf);
+            }
+
+            fclose(mf);
+
+            return true;
         }
-
-        // Write mtl
-        FILE* mf = fopen((file + ".mtl").c_str(), "w");
-
-        if (!mf)
-            return false;
-
-        for (auto& s : mesh.subMeshes)
-        {
-            fputs(("newmtl " + s.material.matName + "\n").c_str(), mf);
-
-            fputs(("map_Kd " + s.material.texture + "\n").c_str(), mf);
-
-            ZMath::float4 color;
-            color.fromABGR8(s.material.color);
-
-            fputs(("Kd " + std::to_string(color.x) + " " + std::to_string(color.y) + " " + std::to_string(color.z) + "\n").c_str(), mf);
-            fputs(("Ka " + std::to_string(color.x) + " " + std::to_string(color.y) + " " + std::to_string(color.z) + "\n").c_str(), mf);
-
-            fputs("\n", mf);
-        }
-
-        fclose(mf);
-
-        return true;
-    }
-}  // namespace Utils
+    }  // namespace Utils
+}  // namespace ZenLib

--- a/utils/freeList.h
+++ b/utils/freeList.h
@@ -1,86 +1,90 @@
 #pragma once
 #include <stddef.h>
 
-namespace ZMemory
+namespace ZenLib
 {
-    /**
+    namespace ZMemory
+    {
+        /**
  * List supporting finding, obtaining and returning free list elements in O(1) time
  */
-    template <typename T>
-    class FreeList
-    {
-    public:
-        FreeList(T* start, T* end, size_t elementSize, size_t numElements, size_t alignment, size_t offset)
+        template <typename T>
+        class FreeList
         {
-            // TODO: Implement alignment and offset
-
-            union {
-                T* as_T;
-                char* as_char;
-                FreeList* as_self;
-            };
-
-            // Assign start of the list to the union
-            as_T = start;
-
-            // First element is also the first free one
-            m_Next = as_self;
-            as_char += elementSize;
-
-            // initialize the free list - make every m_next of each element point to the next element in the list
-            FreeList* runner = m_Next;
-            for (size_t i = 1; i < numElements; ++i)
+        public:
+            FreeList(T* start, T* end, size_t elementSize, size_t numElements, size_t alignment, size_t offset)
             {
-                runner->m_Next = as_self;
-                runner = as_self;
+                // TODO: Implement alignment and offset
+
+                union
+                {
+                    T* as_T;
+                    char* as_char;
+                    FreeList* as_self;
+                };
+
+                // Assign start of the list to the union
+                as_T = start;
+
+                // First element is also the first free one
+                m_Next = as_self;
                 as_char += elementSize;
+
+                // initialize the free list - make every m_next of each element point to the next element in the list
+                FreeList* runner = m_Next;
+                for (size_t i = 1; i < numElements; ++i)
+                {
+                    runner->m_Next = as_self;
+                    runner = as_self;
+                    as_char += elementSize;
+                }
+
+                // Mark tail of the list
+                runner->m_Next = nullptr;
+
+                // All free
+                m_NumObtainedElements = 0;
             }
 
-            // Mark tail of the list
-            runner->m_Next = nullptr;
-
-            // All free
-            m_NumObtainedElements = 0;
-        }
-
-        /**
+            /**
          * Returns the next free element from the list
          */
-        inline T* obtainElement()
-        {
-            if (!m_Next)
-                return nullptr;  // Out of space
+            inline T* obtainElement()
+            {
+                if (!m_Next)
+                    return nullptr;  // Out of space
 
-            FreeList* head = m_Next;
-            m_Next = head->m_Next;
+                FreeList* head = m_Next;
+                m_Next = head->m_Next;
 
-            m_NumObtainedElements++;
+                m_NumObtainedElements++;
 
-            return reinterpret_cast<T*>(head);
-        }
+                return reinterpret_cast<T*>(head);
+            }
 
-        /**
+            /**
          * Marks the given list-element as free again
          */
-        inline void returnElement(T* ptr)
-        {
-            FreeList* newHead = reinterpret_cast<FreeList*>(ptr);
-            newHead->m_Next = m_Next;
-            m_Next = newHead;
+            inline void returnElement(T* ptr)
+            {
+                FreeList* newHead = reinterpret_cast<FreeList*>(ptr);
+                newHead->m_Next = m_Next;
+                m_Next = newHead;
 
-            m_NumObtainedElements--;
-        }
+                m_NumObtainedElements--;
+            }
 
-        /**
+            /**
          * Returns how many elements where obtained until now
          */
-        inline size_t getNumObtainedElements()
-        {
-            return m_NumObtainedElements;
-        }
+            inline size_t getNumObtainedElements()
+            {
+                return m_NumObtainedElements;
+            }
 
-    private:
-        FreeList* m_Next;
-        size_t m_NumObtainedElements;
-    };
-}  // namespace ZMemory
+        private:
+            FreeList* m_Next;
+            size_t m_NumObtainedElements;
+        };
+    }  // namespace ZMemory
+}  // namespace ZenLib

--- a/utils/mathlib.cpp
+++ b/utils/mathlib.cpp
@@ -1,34 +1,37 @@
 #include "mathlib.h"
 
-std::ostream& ZMath::operator<<(std::ostream& out, ZMath::t_float2& v)
+namespace ZenLib
 {
-    out << "[" + std::to_string(v.x) + ", " + std::to_string(v.y) + "]";
-    return out;
-}
-
-std::ostream& ZMath::operator<<(std::ostream& out, ZMath::t_float3& v)
-{
-    out << "[" + std::to_string(v.x) + ", " + std::to_string(v.y) + ", " + std::to_string(v.z) + "]";
-    return out;
-}
-
-std::ostream& ZMath::operator<<(std::ostream& out, ZMath::t_float4& v)
-{
-    out << "[" + std::to_string(v.x) + ", " + std::to_string(v.y) + ", " + std::to_string(v.z) + ", " + std::to_string(v.w) + "]";
-    return out;
-}
-
-std::ostream& ZMath::operator<<(std::ostream& out, ZMath::Matrix& m)
-{
-    out << "[";
-    for (size_t i = 0; i < 16; i++)
+    std::ostream& ZMath::operator<<(std::ostream& out, ZMath::t_float2& v)
     {
-        out << std::to_string(m.mv[i]);
-
-        // Only add "," when not at the last value
-        if (i != 15)
-            out << ", ";
+        out << "[" + std::to_string(v.x) + ", " + std::to_string(v.y) + "]";
+        return out;
     }
-    out << "]";
-    return out;
-}
+
+    std::ostream& ZMath::operator<<(std::ostream& out, ZMath::t_float3& v)
+    {
+        out << "[" + std::to_string(v.x) + ", " + std::to_string(v.y) + ", " + std::to_string(v.z) + "]";
+        return out;
+    }
+
+    std::ostream& ZMath::operator<<(std::ostream& out, ZMath::t_float4& v)
+    {
+        out << "[" + std::to_string(v.x) + ", " + std::to_string(v.y) + ", " + std::to_string(v.z) + ", " + std::to_string(v.w) + "]";
+        return out;
+    }
+
+    std::ostream& ZMath::operator<<(std::ostream& out, ZMath::Matrix& m)
+    {
+        out << "[";
+        for (size_t i = 0; i < 16; i++)
+        {
+            out << std::to_string(m.mv[i]);
+
+            // Only add "," when not at the last value
+            if (i != 15)
+                out << ", ";
+        }
+        out << "]";
+        return out;
+    }
+}  // namespace ZenLib

--- a/utils/mathlib.h
+++ b/utils/mathlib.h
@@ -4,356 +4,363 @@
 
 #include <string.h>
 
-namespace ZMath
+namespace ZenLib
 {
-    static const float Pi = 3.14159265359f;
-
-    constexpr int64_t ipow(int64_t base, int exp, int64_t result = 1)
+    namespace ZMath
     {
-        return exp < 1 ? result : ipow(base * base, exp / 2, (exp % 2) ? result * base : result);
-    }
+        static const float Pi = 3.14159265359f;
 
-    struct t_float2
-    {
-        t_float2() {}
-        t_float2(float x, float y)
+        constexpr int64_t ipow(int64_t base, int exp, int64_t result = 1)
         {
-            this->x = x;
-            this->y = y;
+            return exp < 1 ? result : ipow(base * base, exp / 2, (exp % 2) ? result * base : result);
         }
 
-        union {
-            struct
+        struct t_float2
+        {
+            t_float2() {}
+            t_float2(float x, float y)
             {
-                float x;
-                float y;
+                this->x = x;
+                this->y = y;
+            }
+
+            union
+            {
+                struct
+                {
+                    float x;
+                    float y;
+                };
+
+                float v[2];
             };
 
-            float v[2];
+            std::string toString() const
+            {
+                std::string out;
+                out = "[" + std::to_string(x) + ", " + std::to_string(y) + "]";
+
+                return out;
+            }
+
+            friend std::ostream& operator<<(std::ostream& out, t_float2& v);
         };
 
-        std::string toString() const
+        std::ostream& operator<<(std::ostream& out, t_float2& v);
+
+        struct t_float3
         {
-            std::string out;
-            out = "[" + std::to_string(x) + ", " + std::to_string(y) + "]";
-
-            return out;
-        }
-
-        friend std::ostream& operator<<(std::ostream& out, t_float2& v);
-    };
-
-    std::ostream& operator<<(std::ostream& out, t_float2& v);
-
-    struct t_float3
-    {
-        t_float3() {}
-        t_float3(float x, float y, float z)
-        {
-            this->x = x;
-            this->y = y;
-            this->z = z;
-        }
-
-        union {
-            struct
+            t_float3() {}
+            t_float3(float x, float y, float z)
             {
-                float x;
-                float y;
-                float z;
+                this->x = x;
+                this->y = y;
+                this->z = z;
+            }
+
+            union
+            {
+                struct
+                {
+                    float x;
+                    float y;
+                    float z;
+                };
+
+                float v[3];
             };
 
-            float v[3];
+            std::string toString() const
+            {
+                std::string out;
+                out = "[" + std::to_string(x) + ", " + std::to_string(y) + ", " + std::to_string(z) + "]";
+
+                return out;
+            }
+
+            friend std::ostream& operator<<(std::ostream& out, t_float3& v);
         };
 
-        std::string toString() const
+        std::ostream& operator<<(std::ostream& out, t_float3& v);
+
+        struct t_float4
         {
-            std::string out;
-            out = "[" + std::to_string(x) + ", " + std::to_string(y) + ", " + std::to_string(z) + "]";
-
-            return out;
-        }
-
-        friend std::ostream& operator<<(std::ostream& out, t_float3& v);
-    };
-
-    std::ostream& operator<<(std::ostream& out, t_float3& v);
-
-    struct t_float4
-    {
-        t_float4() {}
-        t_float4(float x, float y, float z, float w)
-        {
-            this->x = x;
-            this->y = y;
-            this->z = z;
-            this->w = w;
-        }
-
-        union {
-            struct
+            t_float4() {}
+            t_float4(float x, float y, float z, float w)
             {
-                float x;
-                float y;
-                float z;
-                float w;
+                this->x = x;
+                this->y = y;
+                this->z = z;
+                this->w = w;
+            }
+
+            union
+            {
+                struct
+                {
+                    float x;
+                    float y;
+                    float z;
+                    float w;
+                };
+
+                float v[4];
             };
 
-            float v[4];
-        };
-
-        /**
+            /**
 		 * @brief Converts the given ABGR8-Color to float4
 		 */
-        void fromABGR8(uint32_t argb)
-        {
-            unsigned char a = argb >> 24;
-            unsigned char b = (argb >> 16) & 0xFF;
-            unsigned char g = (argb >> 8) & 0xFF;
-            unsigned char r = argb & 0xFF;
+            void fromABGR8(uint32_t argb)
+            {
+                unsigned char a = argb >> 24;
+                unsigned char b = (argb >> 16) & 0xFF;
+                unsigned char g = (argb >> 8) & 0xFF;
+                unsigned char r = argb & 0xFF;
 
-            x = r / 255.0f;
-            y = g / 255.0f;
-            z = b / 255.0f;
-            w = a / 255.0f;
-        }
+                x = r / 255.0f;
+                y = g / 255.0f;
+                z = b / 255.0f;
+                w = a / 255.0f;
+            }
 
-        /**
+            /**
 		* @brief Converts the stored color to ARGB8
 		*/
-        uint32_t toABGR8()
-        {
-            unsigned char b[] = {static_cast<unsigned char>(w * 255.0f),
-                                 static_cast<unsigned char>(z * 255.0f),
-                                 static_cast<unsigned char>(y * 255.0f),
-                                 static_cast<unsigned char>(x * 255.0f)};
-
-            return *reinterpret_cast<uint32_t*>(b);
-        }
-
-        std::string toString() const
-        {
-            std::string out;
-            out = "[" + std::to_string(x) + ", " + std::to_string(y) + ", " + std::to_string(z) + ", " + std::to_string(w) + "]";
-
-            return out;
-        }
-
-        friend std::ostream& operator<<(std::ostream& out, t_float4& v);
-    };
-
-    std::ostream& operator<<(std::ostream& out, t_float4& v);
-
-    template <typename T, typename... S>
-    struct t_vector : public T
-    {
-        t_vector(S... x)
-            : T(x...)
-        {
-        }
-        t_vector() {}
-
-        t_vector(const T& v)
-        {
-            T::_glmt_vector = v._glmt_vector;
-        }
-
-        // Comparision operators
-        bool operator==(const t_vector<T, S...>& v) const
-        {
-            return memcmp(T::v, v.v, sizeof(v.v)) == 0;
-        }
-
-        bool operator!=(const t_vector<T, S...>& v) const
-        {
-            return !(*this == v);
-        }
-
-        t_vector<T, S...> operator*(float s) const
-        {
-            t_vector<T, S...> rs;
-
-            for (size_t i = 0; i < sizeof(T) / sizeof(float); i++)  // Fixme: Doesn't work for double-vectors! Also, not very nice solution.
+            uint32_t toABGR8()
             {
-                rs.v[i] = T::v[i] * s;
+                unsigned char b[] = {static_cast<unsigned char>(w * 255.0f),
+                                     static_cast<unsigned char>(z * 255.0f),
+                                     static_cast<unsigned char>(y * 255.0f),
+                                     static_cast<unsigned char>(x * 255.0f)};
+
+                return *reinterpret_cast<uint32_t*>(b);
             }
 
-            return rs;
-        }
-
-        t_vector<T, S...>& operator*=(float s)
-        {
-            *this = (*this) * s;
-            return *this;
-        }
-    };
-
-    typedef t_vector<t_float2, float, float> float2;
-    typedef t_vector<t_float3, float, float, float> float3;
-    typedef t_vector<t_float4, float, float, float, float> float4;
-
-    //------------------------------------------------------------------------------
-    // 4x4 Matrix (assumes right-handed cooordinates)
-    struct Matrix
-    {
-        Matrix()
-            : v{float4(), float4(), float4(), float4()}
-        {
-        }
-
-        Matrix(float* pm)
-            : v{float4(), float4(), float4(), float4()}
-        {
-            memcpy(m, pm, sizeof(m));
-        }
-
-        Matrix(float m00, float m01, float m02, float m03,
-               float m10, float m11, float m12, float m13,
-               float m20, float m21, float m22, float m23,
-               float m30, float m31, float m32, float m33)
-            : v{float4(), float4(), float4(), float4()}
-        {
-            m[0][0] = m00;
-            m[0][1] = m01;
-            m[0][2] = m02;
-            m[0][3] = m03;
-
-            m[1][0] = m10;
-            m[1][1] = m11;
-            m[1][2] = m12;
-            m[1][3] = m13;
-
-            m[2][0] = m20;
-            m[2][1] = m21;
-            m[2][2] = m22;
-            m[2][3] = m23;
-
-            m[3][0] = m30;
-            m[3][1] = m31;
-            m[3][2] = m32;
-            m[3][3] = m33;
-        }
-
-        void Transpose()
-        {
-            Matrix mm = *this;
-
-            m[0][0] = mm.m[0][0];
-            m[0][1] = mm.m[1][0];
-            m[0][2] = mm.m[2][0];
-            m[0][3] = mm.m[3][0];
-            m[1][0] = mm.m[0][1];
-            m[1][1] = mm.m[1][1];
-            m[1][2] = mm.m[2][1];
-            m[1][3] = mm.m[3][1];
-            m[2][0] = mm.m[0][2];
-            m[2][1] = mm.m[1][2];
-            m[2][2] = mm.m[2][2];
-            m[2][3] = mm.m[3][2];
-            m[3][0] = mm.m[0][3];
-            m[3][1] = mm.m[1][3];
-            m[3][2] = mm.m[2][3];
-            m[3][3] = mm.m[3][3];
-        }
-
-        // Properties
-        float3 Up() const { return float3(_21, _22, _23); }
-        void Up(const float3& vec)
-        {
-            _21 = vec.x;
-            _22 = vec.y;
-            _23 = vec.z;
-        }
-
-        float3 Down() const { return float3(-_21, -_22, -_23); }
-        void Down(const float3& vec)
-        {
-            _21 = -vec.x;
-            _22 = -vec.y;
-            _23 = -vec.z;
-        }
-
-        float3 Right() const { return float3(_11, _12, _13); }
-        void Right(const float3& vec)
-        {
-            _11 = vec.x;
-            _12 = vec.y;
-            _13 = vec.z;
-        }
-
-        float3 Left() const { return float3(-_11, -_12, -_13); }
-        void Left(const float3& vec)
-        {
-            _11 = -vec.x;
-            _12 = -vec.y;
-            _13 = -vec.z;
-        }
-
-        float3 Forward() const { return float3(-_31, -_32, -_33); }
-        void Forward(const float3& vec)
-        {
-            _31 = -vec.x;
-            _32 = -vec.y;
-            _33 = -vec.z;
-        }
-
-        float3 Backward() const { return float3(_31, _32, _33); }
-        void Backward(const float3& vec)
-        {
-            _31 = vec.x;
-            _32 = vec.y;
-            _33 = vec.z;
-        }
-
-        float3 Translation() const { return float3(_41, _42, _43); }
-        float3 TranslationT() const { return float3(_14, _24, _34); }
-        void Translation(const float3& vec)
-        {
-            _41 = vec.x;
-            _42 = vec.y;
-            _43 = vec.z;
-        }
-
-        static Matrix CreateIdentity()
-        {
-            return Matrix(1, 0, 0, 0,
-                          0, 1, 0, 0,
-                          0, 0, 1, 0,
-                          0, 0, 0, 1);
-        }
-
-        union {
-            struct
+            std::string toString() const
             {
-                float _11, _12, _13, _14;
-                float _21, _22, _23, _24;
-                float _31, _32, _33, _34;
-                float _41, _42, _43, _44;
-            };
-            float m[4][4];
-            float4 v[4];
-            float mv[16];
+                std::string out;
+                out = "[" + std::to_string(x) + ", " + std::to_string(y) + ", " + std::to_string(z) + ", " + std::to_string(w) + "]";
+
+                return out;
+            }
+
+            friend std::ostream& operator<<(std::ostream& out, t_float4& v);
         };
 
-        std::string toString()
+        std::ostream& operator<<(std::ostream& out, t_float4& v);
+
+        template <typename T, typename... S>
+        struct t_vector : public T
         {
-            std::string out;
-            out = "[";
-            for (size_t i = 0; i < 16; i++)
+            t_vector(S... x)
+                : T(x...)
             {
-                out += std::to_string(mv[i]);
-
-                // Only add "," when not at the last value
-                if (i != 15)
-                    out += ", ";
             }
-            out += "]";
+            t_vector() {}
 
-            return out;
-        }
+            t_vector(const T& v)
+            {
+                T::_glmt_vector = v._glmt_vector;
+            }
 
-        friend std::ostream& operator<<(std::ostream& out, Matrix& v);
-    };
+            // Comparision operators
+            bool operator==(const t_vector<T, S...>& v) const
+            {
+                return memcmp(T::v, v.v, sizeof(v.v)) == 0;
+            }
 
-    std::ostream& operator<<(std::ostream& out, Matrix& m);
-}  // namespace ZMath
+            bool operator!=(const t_vector<T, S...>& v) const
+            {
+                return !(*this == v);
+            }
+
+            t_vector<T, S...> operator*(float s) const
+            {
+                t_vector<T, S...> rs;
+
+                for (size_t i = 0; i < sizeof(T) / sizeof(float); i++)  // Fixme: Doesn't work for double-vectors! Also, not very nice solution.
+                {
+                    rs.v[i] = T::v[i] * s;
+                }
+
+                return rs;
+            }
+
+            t_vector<T, S...>& operator*=(float s)
+            {
+                *this = (*this) * s;
+                return *this;
+            }
+        };
+
+        typedef t_vector<t_float2, float, float> float2;
+        typedef t_vector<t_float3, float, float, float> float3;
+        typedef t_vector<t_float4, float, float, float, float> float4;
+
+        //------------------------------------------------------------------------------
+        // 4x4 Matrix (assumes right-handed cooordinates)
+        struct Matrix
+        {
+            Matrix()
+                : v{float4(), float4(), float4(), float4()}
+            {
+            }
+
+            Matrix(float* pm)
+                : v{float4(), float4(), float4(), float4()}
+            {
+                memcpy(m, pm, sizeof(m));
+            }
+
+            Matrix(float m00, float m01, float m02, float m03,
+                   float m10, float m11, float m12, float m13,
+                   float m20, float m21, float m22, float m23,
+                   float m30, float m31, float m32, float m33)
+                : v{float4(), float4(), float4(), float4()}
+            {
+                m[0][0] = m00;
+                m[0][1] = m01;
+                m[0][2] = m02;
+                m[0][3] = m03;
+
+                m[1][0] = m10;
+                m[1][1] = m11;
+                m[1][2] = m12;
+                m[1][3] = m13;
+
+                m[2][0] = m20;
+                m[2][1] = m21;
+                m[2][2] = m22;
+                m[2][3] = m23;
+
+                m[3][0] = m30;
+                m[3][1] = m31;
+                m[3][2] = m32;
+                m[3][3] = m33;
+            }
+
+            void Transpose()
+            {
+                Matrix mm = *this;
+
+                m[0][0] = mm.m[0][0];
+                m[0][1] = mm.m[1][0];
+                m[0][2] = mm.m[2][0];
+                m[0][3] = mm.m[3][0];
+                m[1][0] = mm.m[0][1];
+                m[1][1] = mm.m[1][1];
+                m[1][2] = mm.m[2][1];
+                m[1][3] = mm.m[3][1];
+                m[2][0] = mm.m[0][2];
+                m[2][1] = mm.m[1][2];
+                m[2][2] = mm.m[2][2];
+                m[2][3] = mm.m[3][2];
+                m[3][0] = mm.m[0][3];
+                m[3][1] = mm.m[1][3];
+                m[3][2] = mm.m[2][3];
+                m[3][3] = mm.m[3][3];
+            }
+
+            // Properties
+            float3 Up() const { return float3(_21, _22, _23); }
+            void Up(const float3& vec)
+            {
+                _21 = vec.x;
+                _22 = vec.y;
+                _23 = vec.z;
+            }
+
+            float3 Down() const { return float3(-_21, -_22, -_23); }
+            void Down(const float3& vec)
+            {
+                _21 = -vec.x;
+                _22 = -vec.y;
+                _23 = -vec.z;
+            }
+
+            float3 Right() const { return float3(_11, _12, _13); }
+            void Right(const float3& vec)
+            {
+                _11 = vec.x;
+                _12 = vec.y;
+                _13 = vec.z;
+            }
+
+            float3 Left() const { return float3(-_11, -_12, -_13); }
+            void Left(const float3& vec)
+            {
+                _11 = -vec.x;
+                _12 = -vec.y;
+                _13 = -vec.z;
+            }
+
+            float3 Forward() const { return float3(-_31, -_32, -_33); }
+            void Forward(const float3& vec)
+            {
+                _31 = -vec.x;
+                _32 = -vec.y;
+                _33 = -vec.z;
+            }
+
+            float3 Backward() const { return float3(_31, _32, _33); }
+            void Backward(const float3& vec)
+            {
+                _31 = vec.x;
+                _32 = vec.y;
+                _33 = vec.z;
+            }
+
+            float3 Translation() const { return float3(_41, _42, _43); }
+            float3 TranslationT() const { return float3(_14, _24, _34); }
+            void Translation(const float3& vec)
+            {
+                _41 = vec.x;
+                _42 = vec.y;
+                _43 = vec.z;
+            }
+
+            static Matrix CreateIdentity()
+            {
+                return Matrix(1, 0, 0, 0,
+                              0, 1, 0, 0,
+                              0, 0, 1, 0,
+                              0, 0, 0, 1);
+            }
+
+            union
+            {
+                struct
+                {
+                    float _11, _12, _13, _14;
+                    float _21, _22, _23, _24;
+                    float _31, _32, _33, _34;
+                    float _41, _42, _43, _44;
+                };
+                float m[4][4];
+                float4 v[4];
+                float mv[16];
+            };
+
+            std::string toString()
+            {
+                std::string out;
+                out = "[";
+                for (size_t i = 0; i < 16; i++)
+                {
+                    out += std::to_string(mv[i]);
+
+                    // Only add "," when not at the last value
+                    if (i != 15)
+                        out += ", ";
+                }
+                out += "]";
+
+                return out;
+            }
+
+            friend std::ostream& operator<<(std::ostream& out, Matrix& v);
+        };
+
+        std::ostream& operator<<(std::ostream& out, Matrix& m);
+    }  // namespace ZMath
+}  // namespace ZenLib

--- a/utils/memUtils.h
+++ b/utils/memUtils.h
@@ -1,12 +1,15 @@
 #pragma once
 
-namespace ZMemory
+namespace ZenLib
 {
-    /**
+    namespace ZMemory
+    {
+        /**
      * Returns the number of bits needed to store the number x, at compile time
      */
-    constexpr unsigned numberOfBits(unsigned x)
-    {
-        return x < 2 ? x : 1 + numberOfBits(x >> 1);
-    }
-}  // namespace ZMemory
+        constexpr unsigned numberOfBits(unsigned x)
+        {
+            return x < 2 ? x : 1 + numberOfBits(x >> 1);
+        }
+    }  // namespace ZMemory
+}  // namespace ZenLib

--- a/utils/split.cpp
+++ b/utils/split.cpp
@@ -1,50 +1,53 @@
 #include "split.h"
 
-std::vector<std::string>& Utils::split(const std::string& s, const char delim, std::vector<std::string>& elems)
+namespace ZenLib
 {
-    std::stringstream ss(s);
-    std::string item;
-    while (std::getline(ss, item, delim))
-        elems.push_back(item);
-
-    return elems;
-}
-
-std::vector<std::string> Utils::split(const std::string& s, const char delim)
-{
-    std::vector<std::string> elems;
-    split(s, delim, elems);
-    return elems;
-}
-
-std::string Utils::replaceString(std::string subject, const std::string& search, const std::string& replace)
-{
-    size_t pos = 0;
-    while ((pos = subject.find(search, pos)) != std::string::npos)
+    std::vector<std::string>& Utils::split(const std::string& s, const char delim, std::vector<std::string>& elems)
     {
-        subject.replace(pos, search.length(), replace);
-        pos += replace.length();
+        std::stringstream ss(s);
+        std::string item;
+        while (std::getline(ss, item, delim))
+            elems.push_back(item);
+
+        return elems;
     }
-    return subject;
-}
 
-std::vector<std::string> Utils::split(const std::string& _s, const std::string& delim)
-{
-    std::vector<std::string> parts;
-    std::stringstream stringStream(_s);
-    std::string line;
-    while (std::getline(stringStream, line))
+    std::vector<std::string> Utils::split(const std::string& s, const char delim)
     {
-        std::size_t prev = 0, pos;
-        while ((pos = line.find_first_of(delim, prev)) != std::string::npos)
+        std::vector<std::string> elems;
+        split(s, delim, elems);
+        return elems;
+    }
+
+    std::string Utils::replaceString(std::string subject, const std::string& search, const std::string& replace)
+    {
+        size_t pos = 0;
+        while ((pos = subject.find(search, pos)) != std::string::npos)
         {
-            if (pos > prev)
-                parts.push_back(line.substr(prev, pos - prev));
-            prev = pos + 1;
+            subject.replace(pos, search.length(), replace);
+            pos += replace.length();
         }
-        if (prev < line.length())
-            parts.push_back(line.substr(prev, std::string::npos));
+        return subject;
     }
 
-    return parts;
-}
+    std::vector<std::string> Utils::split(const std::string& _s, const std::string& delim)
+    {
+        std::vector<std::string> parts;
+        std::stringstream stringStream(_s);
+        std::string line;
+        while (std::getline(stringStream, line))
+        {
+            std::size_t prev = 0, pos;
+            while ((pos = line.find_first_of(delim, prev)) != std::string::npos)
+            {
+                if (pos > prev)
+                    parts.push_back(line.substr(prev, pos - prev));
+                prev = pos + 1;
+            }
+            if (prev < line.length())
+                parts.push_back(line.substr(prev, std::string::npos));
+        }
+
+        return parts;
+    }
+}  // namespace ZenLib

--- a/utils/split.h
+++ b/utils/split.h
@@ -4,23 +4,26 @@
 #include <string>
 #include <vector>
 
-namespace Utils
+namespace ZenLib
 {
-    std::vector<std::string>& split(const std::string& s, const char delim, std::vector<std::string>& elems);
+    namespace Utils
+    {
+        std::vector<std::string>& split(const std::string& s, const char delim, std::vector<std::string>& elems);
 
-    /**
+        /**
      * @brief split string function
      * @param string
      * @param delimitor
      * @return splitted string in a std::vector<std::string>
      */
-    std::vector<std::string> split(const std::string& s, const char delim);
+        std::vector<std::string> split(const std::string& s, const char delim);
 
-    /**
+        /**
 	 * @brief Splits a string on every occasion of one of the input-chars, in the given order
 	 *		  Undefined behavior if the chars occur multiple times.
 	 */
-    std::vector<std::string> split(const std::string& s, const std::string& delim);
+        std::vector<std::string> split(const std::string& s, const std::string& delim);
 
-    std::string replaceString(std::string subject, const std::string& search, const std::string& replace);
-}  // namespace Utils
+        std::string replaceString(std::string subject, const std::string& search, const std::string& replace);
+    }  // namespace Utils
+}  // namespace ZenLib

--- a/utils/staticReferencedAllocator.h
+++ b/utils/staticReferencedAllocator.h
@@ -8,242 +8,245 @@
 #include "memUtils.h"
 #include <assert.h>
 
-namespace ZMemory
+namespace ZenLib
 {
-    /**
+    namespace ZMemory
+    {
+        /**
      * Max size a GenericHandle can be in bits
      */
-    enum
-    {
-        GENERIC_HANDLE_MAX_SIZE_BITS = sizeof(uint32_t) * 8 * 2
-    };
-
-    template <int N1, int N2>
-    struct GenericHandle
-    {
-        enum : uint32_t
+        enum
         {
-            INVALID_HANDLE = static_cast<uint32_t>(-1) >> (32 - N1)
+            GENERIC_HANDLE_MAX_SIZE_BITS = sizeof(uint32_t) * 8 * 2
         };
 
-        GenericHandle()
+        template <int N1, int N2>
+        struct GenericHandle
         {
-            invalidate();
-        }
+            enum : uint32_t
+            {
+                INVALID_HANDLE = static_cast<uint32_t>(-1) >> (32 - N1)
+            };
 
-        uint32_t index : N1;
-        uint32_t generation : N2;
+            GenericHandle()
+            {
+                invalidate();
+            }
 
-        void invalidate()
-        {
-            // Assign -1 to index
-            index = INVALID_HANDLE;
-            generation = 0;
-        }
+            uint32_t index : N1;
+            uint32_t generation : N2;
 
-        bool isValid() const
-        {
-            // Index != -1
-            return index != INVALID_HANDLE;
-        }
+            void invalidate()
+            {
+                // Assign -1 to index
+                index = INVALID_HANDLE;
+                generation = 0;
+            }
 
-        bool operator<(const GenericHandle<N1, N2>& r) const
-        {
-            return index < r.index;
-        }
+            bool isValid() const
+            {
+                // Index != -1
+                return index != INVALID_HANDLE;
+            }
 
-        bool operator==(const GenericHandle<N1, N2>& r) const
-        {
-            return index == r.index && generation == r.generation;
-        }
-    };
+            bool operator<(const GenericHandle<N1, N2>& r) const
+            {
+                return index < r.index;
+            }
 
-    /**
+            bool operator==(const GenericHandle<N1, N2>& r) const
+            {
+                return index == r.index && generation == r.generation;
+            }
+        };
+
+        /**
      * Casts between handles of different size
      */
-    template <typename HT, int M1, int M2>
-    HT handleCast(const GenericHandle<M1, M2>& h)
-    {
-        HT b;
-        b.generation = h.generation;
+        template <typename HT, int M1, int M2>
+        HT handleCast(const GenericHandle<M1, M2>& h)
+        {
+            HT b;
+            b.generation = h.generation;
 
-        if (!h.isValid())
-            b.invalidate();
-        else
-            b.index = h.index;
+            if (!h.isValid())
+                b.invalidate();
+            else
+                b.index = h.index;
 
-        return b;
-    }
+            return b;
+        }
 
-    /**
+        /**
       * 32-32 bit handle, usefull if you don't know the exact type of your handles
       */
-    typedef GenericHandle<32, 32> BigHandle;
-    template <int N1, int N2>
-    BigHandle toBigHandle(const GenericHandle<N1, N2>& h)
-    {
-        return handleCast<BigHandle>(h);
-    }
+        typedef GenericHandle<32, 32> BigHandle;
+        template <int N1, int N2>
+        BigHandle toBigHandle(const GenericHandle<N1, N2>& h)
+        {
+            return handleCast<BigHandle>(h);
+        }
 
-    /**
+        /**
      * @param T Type of data stored in the allocator
      * @param NUM Number of elements statically allocated
      */
-    template <typename T, unsigned int NUM>
-    class StaticReferencedAllocator
-    {
-    public:
-        //typedef GenericHandle<numberOfBits(NUM), std::min(32u, GENERIC_HANDLE_MAX_SIZE_BITS - numberOfBits(NUM))> Handle;
-        typedef GenericHandle<numberOfBits(NUM), 32u> Handle;
+        template <typename T, unsigned int NUM>
+        class StaticReferencedAllocator
+        {
+        public:
+            //typedef GenericHandle<numberOfBits(NUM), std::min(32u, GENERIC_HANDLE_MAX_SIZE_BITS - numberOfBits(NUM))> Handle;
+            typedef GenericHandle<numberOfBits(NUM), 32u> Handle;
 
-        /**
+            /**
          * Outside-Mirror for the type this can create
          */
-        typedef T Type;
+            typedef T Type;
 
-        StaticReferencedAllocator()
-            : m_Elements(new T[NUM])
-            , m_ElementsToInternalHandles(new size_t[NUM])
-            , m_InternalHandles(new FLHandle[NUM])
-            , m_FreeList(m_InternalHandles, m_InternalHandles + NUM, sizeof(m_InternalHandles[0]), NUM, sizeof(m_InternalHandles[0]), 0)
-            , m_LastInternalHandle(nullptr)
-        {
-            // Initialize handles
-            for (size_t i = 0; i < NUM; i++)
+            StaticReferencedAllocator()
+                : m_Elements(new T[NUM])
+                , m_ElementsToInternalHandles(new size_t[NUM])
+                , m_InternalHandles(new FLHandle[NUM])
+                , m_FreeList(m_InternalHandles, m_InternalHandles + NUM, sizeof(m_InternalHandles[0]), NUM, sizeof(m_InternalHandles[0]), 0)
+                , m_LastInternalHandle(nullptr)
             {
-                m_InternalHandles[i].m_Handle.invalidate();
+                // Initialize handles
+                for (size_t i = 0; i < NUM; i++)
+                {
+                    m_InternalHandles[i].m_Handle.invalidate();
+                }
             }
-        }
 
-        virtual ~StaticReferencedAllocator()
-        {
-            delete[] m_Elements;
-            delete[] m_InternalHandles;
-            delete[] m_ElementsToInternalHandles;
-        }
+            virtual ~StaticReferencedAllocator()
+            {
+                delete[] m_Elements;
+                delete[] m_InternalHandles;
+                delete[] m_ElementsToInternalHandles;
+            }
 
-        /**
+            /**
          * Returns a handle to a free chunk of memory and marks it as used
          */
-        Handle createObject()
-        {
-            assert(m_FreeList.getNumObtainedElements() != NUM);
+            Handle createObject()
+            {
+                assert(m_FreeList.getNumObtainedElements() != NUM);
 
-            // Use the element at the end of the array as target
-            size_t idx = m_FreeList.getNumObtainedElements();
+                // Use the element at the end of the array as target
+                size_t idx = m_FreeList.getNumObtainedElements();
 
-            // Get a new handle from the free-list
-            auto* handle = m_FreeList.obtainElement();
-            handle->m_Handle.index = static_cast<uint32_t>(idx);  // TODO: Care for bit-size of 'index'
-            // (Don't need to touch the generation, only needed on deletion)
+                // Get a new handle from the free-list
+                auto* handle = m_FreeList.obtainElement();
+                handle->m_Handle.index = static_cast<uint32_t>(idx);  // TODO: Care for bit-size of 'index'
+                // (Don't need to touch the generation, only needed on deletion)
 
-            // Store this as the new handle to the end of the list
-            m_LastInternalHandle = handle;
+                // Store this as the new handle to the end of the list
+                m_LastInternalHandle = handle;
 
-            // Create output handle
-            Handle hOut;
-            hOut.index = static_cast<uint32_t>(handle - m_InternalHandles);
-            hOut.generation = handle->m_Handle.generation;
+                // Create output handle
+                Handle hOut;
+                hOut.index = static_cast<uint32_t>(handle - m_InternalHandles);
+                hOut.generation = handle->m_Handle.generation;
 
-            // Connect element and internal handle
-            m_ElementsToInternalHandles[idx] = hOut.index;
+                // Connect element and internal handle
+                m_ElementsToInternalHandles[idx] = hOut.index;
 
-            return hOut;
-        }
+                return hOut;
+            }
 
-        /**
+            /**
          * @return the actual element to the handle h
          */
-        T& getElement(const Handle& h)
-        {
-            assert(m_InternalHandles[h.index].m_Handle.generation == h.generation);
+            T& getElement(const Handle& h)
+            {
+                assert(m_InternalHandles[h.index].m_Handle.generation == h.generation);
 
-            return m_Elements[m_InternalHandles[h.index].m_Handle.index];
-        }
+                return m_Elements[m_InternalHandles[h.index].m_Handle.index];
+            }
 
-        /**
+            /**
          * Marks the element with the given handle as free and calls the "OnRemoved"-Callback before doing so
          */
-        void removeObject(const Handle& h)
-        {
-            // Check if the handle is still valid. If not, we are accessing a different object!
-            assert(m_InternalHandles[h.index].m_Handle.generation == h.generation);
-            assert(m_LastInternalHandle != nullptr);  // Must have at least one handle in there
+            void removeObject(const Handle& h)
+            {
+                // Check if the handle is still valid. If not, we are accessing a different object!
+                assert(m_InternalHandles[h.index].m_Handle.generation == h.generation);
+                assert(m_LastInternalHandle != nullptr);  // Must have at least one handle in there
 
-            // Get actual index of handle-target
-            uint32_t actIdx = m_InternalHandles[h.index].m_Handle.index;
+                // Get actual index of handle-target
+                uint32_t actIdx = m_InternalHandles[h.index].m_Handle.index;
 
-            if (m_OnRemoved)
-                m_OnRemoved(m_Elements[actIdx]);
+                if (m_OnRemoved)
+                    m_OnRemoved(m_Elements[actIdx]);
 
-            // Overwrite this element with the last one
-            m_Elements[actIdx] = m_Elements[m_LastInternalHandle->m_Handle.index];
+                // Overwrite this element with the last one
+                m_Elements[actIdx] = m_Elements[m_LastInternalHandle->m_Handle.index];
 
-            // Fix the handle of the last element
-            m_LastInternalHandle->m_Handle.index = actIdx;
-            m_ElementsToInternalHandles[actIdx] = m_LastInternalHandle - m_InternalHandles;
+                // Fix the handle of the last element
+                m_LastInternalHandle->m_Handle.index = actIdx;
+                m_ElementsToInternalHandles[actIdx] = m_LastInternalHandle - m_InternalHandles;
 
-            // Increase generation of old element
-            m_InternalHandles[h.index].m_Handle.generation++;
+                // Increase generation of old element
+                m_InternalHandles[h.index].m_Handle.generation++;
 
-            // Return the handle to the free-list
-            m_FreeList.returnElement(&m_InternalHandles[h.index]);
+                // Return the handle to the free-list
+                m_FreeList.returnElement(&m_InternalHandles[h.index]);
 
-            // Get new back-object
-            if (m_FreeList.getNumObtainedElements() > 0)
-                m_LastInternalHandle = &m_InternalHandles[m_ElementsToInternalHandles[m_FreeList.getNumObtainedElements() - 1]];
-            else
-                m_LastInternalHandle = nullptr;
-        }
+                // Get new back-object
+                if (m_FreeList.getNumObtainedElements() > 0)
+                    m_LastInternalHandle = &m_InternalHandles[m_ElementsToInternalHandles[m_FreeList.getNumObtainedElements() - 1]];
+                else
+                    m_LastInternalHandle = nullptr;
+            }
 
-        /**
+            /**
          * Sets a callback to what should happen when an object got deleted
          */
-        void setOnRemoveCallback(const std::function<void(T&)> onRemoved)
-        {
-            m_OnRemoved = onRemoved;
-        }
+            void setOnRemoveCallback(const std::function<void(T&)> onRemoved)
+            {
+                m_OnRemoved = onRemoved;
+            }
 
-        /**
+            /**
          * Returns all elements as continuous chunk of memory
          */
-        T* getElements()
-        {
-            return m_Elements;
-        }
+            T* getElements()
+            {
+                return m_Elements;
+            }
 
-        /**
+            /**
          * Returns the number of allocated elements, aka. how far to go using getElements()
          */
-        size_t getNumObtainedElements()
-        {
-            return m_FreeList.getNumObtainedElements();
-        }
+            size_t getNumObtainedElements()
+            {
+                return m_FreeList.getNumObtainedElements();
+            }
 
-    private:
-        /** Actual element data */
-        T* m_Elements;
+        private:
+            /** Actual element data */
+            T* m_Elements;
 
-        /** Contains the index of an internal handle for each element */
-        size_t* m_ElementsToInternalHandles;
+            /** Contains the index of an internal handle for each element */
+            size_t* m_ElementsToInternalHandles;
 
-        /** Helper-struct to get around FreeList needing at least the size of a pointer to operate */
-        struct FLHandle
-        {
-            void* m_Next;  // Don't let the free-list overwrite our generation
-            Handle m_Handle;
+            /** Helper-struct to get around FreeList needing at least the size of a pointer to operate */
+            struct FLHandle
+            {
+                void* m_Next;  // Don't let the free-list overwrite our generation
+                Handle m_Handle;
+            };
+
+            /** Make handles with enough bits to hold NUM indices. Use the rest for generations. */
+            FLHandle* m_InternalHandles;
+
+            /** Handle to the last element created */
+            FLHandle* m_LastInternalHandle;
+
+            /** List of free handles */
+            FreeList<FLHandle> m_FreeList;
+
+            /** Function to call when an object was removed */
+            std::function<void(T&)> m_OnRemoved;
         };
-
-        /** Make handles with enough bits to hold NUM indices. Use the rest for generations. */
-        FLHandle* m_InternalHandles;
-
-        /** Handle to the last element created */
-        FLHandle* m_LastInternalHandle;
-
-        /** List of free handles */
-        FreeList<FLHandle> m_FreeList;
-
-        /** Function to call when an object was removed */
-        std::function<void(T&)> m_OnRemoved;
-    };
-}  // namespace ZMemory
+    }  // namespace ZMemory
+}  // namespace ZenLib

--- a/utils/systemlinux.h
+++ b/utils/systemlinux.h
@@ -2,14 +2,17 @@
 
 #include <sys/stat.h>
 
-namespace Utils
+namespace ZenLib
 {
-    class System
+    namespace Utils
     {
-    public:
-        static void mkdir(const char* path)
+        class System
         {
-            ::mkdir(path, S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH);
-        }
-    };
-}  // namespace Utils
+        public:
+            static void mkdir(const char* path)
+            {
+                ::mkdir(path, S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH);
+            }
+        };
+    }  // namespace Utils
+}  // namespace ZenLib

--- a/utils/systemwindows.h
+++ b/utils/systemwindows.h
@@ -1,17 +1,20 @@
 #pragma once
 #include <windows.h>
 
-namespace Utils
+namespace ZenLib
 {
-    class System
+    namespace Utils
     {
-    public:
-        /**
+        class System
+        {
+        public:
+            /**
 		 * @brief Creates a directory on the systems file structure
 		 */
-        static void mkdir(const char* path)
-        {
-            CreateDirectory(path, nullptr);
-        }
-    };
-}  // namespace Utils
+            static void mkdir(const char* path)
+            {
+                CreateDirectory(path, nullptr);
+            }
+        };
+    }  // namespace Utils
+}  // namespace ZenLib

--- a/utils/tuple.h
+++ b/utils/tuple.h
@@ -1,61 +1,64 @@
 #pragma once
 #include <tuple>
 
-namespace Utils
+namespace ZenLib
 {
-    /**
-	* @brief tuple-foreach. Based on http://stackoverflow.com/a/16387374
-	*/
-    namespace tf
+    namespace Utils
     {
         /**
+	* @brief tuple-foreach. Based on http://stackoverflow.com/a/16387374
+	*/
+        namespace tf
+        {
+            /**
 		* @brief generate a compile-time list of values from 0 to N
 		*/
-        template <int... Is>
-        struct seq
-        {
-        };
+            template <int... Is>
+            struct seq
+            {
+            };
 
-        template <int N, int... Is>
-        struct gen_seq : gen_seq<N - 1, N - 1, Is...>
-        {
-        };
+            template <int N, int... Is>
+            struct gen_seq : gen_seq<N - 1, N - 1, Is...>
+            {
+            };
 
-        template <int... Is>
-        struct gen_seq<0, Is...> : seq<Is...>
-        {
-        };
+            template <int... Is>
+            struct gen_seq<0, Is...> : seq<Is...>
+            {
+            };
 
-        template <typename T, typename F, int... Is>
-        void _internal_for_each(T&& t, F f, seq<Is...>)
-        {
-            // Generate an array looking like this:
-            // auto l = {(f1,0), (f2,0), ... , (fn,0)}
+            template <typename T, typename F, int... Is>
+            void _internal_for_each(T&& t, F f, seq<Is...>)
+            {
+                // Generate an array looking like this:
+                // auto l = {(f1,0), (f2,0), ... , (fn,0)}
 
-            // The ",0" in (fi, 0) are important to get the compiler to
-            // be quiet about not knowing the size of the fi-call for
-            // the initializer list: The actual value of the fi-call will
-            // be discarded and only the rightmost one will be used,
-            // making the initializer list ending up as a list of 0s
-            // while actually calling all functions.
-            auto l = {(f(std::get<Is>(t)), 0)...};
-        }
-    }  // namespace tf
+                // The ",0" in (fi, 0) are important to get the compiler to
+                // be quiet about not knowing the size of the fi-call for
+                // the initializer list: The actual value of the fi-call will
+                // be discarded and only the rightmost one will be used,
+                // making the initializer list ending up as a list of 0s
+                // while actually calling all functions.
+                auto l = {(f(std::get<Is>(t)), 0)...};
+            }
+        }  // namespace tf
 
-    /**
+        /**
 	* @brief Calls lambda-function f for each element in the tuple t
 	*/
-    template <typename... Ts, typename F>
-    void for_each_in_tuple(std::tuple<Ts...>& t, F f)
-    {
-        // Generate a list for all types of fields we have in the tuple
-        tf::_internal_for_each(t, f, tf::gen_seq<sizeof...(Ts)>());
-    }
+        template <typename... Ts, typename F>
+        void for_each_in_tuple(std::tuple<Ts...>& t, F f)
+        {
+            // Generate a list for all types of fields we have in the tuple
+            tf::_internal_for_each(t, f, tf::gen_seq<sizeof...(Ts)>());
+        }
 
-    /**
+        /**
 	* Example:
 	* auto t = std::make_tuple(1, 2, "test", 4.0f);
 	* for_each_in_tuple(t, [](auto& v){v += 1;});
 	*/
 
-}  // namespace Utils
+    }  // namespace Utils
+}  // namespace ZenLib

--- a/utils/vector.h
+++ b/utils/vector.h
@@ -4,56 +4,59 @@
 #include <vector>
 #include <inttypes.h>
 
-namespace Utils
+namespace ZenLib
 {
-    template <typename T>
-    class Vector
+    namespace Utils
     {
-    public:
-        Vector(size_t size = 0)
-            : m_Data(size)
+        template <typename T>
+        class Vector
         {
-        }
+        public:
+            Vector(size_t size = 0)
+                : m_Data(size)
+            {
+            }
 
-        Vector(size_t size, T s)
-            : m_Data(size, s)
-        {
-        }
+            Vector(size_t size, T s)
+                : m_Data(size, s)
+            {
+            }
 
-        size_t size() const
-        {
-            return m_Data.size();
-        }
+            size_t size() const
+            {
+                return m_Data.size();
+            }
 
-        void resize(size_t size)
-        {
-            m_Data.resize(size);
-        }
+            void resize(size_t size)
+            {
+                m_Data.resize(size);
+            }
 
-        T& operator[](size_t s)
-        {
-            return m_Data[s];
-        }
+            T& operator[](size_t s)
+            {
+                return m_Data[s];
+            }
 
-        void push_back(const T& s)
-        {
-            m_Data.push_back(s);
-        }
+            void push_back(const T& s)
+            {
+                m_Data.push_back(s);
+            }
 
-        void remove(uint32_t id)
-        {
-            m_Data.erase(m_Data.begin() + id, m_Data.begin() + id + 1);
-        }
+            void remove(uint32_t id)
+            {
+                m_Data.erase(m_Data.begin() + id, m_Data.begin() + id + 1);
+            }
 
-        void clear(bool freeMemory = false)
-        {
-            m_Data.clear();
-            if (freeMemory)
-                m_Data.shrink_to_fit();
-        }
+            void clear(bool freeMemory = false)
+            {
+                m_Data.clear();
+                if (freeMemory)
+                    m_Data.shrink_to_fit();
+            }
 
-        typedef T value_type;
+            typedef T value_type;
 
-        std::vector<T> m_Data;
-    };
-}  // namespace Utils
+            std::vector<T> m_Data;
+        };
+    }  // namespace Utils
+}  // namespace ZenLib

--- a/vdfs/fileIndex.cpp
+++ b/vdfs/fileIndex.cpp
@@ -7,209 +7,212 @@
 #include <physfs.h>
 #include "utils/logger.h"
 
-using namespace VDFS;
-
-namespace internal
+namespace ZenLib
 {
-    // Must be initialized with the 0th argument passed to the executable for PhysFS.
-    std::string argv0;
+    using namespace VDFS;
 
-    // We need to do some poor-mans-refcounting to be able to know when we
-    // need to init and deinit physfs.
-    size_t numAliveIndices = 0;
-}  // namespace internal
-
-FileIndex::FileIndex()
-{
-    if (internal::argv0.empty())
+    namespace internal
     {
-        auto const error = "VDFS not intialized! Please call 'initVDFS' before using!";
-        LogError() << error;
-        throw std::runtime_error(error);
+        // Must be initialized with the 0th argument passed to the executable for PhysFS.
+        std::string argv0;
+
+        // We need to do some poor-mans-refcounting to be able to know when we
+        // need to init and deinit physfs.
+        size_t numAliveIndices = 0;
+    }  // namespace internal
+
+    FileIndex::FileIndex()
+    {
+        if (internal::argv0.empty())
+        {
+            auto const error = "VDFS not intialized! Please call 'initVDFS' before using!";
+            LogError() << error;
+            throw std::runtime_error(error);
+        }
+
+        if (!PHYSFS_isInit())
+            PHYSFS_init(internal::argv0.c_str());
+
+        internal::numAliveIndices++;
+
+        assert(!internal::argv0.empty());
     }
 
-    if (!PHYSFS_isInit())
-        PHYSFS_init(internal::argv0.c_str());
+    FileIndex::~FileIndex()
+    {
+        assert(internal::numAliveIndices != 0);
+        internal::numAliveIndices--;
 
-    internal::numAliveIndices++;
+        if (internal::numAliveIndices == 0 && PHYSFS_isInit())
+            PHYSFS_deinit();
+    }
 
-    assert(!internal::argv0.empty());
-}
+    void FileIndex::initVDFS(const char* argv0)
+    {
+        assert(internal::argv0.empty());
 
-FileIndex::~FileIndex()
-{
-    assert(internal::numAliveIndices != 0);
-    internal::numAliveIndices--;
+        internal::argv0 = argv0;
+    }
 
-    if (internal::numAliveIndices == 0 && PHYSFS_isInit())
-        PHYSFS_deinit();
-}
-
-void FileIndex::initVDFS(const char* argv0)
-{
-    assert(internal::argv0.empty());
-
-    internal::argv0 = argv0;
-}
-
-/**
+    /**
 * @brief Loads a VDF-File and initializes everything
 */
-bool FileIndex::loadVDF(const std::string& vdf, uint32_t priority, const std::string& mountPoint)
-{
-    assert(!isFinalized());
-
-    if (isFinalized())
+    bool FileIndex::loadVDF(const std::string& vdf, uint32_t priority, const std::string& mountPoint)
     {
-        LogWarn() << "Cannot load new VDFS-archives into finalized index!";
-        return false;
+        assert(!isFinalized());
+
+        if (isFinalized())
+        {
+            LogWarn() << "Cannot load new VDFS-archives into finalized index!";
+            return false;
+        }
+
+        if (!PHYSFS_mount(vdf.c_str(), mountPoint.c_str(), 1))
+        {
+            LogInfo() << "Couldn't load VDF-Archive " << vdf << ": " << PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode());
+            return false;
+        }
+
+        return true;
     }
 
-    if (!PHYSFS_mount(vdf.c_str(), mountPoint.c_str(), 1))
+    bool FileIndex::mountFolder(const std::string& path, const std::string& mountPoint)
     {
-        LogInfo() << "Couldn't load VDF-Archive " << vdf << ": " << PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode());
-        return false;
+        if (!PHYSFS_mount(path.c_str(), mountPoint.c_str(), 1))
+        {
+            LogInfo() << "Couldn't mount directory " << path << ": " << PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode());
+            return false;
+        }
+
+        return true;
     }
 
-    return true;
-}
-
-bool FileIndex::mountFolder(const std::string& path, const std::string& mountPoint)
-{
-    if (!PHYSFS_mount(path.c_str(), mountPoint.c_str(), 1))
-    {
-        LogInfo() << "Couldn't mount directory " << path << ": " << PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode());
-        return false;
-    }
-
-    return true;
-}
-
-/**
+    /**
 * @brief Fills a vector with the data of the given file
 */
-bool FileIndex::getFileData(const std::string& file, std::vector<uint8_t>& data) const
-{
-    assert(isFinalized());
-
-    std::string caseSensitivePath = findCaseSensitiveNameOf(file);
-    bool exists = caseSensitivePath != "";
-
-    if (!exists) return false;
-
-    PHYSFS_File* handle = PHYSFS_openRead(caseSensitivePath.c_str());
-    if (!handle)
+    bool FileIndex::getFileData(const std::string& file, std::vector<uint8_t>& data) const
     {
-        LogInfo() << "Cannot read file " << file << ": " << PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode());
-        return false;
-    }
+        assert(isFinalized());
 
-    auto length = PHYSFS_fileLength(handle);
-    data.resize(length);
-    if (PHYSFS_readBytes(handle, data.data(), length) < length)
-    {
-        LogInfo() << "Cannot read file " << file << ": " << PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode());
+        std::string caseSensitivePath = findCaseSensitiveNameOf(file);
+        bool exists = caseSensitivePath != "";
+
+        if (!exists) return false;
+
+        PHYSFS_File* handle = PHYSFS_openRead(caseSensitivePath.c_str());
+        if (!handle)
+        {
+            LogInfo() << "Cannot read file " << file << ": " << PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode());
+            return false;
+        }
+
+        auto length = PHYSFS_fileLength(handle);
+        data.resize(length);
+        if (PHYSFS_readBytes(handle, data.data(), length) < length)
+        {
+            LogInfo() << "Cannot read file " << file << ": " << PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode());
+            PHYSFS_close(handle);
+            return false;
+        }
         PHYSFS_close(handle);
-        return false;
+        return true;
     }
-    PHYSFS_close(handle);
-    return true;
-}
 
-bool FileIndex::hasFile(const std::string& name) const
-{
-    assert(isFinalized());
-
-    return findCaseSensitiveNameOf(name) != "";
-}
-
-int64_t VDFS::FileIndex::getLastModTime(const std::string& name)
-{
-    int64_t result = -1;
-    std::ifstream infile(name);
-    if (infile.good())
+    bool FileIndex::hasFile(const std::string& name) const
     {
-        std::string firstLine;
-        std::getline(infile, firstLine);
-        struct std::tm tm;
-        std::smatch match;
+        assert(isFinalized());
 
-        // Regex of the datetime used by G1 and G2 e.g. (Thu, 19 Dec 2002 19:24:42 GMT)
-        std::regex rgxG1G2("\\(.*, ([[:digit:]]*) (.*) ([[:digit:]]*) ([[:digit:]]*):([[:digit:]]*):([[:digit:]]*) GMT\\)");
-
-        // Regex of the datetime used by G1 e.g. 19.06.2001  18:58.06
-        std::regex rgxG1("([[:digit:]]*)\\.([[:digit:]]*)\\.([[:digit:]]*)  ([[:digit:]]*):([[:digit:]]*).([[:digit:]]*)");
-
-        if (std::regex_search(firstLine, match, rgxG1G2))
-        {
-            std::istringstream datetime(match[1].str() + "-" + match[2].str() + "-" + match[3].str() + " " + match[4].str() + ":" + match[5].str() + ":" + match[6].str());
-
-            datetime >> std::get_time(&tm, "%d-%b-%Y %H:%M:%S");
-            if (!datetime.fail())
-                result = std::mktime(&tm);
-        }
-        else if (std::regex_search(firstLine, match, rgxG1))
-        {
-            std::istringstream datetime(match[1].str() + "-" + match[2].str() + "-" + match[3].str() + " " + match[4].str() + ":" + match[5].str() + ":" + match[6].str());
-
-            datetime >> std::get_time(&tm, "%d-%m-%Y %H:%M:%S");
-            if (!datetime.fail())
-                result = std::mktime(&tm);
-        }
-
-        infile.close();
+        return findCaseSensitiveNameOf(name) != "";
     }
 
-    return result;
-}
-
-std::vector<std::string> FileIndex::getKnownFiles(const std::string& path) const
-{
-    std::vector<std::string> vec;
-    char** files = PHYSFS_enumerateFiles(path.c_str());
-    char** i;
-    for (i = files; *i != NULL; i++)
-        vec.push_back(*i);
-    PHYSFS_freeList(files);
-    return vec;
-}
-
-void FileIndex::updateUpperedFilenamesMap()
-{
-    std::vector<std::string> files = getKnownFiles();
-
-    m_FilenamesByUpperedFileNames.clear();
-    for (const std::string& file : files)
+    int64_t VDFS::FileIndex::getLastModTime(const std::string& name)
     {
-        std::string uppered = file;
-        std::transform(uppered.begin(), uppered.end(), uppered.begin(), ::toupper);
+        int64_t result = -1;
+        std::ifstream infile(name);
+        if (infile.good())
+        {
+            std::string firstLine;
+            std::getline(infile, firstLine);
+            struct std::tm tm;
+            std::smatch match;
 
-        m_FilenamesByUpperedFileNames[uppered] = file;
+            // Regex of the datetime used by G1 and G2 e.g. (Thu, 19 Dec 2002 19:24:42 GMT)
+            std::regex rgxG1G2("\\(.*, ([[:digit:]]*) (.*) ([[:digit:]]*) ([[:digit:]]*):([[:digit:]]*):([[:digit:]]*) GMT\\)");
+
+            // Regex of the datetime used by G1 e.g. 19.06.2001  18:58.06
+            std::regex rgxG1("([[:digit:]]*)\\.([[:digit:]]*)\\.([[:digit:]]*)  ([[:digit:]]*):([[:digit:]]*).([[:digit:]]*)");
+
+            if (std::regex_search(firstLine, match, rgxG1G2))
+            {
+                std::istringstream datetime(match[1].str() + "-" + match[2].str() + "-" + match[3].str() + " " + match[4].str() + ":" + match[5].str() + ":" + match[6].str());
+
+                datetime >> std::get_time(&tm, "%d-%b-%Y %H:%M:%S");
+                if (!datetime.fail())
+                    result = std::mktime(&tm);
+            }
+            else if (std::regex_search(firstLine, match, rgxG1))
+            {
+                std::istringstream datetime(match[1].str() + "-" + match[2].str() + "-" + match[3].str() + " " + match[4].str() + ":" + match[5].str() + ":" + match[6].str());
+
+                datetime >> std::get_time(&tm, "%d-%m-%Y %H:%M:%S");
+                if (!datetime.fail())
+                    result = std::mktime(&tm);
+            }
+
+            infile.close();
+        }
+
+        return result;
     }
-}
 
-std::string FileIndex::findCaseSensitiveNameOf(const std::string& caseInsensitiveName) const
-{
-    assert(isFinalized());
+    std::vector<std::string> FileIndex::getKnownFiles(const std::string& path) const
+    {
+        std::vector<std::string> vec;
+        char** files = PHYSFS_enumerateFiles(path.c_str());
+        char** i;
+        for (i = files; *i != NULL; i++)
+            vec.push_back(*i);
+        PHYSFS_freeList(files);
+        return vec;
+    }
 
-    std::string uppered = caseInsensitiveName;
-    std::transform(caseInsensitiveName.begin(), caseInsensitiveName.end(), uppered.begin(), ::toupper);
+    void FileIndex::updateUpperedFilenamesMap()
+    {
+        std::vector<std::string> files = getKnownFiles();
 
-    auto it = m_FilenamesByUpperedFileNames.find(uppered);
+        m_FilenamesByUpperedFileNames.clear();
+        for (const std::string& file : files)
+        {
+            std::string uppered = file;
+            std::transform(uppered.begin(), uppered.end(), uppered.begin(), ::toupper);
 
-    if (it == m_FilenamesByUpperedFileNames.end())
-        return "";
+            m_FilenamesByUpperedFileNames[uppered] = file;
+        }
+    }
 
-    return it->second;
-}
+    std::string FileIndex::findCaseSensitiveNameOf(const std::string& caseInsensitiveName) const
+    {
+        assert(isFinalized());
 
-void FileIndex::finalizeLoad()
-{
-    // Must be called here so opening files will actually work
-    updateUpperedFilenamesMap();
-}
+        std::string uppered = caseInsensitiveName;
+        std::transform(caseInsensitiveName.begin(), caseInsensitiveName.end(), uppered.begin(), ::toupper);
 
-bool FileIndex::isFinalized() const
-{
-    return !m_FilenamesByUpperedFileNames.empty();
-}
+        auto it = m_FilenamesByUpperedFileNames.find(uppered);
+
+        if (it == m_FilenamesByUpperedFileNames.end())
+            return "";
+
+        return it->second;
+    }
+
+    void FileIndex::finalizeLoad()
+    {
+        // Must be called here so opening files will actually work
+        updateUpperedFilenamesMap();
+    }
+
+    bool FileIndex::isFinalized() const
+    {
+        return !m_FilenamesByUpperedFileNames.empty();
+    }
+}  // namespace ZenLib

--- a/vdfs/fileIndex.h
+++ b/vdfs/fileIndex.h
@@ -5,76 +5,79 @@
 #include <unordered_map>
 #include <vector>
 
-namespace VDFS
+namespace ZenLib
 {
-    class FileIndex
+    namespace VDFS
     {
-    public:
-        FileIndex();
-        ~FileIndex();
+        class FileIndex
+        {
+        public:
+            FileIndex();
+            ~FileIndex();
 
-        /**
+            /**
          * @brief Initializes the VDFS
          */
-        static void initVDFS(const char* argv0);
+            static void initVDFS(const char* argv0);
 
-        /**
+            /**
          * @brief Loads a VDF-File and initializes everything
          */
-        bool loadVDF(const std::string& vdf, uint32_t priority = 0, const std::string& mountPoint = "/");
+            bool loadVDF(const std::string& vdf, uint32_t priority = 0, const std::string& mountPoint = "/");
 
-        /**
+            /**
          * Mounts the given folder-structure into the file-index
          * @param path folder to mount
          * @return success
          */
-        bool mountFolder(const std::string& path, const std::string& mountPoint = "/");
+            bool mountFolder(const std::string& path, const std::string& mountPoint = "/");
 
-        /**
+            /**
          * Must be called after you have mounted/loaded all files. Otherwise files won't be openable.
          */
-        void finalizeLoad();
+            void finalizeLoad();
 
-        /**
+            /**
          * @brief Fills a vector with the data of the given file
          */
-        bool getFileData(const std::string& file, std::vector<uint8_t>& data) const;
+            bool getFileData(const std::string& file, std::vector<uint8_t>& data) const;
 
-        /**
+            /**
          * @brief Returnst the list of all known files
          */
-        std::vector<std::string> getKnownFiles(const std::string& path = "/") const;
+            std::vector<std::string> getKnownFiles(const std::string& path = "/") const;
 
-        /**
+            /**
          * @return Whether a file with the given name exists
          */
-        bool hasFile(const std::string& name) const;
+            bool hasFile(const std::string& name) const;
 
-        /**
+            /**
          * Get the last modification time of the given VDF-File.
          * @param name of the VDF-File
          * @return If successful then the datetime inside the VDF header which represents
          * the last modification time of the VDF-File will be returned as seconds since
          * the unix epoch 00:00, Jan 1 1970 UTC otherwise -1.
          */
-        static int64_t getLastModTime(const std::string& name);
+            static int64_t getLastModTime(const std::string& name);
 
-    private:
-        /**
+        private:
+            /**
          * @return Whether this fileindex has been finalized
          */
-        bool isFinalized() const;
+            bool isFinalized() const;
 
-        /**
+            /**
          * Updates the cache used by findCaseSensitiveNameOf
          */
-        void updateUpperedFilenamesMap();
+            void updateUpperedFilenamesMap();
 
-        /**
+            /**
          * @return Case-sensitive version of the given case-insensitive filename. Empty string if not found.
          */
-        std::string findCaseSensitiveNameOf(const std::string& caseInsensitiveName) const;
+            std::string findCaseSensitiveNameOf(const std::string& caseInsensitiveName) const;
 
-        std::map<std::string, std::string> m_FilenamesByUpperedFileNames;
-    };
-}  // namespace VDFS
+            std::map<std::string, std::string> m_FilenamesByUpperedFileNames;
+        };
+    }  // namespace VDFS
+}  // namespace ZenLib

--- a/zenload/DATFile.cpp
+++ b/zenload/DATFile.cpp
@@ -7,414 +7,417 @@
 #include <map>
 #include <utils/logger.h>
 
-using namespace ZenLoad;
-
-std::map<int, const char*> OP_MAP = {
-    {0, "Add"},              // a + b
-    {1, "Subract"},          // a - b
-    {2, "Multiply"},         // a * b
-    {3, "Divide"},           // a / b
-    {4, "Mod"},              // a % b
-    {5, "BinOr"},            // a | b
-    {6, "BinAnd"},           // a & b
-    {7, "Less"},             // a < b
-    {8, "Greater"},          // a > b
-    {9, "Assign"},           // a = b
-    {11, "LogOr"},           // a || b
-    {12, "LogAnd"},          // a && b
-    {13, "ShiftLeft"},       // a << b
-    {14, "ShiftRight"},      // a >> b
-    {15, "LessOrEqual"},     // a <= b
-    {16, "Equal"},           // a == b
-    {17, "NotEqual"},        // a != b
-    {18, "GreaterOrEqual"},  // a >= b
-    {19, "AssignAdd"},       // a += b (a = a + b)
-    {20, "AssignSubtract"},  // a -= b (a = a - b)
-    {21, "AssignMultiply"},  // a *= b (a = a * b)
-    {22, "AssignDivide"},    // a /= b (a = a / b)
-    {30, "Plus"},            // +a
-    {31, "Minus"},           // -a
-    {32, "Not"},             // !a
-    {33, "Negate"},          // ~a
-    {60, "Ret"},
-    {61, "Call"},
-    {62, "CallExternal"},
-    {64, "PushInt"},
-    {65, "PushVar"},
-    {67, "PushInstance"},
-    {70, "AssignString"},
-    {71, "AssignStringRef"},
-    {72, "AssignFunc"},
-    {73, "AssignFloat"},
-    {74, "AssignInstance"},
-    {75, "Jump"},
-    {76, "JumpIf"},
-    {80, "SetInstance"},
-    {245, "PushArrayVar"},  // EParOp_PushVar + EParOp_Array
-};
-
-DATFile::DATFile()
-    : m_Parser()
-    , m_Verbose(false)
+namespace ZenLib
 {
-}
+    using namespace ZenLoad;
 
-DATFile::DATFile(const std::string& file, bool verbose)
-    : m_Parser(file)
-    , m_Verbose(verbose)
-{
-    parseFile();
-}
+    std::map<int, const char*> OP_MAP = {
+        {0, "Add"},              // a + b
+        {1, "Subract"},          // a - b
+        {2, "Multiply"},         // a * b
+        {3, "Divide"},           // a / b
+        {4, "Mod"},              // a % b
+        {5, "BinOr"},            // a | b
+        {6, "BinAnd"},           // a & b
+        {7, "Less"},             // a < b
+        {8, "Greater"},          // a > b
+        {9, "Assign"},           // a = b
+        {11, "LogOr"},           // a || b
+        {12, "LogAnd"},          // a && b
+        {13, "ShiftLeft"},       // a << b
+        {14, "ShiftRight"},      // a >> b
+        {15, "LessOrEqual"},     // a <= b
+        {16, "Equal"},           // a == b
+        {17, "NotEqual"},        // a != b
+        {18, "GreaterOrEqual"},  // a >= b
+        {19, "AssignAdd"},       // a += b (a = a + b)
+        {20, "AssignSubtract"},  // a -= b (a = a - b)
+        {21, "AssignMultiply"},  // a *= b (a = a * b)
+        {22, "AssignDivide"},    // a /= b (a = a / b)
+        {30, "Plus"},            // +a
+        {31, "Minus"},           // -a
+        {32, "Not"},             // !a
+        {33, "Negate"},          // ~a
+        {60, "Ret"},
+        {61, "Call"},
+        {62, "CallExternal"},
+        {64, "PushInt"},
+        {65, "PushVar"},
+        {67, "PushInstance"},
+        {70, "AssignString"},
+        {71, "AssignStringRef"},
+        {72, "AssignFunc"},
+        {73, "AssignFloat"},
+        {74, "AssignInstance"},
+        {75, "Jump"},
+        {76, "JumpIf"},
+        {80, "SetInstance"},
+        {245, "PushArrayVar"},  // EParOp_PushVar + EParOp_Array
+    };
 
-void DATFile::parseFile()
-{
-    uint8_t version = m_Parser.readBinaryByte();
-    if (m_Verbose) LogInfo() << "DAT-Version: " << (int)version;
-
-    readSymTable();
-}
-
-void DATFile::readSymTable()
-{
-    if (m_Verbose) LogInfo() << "Reading Sym-Table...";
-
-    uint32_t count = m_Parser.readBinaryDWord();
-    m_SymTable.sortTable.resize(count);
-    m_Parser.readBinaryRaw(m_SymTable.sortTable.data(), sizeof(uint32_t) * count);
-
-    if (m_Verbose) LogInfo() << "Reading " << count << " symbols ";
-
-    // Read symbols
-    for (uint32_t i = 0; i < count; i++)
+    DATFile::DATFile()
+        : m_Parser()
+        , m_Verbose(false)
     {
-        PARSymbol s;
-        uint32_t named = m_Parser.readBinaryDWord();
-
-        if (named)
-        {
-            uint8_t b = m_Parser.readBinaryByte();
-            while (b != 0x0A)
-            {
-                if (b != 0xFF)  // FIXME: This happens at INSTANCE_HELP?
-                    s.name += b;
-
-                b = m_Parser.readBinaryByte();
-            };
-
-            if (m_Verbose) LogInfo() << "Symbol Name: " << s.name;
-        }
-
-        m_Parser.readBinaryRaw(&s.properties, sizeof(s.properties));
-
-        if (m_Verbose) LogInfo() << "Properties: "
-                                 << "Count: " << s.properties.elemProps.count
-                                 << " Type: " << s.properties.elemProps.type;
-
-        if (0 == (s.properties.elemProps.flags & EParFlag_ClassVar))
-        {
-            switch (s.properties.elemProps.type)
-            {
-                case EParType_Float:
-                    s.floatData.resize(s.properties.elemProps.count);
-                    m_Parser.readBinaryRaw(s.floatData.data(), sizeof(float) * s.floatData.size());
-
-                    if (m_Verbose)
-                        for (uint32_t j = 0; j < s.properties.elemProps.count; j++)
-                            LogInfo() << " - Float: " << s.floatData[j];
-                    break;
-
-                case EParType_Int:
-                    s.intData.resize(s.properties.elemProps.count);
-                    m_Parser.readBinaryRaw(s.intData.data(), sizeof(uint32_t) * s.intData.size());
-
-                    if (m_Verbose)
-                        for (uint32_t j = 0; j < s.properties.elemProps.count; j++)
-                            LogInfo() << " - Int: " << s.intData[j];
-                    break;
-
-                case EParType_String:
-                    s.strData.resize(s.properties.elemProps.count);
-                    for (uint32_t j = 0; j < s.properties.elemProps.count; j++)
-                    {
-                        uint8_t b = m_Parser.readBinaryByte();
-                        while (b != 0x0A)
-                        {
-                            if (b != 0xFF)  // FIXME: This happens at INSTANCE_HELP?
-                                s.strData[j] += b;
-
-                            b = m_Parser.readBinaryByte();
-                        };
-
-                        if (m_Verbose) LogInfo() << " - String[" << j << "]: " << s.strData[j];
-                    }
-
-                    break;
-
-                case EParType_Class:
-                    s.classOffset = static_cast<int32_t>(m_Parser.readBinaryDWord());
-                    if (m_Verbose) LogInfo() << " - ClassOffset: " << s.classOffset;
-                    break;
-
-                case EParType_Func:
-                case EParType_Prototype:
-                case EParType_Instance:
-                    s.address = static_cast<int32_t>(m_Parser.readBinaryDWord());
-                    if (m_Verbose) LogInfo() << " - Address: " << s.address;
-
-                    if (s.properties.elemProps.flags & EParFlag_External)
-                        if (m_Verbose) LogInfo() << "External: Address: " << s.address << " Name: " << s.name;
-                    break;
-            }
-        }
-
-        s.parent = static_cast<int32_t>(m_Parser.readBinaryDWord());
-
-        m_SymTable.symbols.push_back(s);
-
-        if (!s.name.empty())
-            m_SymTable.symbolsByName[s.name] = m_SymTable.symbols.size() - 1;
     }
 
-    readStack();
-}
-
-void DATFile::readStack()
-{
-    if (m_Verbose) LogInfo() << "Reading Stack...";
-    m_Stack.stackSize = m_Parser.readBinaryDWord();
-
-    if (m_Verbose) LogInfo() << " - " << m_Stack.stackSize << " bytes";
-
-    m_Stack.stackOffset = m_Parser.getSeek();
-
-    size_t seek = 0;
-    while (m_Parser.getSeek() < m_Parser.getFileSize())
+    DATFile::DATFile(const std::string& file, bool verbose)
+        : m_Parser(file)
+        , m_Verbose(verbose)
     {
+        parseFile();
+    }
+
+    void DATFile::parseFile()
+    {
+        uint8_t version = m_Parser.readBinaryByte();
+        if (m_Verbose) LogInfo() << "DAT-Version: " << (int)version;
+
+        readSymTable();
+    }
+
+    void DATFile::readSymTable()
+    {
+        if (m_Verbose) LogInfo() << "Reading Sym-Table...";
+
+        uint32_t count = m_Parser.readBinaryDWord();
+        m_SymTable.sortTable.resize(count);
+        m_Parser.readBinaryRaw(m_SymTable.sortTable.data(), sizeof(uint32_t) * count);
+
+        if (m_Verbose) LogInfo() << "Reading " << count << " symbols ";
+
+        // Read symbols
+        for (uint32_t i = 0; i < count; i++)
+        {
+            PARSymbol s;
+            uint32_t named = m_Parser.readBinaryDWord();
+
+            if (named)
+            {
+                uint8_t b = m_Parser.readBinaryByte();
+                while (b != 0x0A)
+                {
+                    if (b != 0xFF)  // FIXME: This happens at INSTANCE_HELP?
+                        s.name += b;
+
+                    b = m_Parser.readBinaryByte();
+                };
+
+                if (m_Verbose) LogInfo() << "Symbol Name: " << s.name;
+            }
+
+            m_Parser.readBinaryRaw(&s.properties, sizeof(s.properties));
+
+            if (m_Verbose) LogInfo() << "Properties: "
+                                     << "Count: " << s.properties.elemProps.count
+                                     << " Type: " << s.properties.elemProps.type;
+
+            if (0 == (s.properties.elemProps.flags & EParFlag_ClassVar))
+            {
+                switch (s.properties.elemProps.type)
+                {
+                    case EParType_Float:
+                        s.floatData.resize(s.properties.elemProps.count);
+                        m_Parser.readBinaryRaw(s.floatData.data(), sizeof(float) * s.floatData.size());
+
+                        if (m_Verbose)
+                            for (uint32_t j = 0; j < s.properties.elemProps.count; j++)
+                                LogInfo() << " - Float: " << s.floatData[j];
+                        break;
+
+                    case EParType_Int:
+                        s.intData.resize(s.properties.elemProps.count);
+                        m_Parser.readBinaryRaw(s.intData.data(), sizeof(uint32_t) * s.intData.size());
+
+                        if (m_Verbose)
+                            for (uint32_t j = 0; j < s.properties.elemProps.count; j++)
+                                LogInfo() << " - Int: " << s.intData[j];
+                        break;
+
+                    case EParType_String:
+                        s.strData.resize(s.properties.elemProps.count);
+                        for (uint32_t j = 0; j < s.properties.elemProps.count; j++)
+                        {
+                            uint8_t b = m_Parser.readBinaryByte();
+                            while (b != 0x0A)
+                            {
+                                if (b != 0xFF)  // FIXME: This happens at INSTANCE_HELP?
+                                    s.strData[j] += b;
+
+                                b = m_Parser.readBinaryByte();
+                            };
+
+                            if (m_Verbose) LogInfo() << " - String[" << j << "]: " << s.strData[j];
+                        }
+
+                        break;
+
+                    case EParType_Class:
+                        s.classOffset = static_cast<int32_t>(m_Parser.readBinaryDWord());
+                        if (m_Verbose) LogInfo() << " - ClassOffset: " << s.classOffset;
+                        break;
+
+                    case EParType_Func:
+                    case EParType_Prototype:
+                    case EParType_Instance:
+                        s.address = static_cast<int32_t>(m_Parser.readBinaryDWord());
+                        if (m_Verbose) LogInfo() << " - Address: " << s.address;
+
+                        if (s.properties.elemProps.flags & EParFlag_External)
+                            if (m_Verbose) LogInfo() << "External: Address: " << s.address << " Name: " << s.name;
+                        break;
+                }
+            }
+
+            s.parent = static_cast<int32_t>(m_Parser.readBinaryDWord());
+
+            m_SymTable.symbols.push_back(s);
+
+            if (!s.name.empty())
+                m_SymTable.symbolsByName[s.name] = m_SymTable.symbols.size() - 1;
+        }
+
+        readStack();
+    }
+
+    void DATFile::readStack()
+    {
+        if (m_Verbose) LogInfo() << "Reading Stack...";
+        m_Stack.stackSize = m_Parser.readBinaryDWord();
+
+        if (m_Verbose) LogInfo() << " - " << m_Stack.stackSize << " bytes";
+
+        m_Stack.stackOffset = m_Parser.getSeek();
+
+        size_t seek = 0;
+        while (m_Parser.getSeek() < m_Parser.getFileSize())
+        {
+            PARStackOpCode s;
+            memset(&s, 0, sizeof(s));
+            s.op = static_cast<EParOp>(m_Parser.readBinaryByte());
+
+            std::stringstream sss;
+            sss << seek << ": " << OP_MAP[s.op];
+
+            std::string ss = sss.str();
+
+            seek += sizeof(uint8_t);
+
+            switch (s.op)
+            {
+                case EParOp_Call:
+                    s.address = m_Parser.readBinaryDWord();
+                    seek += sizeof(int32_t);
+
+                    if (m_Verbose) LogInfo() << ss << " - address: " << s.address;
+                    break;
+
+                case EParOp_CallExternal:
+                    s.symbol = m_Parser.readBinaryDWord();
+                    seek += sizeof(int32_t);
+
+                    if (m_Verbose) LogInfo() << ss << " - symbol: " << s.symbol << " (" << m_SymTable.symbols[s.symbol].name << ")";
+                    break;
+
+                case EParOp_PushInt:
+                    s.value = m_Parser.readBinaryDWord();
+                    seek += sizeof(int32_t);
+
+                    if (m_Verbose) LogInfo() << ss << " - value: " << s.value;
+                    break;
+
+                case EParOp_PushVar:
+                    s.symbol = m_Parser.readBinaryDWord();
+                    seek += sizeof(int32_t);
+
+                    if (m_Verbose) LogInfo() << ss << " - symbol: " << s.symbol << " (" << m_SymTable.symbols[s.symbol].name << ")";
+                    break;
+
+                case EParOp_PushInstance:
+                    s.symbol = m_Parser.readBinaryDWord();
+                    seek += sizeof(int32_t);
+
+                    if (m_Verbose) LogInfo() << ss << " - symbol: " << s.symbol << " (" << m_SymTable.symbols[s.symbol].name << ")";
+                    break;
+
+                case EParOp_Jump:
+                    s.address = m_Parser.readBinaryDWord();
+                    seek += sizeof(int32_t);
+
+                    if (m_Verbose) LogInfo() << ss << " - address: " << s.address;
+                    break;
+
+                case EParOp_JumpIf:
+                    s.address = m_Parser.readBinaryDWord();
+                    seek += sizeof(int32_t);
+
+                    if (m_Verbose) LogInfo() << ss << " - address: " << s.address;
+                    break;
+
+                case EParOp_SetInstance:
+                    s.symbol = m_Parser.readBinaryDWord();
+                    seek += sizeof(int32_t);
+
+                    if (m_Verbose) LogInfo() << ss << " - symbol: " << s.symbol << " (" << m_SymTable.symbols[s.symbol].name << ")";
+                    break;
+
+                case EParOp_PushArrayVar:
+                    s.symbol = m_Parser.readBinaryDWord();
+                    seek += sizeof(int32_t);
+
+                    s.index = m_Parser.readBinaryByte();
+                    seek += sizeof(uint8_t);
+
+                    break;
+                default:
+                    if (m_Verbose) LogInfo() << ss;
+            }
+        }
+    }
+
+    PARSymbol& DATFile::getSymbolByName(const std::string& symName)
+    {
+        std::string n = std::string(symName);
+        std::transform(n.begin(), n.end(), n.begin(), ::toupper);
+
+        return m_SymTable.symbols[m_SymTable.symbolsByName[n]];
+    }
+
+    bool DATFile::hasSymbolName(const std::string& symName)
+    {
+        std::string n = std::string(symName);
+        std::transform(n.begin(), n.end(), n.begin(), ::toupper);
+
+        return m_SymTable.symbolsByName.find(n) != m_SymTable.symbolsByName.end();
+    }
+
+    size_t DATFile::getSymbolIndexByName(const std::string& symName)
+    {
+        std::string n = std::string(symName);
+        std::transform(n.begin(), n.end(), n.begin(), ::toupper);
+
+        return m_SymTable.symbolsByName[n];
+    }
+
+    PARSymbol& DATFile::getSymbolByIndex(size_t idx)
+    {
+        assert(idx < m_SymTable.symbols.size());
+        return m_SymTable.symbols[idx];
+    }
+
+    PARStackOpCode DATFile::getStackOpCode(size_t pc)
+    {
+        m_Parser.setSeek(m_Stack.stackOffset + pc);
+
         PARStackOpCode s;
-        memset(&s, 0, sizeof(s));
         s.op = static_cast<EParOp>(m_Parser.readBinaryByte());
 
-        std::stringstream sss;
-        sss << seek << ": " << OP_MAP[s.op];
-
-        std::string ss = sss.str();
-
-        seek += sizeof(uint8_t);
+        s.opSize = sizeof(uint8_t);
 
         switch (s.op)
         {
             case EParOp_Call:
                 s.address = m_Parser.readBinaryDWord();
-                seek += sizeof(int32_t);
+                s.opSize += sizeof(int32_t);
 
-                if (m_Verbose) LogInfo() << ss << " - address: " << s.address;
+                if (m_Verbose) LogInfo() << "    - address: " << s.address;
                 break;
 
             case EParOp_CallExternal:
                 s.symbol = m_Parser.readBinaryDWord();
-                seek += sizeof(int32_t);
+                s.opSize += sizeof(int32_t);
 
-                if (m_Verbose) LogInfo() << ss << " - symbol: " << s.symbol << " (" << m_SymTable.symbols[s.symbol].name << ")";
+                if (m_Verbose) LogInfo() << "    - symbol: " << s.symbol << " (" << m_SymTable.symbols[s.symbol].name << ")";
                 break;
 
             case EParOp_PushInt:
                 s.value = m_Parser.readBinaryDWord();
-                seek += sizeof(int32_t);
+                s.opSize += sizeof(int32_t);
 
-                if (m_Verbose) LogInfo() << ss << " - value: " << s.value;
+                if (m_Verbose) LogInfo() << "    - value: " << s.value;
                 break;
 
             case EParOp_PushVar:
                 s.symbol = m_Parser.readBinaryDWord();
-                seek += sizeof(int32_t);
+                s.opSize += sizeof(int32_t);
 
-                if (m_Verbose) LogInfo() << ss << " - symbol: " << s.symbol << " (" << m_SymTable.symbols[s.symbol].name << ")";
+                if (m_Verbose) LogInfo() << "    - symbol: " << s.symbol << " (" << m_SymTable.symbols[s.symbol].name << ")";
                 break;
 
             case EParOp_PushInstance:
                 s.symbol = m_Parser.readBinaryDWord();
-                seek += sizeof(int32_t);
+                s.opSize += sizeof(int32_t);
 
-                if (m_Verbose) LogInfo() << ss << " - symbol: " << s.symbol << " (" << m_SymTable.symbols[s.symbol].name << ")";
+                if (m_Verbose) LogInfo() << "    - symbol: " << s.symbol << " (" << m_SymTable.symbols[s.symbol].name << ")";
                 break;
 
             case EParOp_Jump:
                 s.address = m_Parser.readBinaryDWord();
-                seek += sizeof(int32_t);
+                s.opSize += sizeof(int32_t);
 
-                if (m_Verbose) LogInfo() << ss << " - address: " << s.address;
+                if (m_Verbose) LogInfo() << "    - address: " << s.address;
                 break;
 
             case EParOp_JumpIf:
                 s.address = m_Parser.readBinaryDWord();
-                seek += sizeof(int32_t);
+                s.opSize += sizeof(int32_t);
 
-                if (m_Verbose) LogInfo() << ss << " - address: " << s.address;
+                if (m_Verbose) LogInfo() << "    - address: " << s.address;
                 break;
 
             case EParOp_SetInstance:
                 s.symbol = m_Parser.readBinaryDWord();
-                seek += sizeof(int32_t);
+                s.opSize += sizeof(int32_t);
 
-                if (m_Verbose) LogInfo() << ss << " - symbol: " << s.symbol << " (" << m_SymTable.symbols[s.symbol].name << ")";
+                if (m_Verbose) LogInfo() << "    - symbol: " << s.symbol << " (" << m_SymTable.symbols[s.symbol].name << ")";
                 break;
 
             case EParOp_PushArrayVar:
                 s.symbol = m_Parser.readBinaryDWord();
-                seek += sizeof(int32_t);
+                s.opSize += sizeof(int32_t);
 
                 s.index = m_Parser.readBinaryByte();
-                seek += sizeof(uint8_t);
+                s.opSize += sizeof(uint8_t);
 
                 break;
             default:
-                if (m_Verbose) LogInfo() << ss;
+                break;
         }
-    }
-}
 
-PARSymbol& DATFile::getSymbolByName(const std::string& symName)
-{
-    std::string n = std::string(symName);
-    std::transform(n.begin(), n.end(), n.begin(), ::toupper);
-
-    return m_SymTable.symbols[m_SymTable.symbolsByName[n]];
-}
-
-bool DATFile::hasSymbolName(const std::string& symName)
-{
-    std::string n = std::string(symName);
-    std::transform(n.begin(), n.end(), n.begin(), ::toupper);
-
-    return m_SymTable.symbolsByName.find(n) != m_SymTable.symbolsByName.end();
-}
-
-size_t DATFile::getSymbolIndexByName(const std::string& symName)
-{
-    std::string n = std::string(symName);
-    std::transform(n.begin(), n.end(), n.begin(), ::toupper);
-
-    return m_SymTable.symbolsByName[n];
-}
-
-PARSymbol& DATFile::getSymbolByIndex(size_t idx)
-{
-    assert(idx < m_SymTable.symbols.size());
-    return m_SymTable.symbols[idx];
-}
-
-PARStackOpCode DATFile::getStackOpCode(size_t pc)
-{
-    m_Parser.setSeek(m_Stack.stackOffset + pc);
-
-    PARStackOpCode s;
-    s.op = static_cast<EParOp>(m_Parser.readBinaryByte());
-
-    s.opSize = sizeof(uint8_t);
-
-    switch (s.op)
-    {
-        case EParOp_Call:
-            s.address = m_Parser.readBinaryDWord();
-            s.opSize += sizeof(int32_t);
-
-            if (m_Verbose) LogInfo() << "    - address: " << s.address;
-            break;
-
-        case EParOp_CallExternal:
-            s.symbol = m_Parser.readBinaryDWord();
-            s.opSize += sizeof(int32_t);
-
-            if (m_Verbose) LogInfo() << "    - symbol: " << s.symbol << " (" << m_SymTable.symbols[s.symbol].name << ")";
-            break;
-
-        case EParOp_PushInt:
-            s.value = m_Parser.readBinaryDWord();
-            s.opSize += sizeof(int32_t);
-
-            if (m_Verbose) LogInfo() << "    - value: " << s.value;
-            break;
-
-        case EParOp_PushVar:
-            s.symbol = m_Parser.readBinaryDWord();
-            s.opSize += sizeof(int32_t);
-
-            if (m_Verbose) LogInfo() << "    - symbol: " << s.symbol << " (" << m_SymTable.symbols[s.symbol].name << ")";
-            break;
-
-        case EParOp_PushInstance:
-            s.symbol = m_Parser.readBinaryDWord();
-            s.opSize += sizeof(int32_t);
-
-            if (m_Verbose) LogInfo() << "    - symbol: " << s.symbol << " (" << m_SymTable.symbols[s.symbol].name << ")";
-            break;
-
-        case EParOp_Jump:
-            s.address = m_Parser.readBinaryDWord();
-            s.opSize += sizeof(int32_t);
-
-            if (m_Verbose) LogInfo() << "    - address: " << s.address;
-            break;
-
-        case EParOp_JumpIf:
-            s.address = m_Parser.readBinaryDWord();
-            s.opSize += sizeof(int32_t);
-
-            if (m_Verbose) LogInfo() << "    - address: " << s.address;
-            break;
-
-        case EParOp_SetInstance:
-            s.symbol = m_Parser.readBinaryDWord();
-            s.opSize += sizeof(int32_t);
-
-            if (m_Verbose) LogInfo() << "    - symbol: " << s.symbol << " (" << m_SymTable.symbols[s.symbol].name << ")";
-            break;
-
-        case EParOp_PushArrayVar:
-            s.symbol = m_Parser.readBinaryDWord();
-            s.opSize += sizeof(int32_t);
-
-            s.index = m_Parser.readBinaryByte();
-            s.opSize += sizeof(uint8_t);
-
-            break;
-        default:
-            break;
+        return s;
     }
 
-    return s;
-}
-
-size_t DATFile::addSymbol()
-{
-    m_SymTable.symbols.emplace_back();
-    return m_SymTable.symbols.size() - 1;
-}
-
-void DATFile::iterateSymbolsOfClass(const std::string& className, std::function<void(size_t, PARSymbol&)> callback)
-{
-    constexpr auto none = uint32_t{0xFFFFFFFF};
-
-    // First, find the parent-symbol
-    size_t baseSym = getSymbolIndexByName(className);
-
-    for (size_t i = 0; i < m_SymTable.symbols.size(); i++)
+    size_t DATFile::addSymbol()
     {
-        PARSymbol& s = getSymbolByIndex(i);
-        if (s.parent == none || s.properties.elemProps.type != EParType_Instance)
-            continue;
+        m_SymTable.symbols.emplace_back();
+        return m_SymTable.symbols.size() - 1;
+    }
 
-        PARSymbol& p = getSymbolByIndex(s.parent);
-        uint32_t pBase = s.parent;
+    void DATFile::iterateSymbolsOfClass(const std::string& className, std::function<void(size_t, PARSymbol&)> callback)
+    {
+        constexpr auto none = uint32_t{0xFFFFFFFF};
 
-        // In case this is also just a prototype, go deeper one more level
-        if (p.properties.elemProps.type == EParType_Prototype && p.parent != none)
+        // First, find the parent-symbol
+        size_t baseSym = getSymbolIndexByName(className);
+
+        for (size_t i = 0; i < m_SymTable.symbols.size(); i++)
         {
-            pBase = p.parent;
-        }
+            PARSymbol& s = getSymbolByIndex(i);
+            if (s.parent == none || s.properties.elemProps.type != EParType_Instance)
+                continue;
 
-        // If the parent-classes match, we found an instance of our class
-        if (baseSym == pBase)
-            callback(i, s);
+            PARSymbol& p = getSymbolByIndex(s.parent);
+            uint32_t pBase = s.parent;
+
+            // In case this is also just a prototype, go deeper one more level
+            if (p.properties.elemProps.type == EParType_Prototype && p.parent != none)
+            {
+                pBase = p.parent;
+            }
+
+            // If the parent-classes match, we found an instance of our class
+            if (baseSym == pBase)
+                callback(i, s);
+        }
     }
-}
+}  // namespace ZenLib

--- a/zenload/DATFile.h
+++ b/zenload/DATFile.h
@@ -5,328 +5,331 @@
 #include "zenParser.h"
 #include <utils/staticReferencedAllocator.h>
 
-namespace ZenLoad
+namespace ZenLib
 {
-    enum EInstanceClass
+    namespace ZenLoad
     {
-        IC_Npc,
-        IC_Mission,
-        IC_Info,
-        IC_Item,
-        IC_ItemReact,
-        IC_Focus
-    };
-
-    enum EParFlag
-    {
-        EParFlag_Const = 1 << 0,
-        EParFlag_Return = 1 << 1,
-        EParFlag_ClassVar = 1 << 2,
-        EParFlag_External = 1 << 3,
-        EParFlag_Merged = 1 << 4
-    };
-
-    enum EParType
-    {
-        EParType_Void = 0,
-        EParType_Float = 1,
-        EParType_Int = 2,
-        EParType_String = 3,
-        EParType_Class = 4,
-        EParType_Func = 5,
-        EParType_Prototype = 6,
-        EParType_Instance = 7
-    };
-
-    enum EParOp : uint8_t
-    {
-        EParOp_Add = 0,              // a + b
-        EParOp_Subract = 1,          // a - b
-        EParOp_Multiply = 2,         // a * b
-        EParOp_Divide = 3,           // a / b
-        EParOp_Mod = 4,              // a % b
-        EParOp_BinOr = 5,            // a | b
-        EParOp_BinAnd = 6,           // a & b
-        EParOp_Less = 7,             // a < b
-        EParOp_Greater = 8,          // a > b
-        EParOp_Assign = 9,           // a = b
-        EParOp_LogOr = 11,           // a || b
-        EParOp_LogAnd = 12,          // a && b
-        EParOp_ShiftLeft = 13,       // a << b
-        EParOp_ShiftRight = 14,      // a >> b
-        EParOp_LessOrEqual = 15,     // a <= b
-        EParOp_Equal = 16,           // a == b
-        EParOp_NotEqual = 17,        // a != b
-        EParOp_GreaterOrEqual = 18,  // a >= b
-        EParOp_AssignAdd = 19,       // a += b (a = a + b)
-        EParOp_AssignSubtract = 20,  // a -= b (a = a - b)
-        EParOp_AssignMultiply = 21,  // a *= b (a = a * b)
-        EParOp_AssignDivide = 22,    // a /= b (a = a / b)
-        EParOp_Plus = 30,            // +a
-        EParOp_Minus = 31,           // -a
-        EParOp_Not = 32,             // !a
-        EParOp_Negate = 33,          // ~a
-                                     //	EParOp_LeftBracket     = 40,    // '('
-                                     //	EParOp_RightBracket    = 41,    // ')'
-                                     //	EParOp_Semicolon       = 42,    // ';'
-                                     //	EParOp_Comma           = 43,    // ','
-                                     //	EParOp_CurlyBracket    = 44,    // '{', '}'
-                                     //	EParOp_None            = 45,
-                                     //	EParOp_Float           = 51,
-                                     //	EParOp_Var             = 52,
-                                     //	EParOp_Operator        = 53,
-        EParOp_Ret = 60,
-        EParOp_Call = 61,
-        EParOp_CallExternal = 62,
-        //	EParOp_PopInt          = 63,
-        EParOp_PushInt = 64,
-        EParOp_PushVar = 65,
-        //	EParOp_PushString      = 66,
-        EParOp_PushInstance = 67,
-        //	EParOp_PushIndex       = 68,
-        //	EParOp_PopVar          = 69,
-        EParOp_AssignString = 70,
-        EParOp_AssignStringRef = 71,
-        EParOp_AssignFunc = 72,
-        EParOp_AssignFloat = 73,
-        EParOp_AssignInstance = 74,
-        EParOp_Jump = 75,
-        EParOp_JumpIf = 76,
-        EParOp_SetInstance = 80,
-        //	EParOp_Skip            = 90,
-        //	EParOp_Label           = 91,
-        //	EParOp_Func            = 92,
-        //	EParOp_FuncEnd         = 93,
-        //	EParOp_Class           = 94,
-        //	EParOp_ClassEnd        = 95,
-        //	EParOp_Instance        = 96,
-        //	EParOp_InstanceEnd     = 97,
-        //	EParOp_String          = 98,
-        //	EParOp_Array           = 180,  // EParOp_Var + 128
-        EParOp_PushArrayVar = 245  // EParOp_PushVar + EParOp_Array
-    };
-
-    struct PARSymbol
-    {
-        PARSymbol()
+        enum EInstanceClass
         {
-            dataOffset = -1;
-            instanceDataHandle.invalidate();
-            instanceDataClass = IC_Npc;
-        }
+            IC_Npc,
+            IC_Mission,
+            IC_Info,
+            IC_Item,
+            IC_ItemReact,
+            IC_Focus
+        };
 
-        std::string name;
-
-        struct Properties
+        enum EParFlag
         {
-            int32_t offClsRet;  // Offset (ClassVar) | Size (Class) | ReturnType (Func)
-            struct
-            {
-                uint32_t count : 12;  // Count:12, Type:4 (EParType_), Flags:6 (EParFlag_), Space: 1, Reserved:9
-                uint32_t type : 4;    // EParType_*
-                uint32_t flags : 6;   // EParFlag_*
-                uint32_t space : 1;
-                uint32_t reserved : 9;
-            } elemProps;
+            EParFlag_Const = 1 << 0,
+            EParFlag_Return = 1 << 1,
+            EParFlag_ClassVar = 1 << 2,
+            EParFlag_External = 1 << 3,
+            EParFlag_Merged = 1 << 4
+        };
 
-            struct
-            {
-                uint32_t value : 19;  // Value:19, Reserved:13
-                uint32_t reserved : 13;
-            } fileIndex;
-
-            struct
-            {
-                uint32_t value : 19;  // Value:19, Reserved:13
-                uint32_t reserved : 13;
-            } lineStart;
-
-            struct
-            {
-                uint32_t value : 19;  // Value:19, Reserved:13
-                uint32_t reserved : 13;
-            } lineCount;
-
-            struct
-            {
-                uint32_t value : 24;  // Value:24, Reserved:8
-                uint32_t reserved : 8;
-            } charStart;
-
-            struct
-            {
-                uint32_t value : 24;  // Value:24, Reserved:8
-                uint32_t reserved : 8;
-            } charCount;
-
-        } properties;
-
-        std::vector<float> floatData;
-        std::vector<int32_t> intData;
-        std::vector<std::string> strData;
-        int32_t classOffset;
-        uint32_t address;
-
-        int32_t dataOffset;  // Not stored in files, only valid for classes to directly write to engine memory
-        void* instanceData;  // Not stored in files, only valid for classes to directly write to engine memory
-        ZMemory::BigHandle instanceDataHandle;
-        EInstanceClass instanceDataClass;
-
-        uint32_t parent;  // 0xFFFFFFFF (-1) = none
-
-        int32_t* getIntAddr(size_t idx = 0, void* baseAddr = nullptr)
+        enum EParType
         {
-            if (baseAddr && dataOffset != -1)
-                return reinterpret_cast<int32_t*>(reinterpret_cast<char*>(baseAddr) + dataOffset + (sizeof(int32_t) * idx));
+            EParType_Void = 0,
+            EParType_Float = 1,
+            EParType_Int = 2,
+            EParType_String = 3,
+            EParType_Class = 4,
+            EParType_Func = 5,
+            EParType_Prototype = 6,
+            EParType_Instance = 7
+        };
 
-            if (intData.size() <= idx) intData.resize(idx + 1);
-            return &intData[idx];
-        }
-
-        std::string* getStrAddr(size_t idx = 0, void* baseAddr = nullptr)
+        enum EParOp : uint8_t
         {
-            if (baseAddr && dataOffset != -1)
-                return reinterpret_cast<std::string*>(reinterpret_cast<char*>(baseAddr) + dataOffset + (sizeof(std::string) * idx));
+            EParOp_Add = 0,              // a + b
+            EParOp_Subract = 1,          // a - b
+            EParOp_Multiply = 2,         // a * b
+            EParOp_Divide = 3,           // a / b
+            EParOp_Mod = 4,              // a % b
+            EParOp_BinOr = 5,            // a | b
+            EParOp_BinAnd = 6,           // a & b
+            EParOp_Less = 7,             // a < b
+            EParOp_Greater = 8,          // a > b
+            EParOp_Assign = 9,           // a = b
+            EParOp_LogOr = 11,           // a || b
+            EParOp_LogAnd = 12,          // a && b
+            EParOp_ShiftLeft = 13,       // a << b
+            EParOp_ShiftRight = 14,      // a >> b
+            EParOp_LessOrEqual = 15,     // a <= b
+            EParOp_Equal = 16,           // a == b
+            EParOp_NotEqual = 17,        // a != b
+            EParOp_GreaterOrEqual = 18,  // a >= b
+            EParOp_AssignAdd = 19,       // a += b (a = a + b)
+            EParOp_AssignSubtract = 20,  // a -= b (a = a - b)
+            EParOp_AssignMultiply = 21,  // a *= b (a = a * b)
+            EParOp_AssignDivide = 22,    // a /= b (a = a / b)
+            EParOp_Plus = 30,            // +a
+            EParOp_Minus = 31,           // -a
+            EParOp_Not = 32,             // !a
+            EParOp_Negate = 33,          // ~a
+                                         //	EParOp_LeftBracket     = 40,    // '('
+                                         //	EParOp_RightBracket    = 41,    // ')'
+                                         //	EParOp_Semicolon       = 42,    // ';'
+                                         //	EParOp_Comma           = 43,    // ','
+                                         //	EParOp_CurlyBracket    = 44,    // '{', '}'
+                                         //	EParOp_None            = 45,
+                                         //	EParOp_Float           = 51,
+                                         //	EParOp_Var             = 52,
+                                         //	EParOp_Operator        = 53,
+            EParOp_Ret = 60,
+            EParOp_Call = 61,
+            EParOp_CallExternal = 62,
+            //	EParOp_PopInt          = 63,
+            EParOp_PushInt = 64,
+            EParOp_PushVar = 65,
+            //	EParOp_PushString      = 66,
+            EParOp_PushInstance = 67,
+            //	EParOp_PushIndex       = 68,
+            //	EParOp_PopVar          = 69,
+            EParOp_AssignString = 70,
+            EParOp_AssignStringRef = 71,
+            EParOp_AssignFunc = 72,
+            EParOp_AssignFloat = 73,
+            EParOp_AssignInstance = 74,
+            EParOp_Jump = 75,
+            EParOp_JumpIf = 76,
+            EParOp_SetInstance = 80,
+            //	EParOp_Skip            = 90,
+            //	EParOp_Label           = 91,
+            //	EParOp_Func            = 92,
+            //	EParOp_FuncEnd         = 93,
+            //	EParOp_Class           = 94,
+            //	EParOp_ClassEnd        = 95,
+            //	EParOp_Instance        = 96,
+            //	EParOp_InstanceEnd     = 97,
+            //	EParOp_String          = 98,
+            //	EParOp_Array           = 180,  // EParOp_Var + 128
+            EParOp_PushArrayVar = 245  // EParOp_PushVar + EParOp_Array
+        };
 
-            if (strData.size() <= idx) strData.resize(idx + 1);
-            return &strData[idx];
-        }
-
-        int32_t getIntValue(size_t idx = 0, void* baseAddr = nullptr)
+        struct PARSymbol
         {
-            if (baseAddr && dataOffset != -1)
-                return *reinterpret_cast<int32_t*>(reinterpret_cast<char*>(baseAddr) + dataOffset + (sizeof(int32_t) * idx));
-
-            if (intData.size() <= idx) intData.resize(idx + 1);
-            return intData[idx];
-        }
-
-        void set(int32_t v, size_t idx = 0, void* baseAddr = nullptr)
-        {
-            switch (properties.elemProps.type)
+            PARSymbol()
             {
-                case EParType_Int:
-                    if (intData.size() <= idx) intData.resize(idx + 1);
-                    intData[idx] = v;
-
-                    if (baseAddr && dataOffset != -1)
-                        *reinterpret_cast<int32_t*>(reinterpret_cast<char*>(baseAddr) + dataOffset + (sizeof(int32_t) * idx)) = v;
-                    break;
-
-                case EParType_Float:
-                    if (floatData.size() <= idx) floatData.resize(idx + 1);
-                    floatData[idx] = *reinterpret_cast<float*>(&v);
-
-                    if (baseAddr && dataOffset != -1)
-                        *reinterpret_cast<float*>(reinterpret_cast<char*>(baseAddr) + dataOffset + (sizeof(float) * idx)) = *reinterpret_cast<float*>(&v);
-                    break;
-
-                case EParType_Func:
-                    address = v;
-
-                    if (baseAddr && dataOffset != -1)
-                        *reinterpret_cast<int32_t*>(reinterpret_cast<char*>(baseAddr) + dataOffset + (sizeof(int32_t) * idx)) = v;
-                    break;
+                dataOffset = -1;
+                instanceDataHandle.invalidate();
+                instanceDataClass = IC_Npc;
             }
-        }
 
-        void set(const std::string& v, size_t idx = 0, void* baseAddr = nullptr)
+            std::string name;
+
+            struct Properties
+            {
+                int32_t offClsRet;  // Offset (ClassVar) | Size (Class) | ReturnType (Func)
+                struct
+                {
+                    uint32_t count : 12;  // Count:12, Type:4 (EParType_), Flags:6 (EParFlag_), Space: 1, Reserved:9
+                    uint32_t type : 4;    // EParType_*
+                    uint32_t flags : 6;   // EParFlag_*
+                    uint32_t space : 1;
+                    uint32_t reserved : 9;
+                } elemProps;
+
+                struct
+                {
+                    uint32_t value : 19;  // Value:19, Reserved:13
+                    uint32_t reserved : 13;
+                } fileIndex;
+
+                struct
+                {
+                    uint32_t value : 19;  // Value:19, Reserved:13
+                    uint32_t reserved : 13;
+                } lineStart;
+
+                struct
+                {
+                    uint32_t value : 19;  // Value:19, Reserved:13
+                    uint32_t reserved : 13;
+                } lineCount;
+
+                struct
+                {
+                    uint32_t value : 24;  // Value:24, Reserved:8
+                    uint32_t reserved : 8;
+                } charStart;
+
+                struct
+                {
+                    uint32_t value : 24;  // Value:24, Reserved:8
+                    uint32_t reserved : 8;
+                } charCount;
+
+            } properties;
+
+            std::vector<float> floatData;
+            std::vector<int32_t> intData;
+            std::vector<std::string> strData;
+            int32_t classOffset;
+            uint32_t address;
+
+            int32_t dataOffset;  // Not stored in files, only valid for classes to directly write to engine memory
+            void* instanceData;  // Not stored in files, only valid for classes to directly write to engine memory
+            ZMemory::BigHandle instanceDataHandle;
+            EInstanceClass instanceDataClass;
+
+            uint32_t parent;  // 0xFFFFFFFF (-1) = none
+
+            int32_t* getIntAddr(size_t idx = 0, void* baseAddr = nullptr)
+            {
+                if (baseAddr && dataOffset != -1)
+                    return reinterpret_cast<int32_t*>(reinterpret_cast<char*>(baseAddr) + dataOffset + (sizeof(int32_t) * idx));
+
+                if (intData.size() <= idx) intData.resize(idx + 1);
+                return &intData[idx];
+            }
+
+            std::string* getStrAddr(size_t idx = 0, void* baseAddr = nullptr)
+            {
+                if (baseAddr && dataOffset != -1)
+                    return reinterpret_cast<std::string*>(reinterpret_cast<char*>(baseAddr) + dataOffset + (sizeof(std::string) * idx));
+
+                if (strData.size() <= idx) strData.resize(idx + 1);
+                return &strData[idx];
+            }
+
+            int32_t getIntValue(size_t idx = 0, void* baseAddr = nullptr)
+            {
+                if (baseAddr && dataOffset != -1)
+                    return *reinterpret_cast<int32_t*>(reinterpret_cast<char*>(baseAddr) + dataOffset + (sizeof(int32_t) * idx));
+
+                if (intData.size() <= idx) intData.resize(idx + 1);
+                return intData[idx];
+            }
+
+            void set(int32_t v, size_t idx = 0, void* baseAddr = nullptr)
+            {
+                switch (properties.elemProps.type)
+                {
+                    case EParType_Int:
+                        if (intData.size() <= idx) intData.resize(idx + 1);
+                        intData[idx] = v;
+
+                        if (baseAddr && dataOffset != -1)
+                            *reinterpret_cast<int32_t*>(reinterpret_cast<char*>(baseAddr) + dataOffset + (sizeof(int32_t) * idx)) = v;
+                        break;
+
+                    case EParType_Float:
+                        if (floatData.size() <= idx) floatData.resize(idx + 1);
+                        floatData[idx] = *reinterpret_cast<float*>(&v);
+
+                        if (baseAddr && dataOffset != -1)
+                            *reinterpret_cast<float*>(reinterpret_cast<char*>(baseAddr) + dataOffset + (sizeof(float) * idx)) = *reinterpret_cast<float*>(&v);
+                        break;
+
+                    case EParType_Func:
+                        address = v;
+
+                        if (baseAddr && dataOffset != -1)
+                            *reinterpret_cast<int32_t*>(reinterpret_cast<char*>(baseAddr) + dataOffset + (sizeof(int32_t) * idx)) = v;
+                        break;
+                }
+            }
+
+            void set(const std::string& v, size_t idx = 0, void* baseAddr = nullptr)
+            {
+                if (strData.size() <= idx) strData.resize(idx + 1);
+                strData[idx] = v;
+
+                if (baseAddr && dataOffset != -1)
+                    *reinterpret_cast<std::string*>(reinterpret_cast<char*>(baseAddr) + dataOffset + (sizeof(float) * idx)) = v;
+            }
+
+            bool isDataSame(const PARSymbol& other) const
+            {
+                return intData == other.intData && floatData == other.floatData && strData == other.strData;
+            }
+        };
+
+        struct PARSymTable
         {
-            if (strData.size() <= idx) strData.resize(idx + 1);
-            strData[idx] = v;
+            std::vector<uint32_t> sortTable;
+            std::vector<PARSymbol> symbols;
+            std::unordered_map<std::string, size_t> symbolsByName;
+        };
 
-            if (baseAddr && dataOffset != -1)
-                *reinterpret_cast<std::string*>(reinterpret_cast<char*>(baseAddr) + dataOffset + (sizeof(float) * idx)) = v;
-        }
-
-        bool isDataSame(const PARSymbol& other) const
+        struct PARStack
         {
-            return intData == other.intData && floatData == other.floatData && strData == other.strData;
-        }
-    };
+            size_t stackOffset;
+            size_t stackSize;
+        };
 
-    struct PARSymTable
-    {
-        std::vector<uint32_t> sortTable;
-        std::vector<PARSymbol> symbols;
-        std::unordered_map<std::string, size_t> symbolsByName;
-    };
+        struct PARStackOpCode
+        {
+            EParOp op;
 
-    struct PARStack
-    {
-        size_t stackOffset;
-        size_t stackSize;
-    };
-
-    struct PARStackOpCode
-    {
-        EParOp op;
-
-        /**
+            /**
          * These are valid depending on "op"
          */
-        int32_t address;  // EParOp_Call, EParOp_Jump, EParOp_JumpIf,
-        int32_t symbol;   // EParOp_CallExternal, EParOp_PushVar, EParOp_PushInstance, EParOp_SetInstance, EParOp_PushArrayVar
-        int32_t value;    // EParOp_PushInt
-        uint8_t index;    // EParOp_PushArrayVar
+            int32_t address;  // EParOp_Call, EParOp_Jump, EParOp_JumpIf,
+            int32_t symbol;   // EParOp_CallExternal, EParOp_PushVar, EParOp_PushInstance, EParOp_SetInstance, EParOp_PushArrayVar
+            int32_t value;    // EParOp_PushInt
+            uint8_t index;    // EParOp_PushArrayVar
 
-        size_t opSize;  // Size of this operation
-    };
+            size_t opSize;  // Size of this operation
+        };
 
-    struct PARInstance
-    {
-        std::map<std::string, uint32_t> symbolsByName;
-    };
+        struct PARInstance
+        {
+            std::map<std::string, uint32_t> symbolsByName;
+        };
 
-    class DATFile
-    {
-    public:
-        DATFile();
-        DATFile(const std::string& file, bool verbose = false);
+        class DATFile
+        {
+        public:
+            DATFile();
+            DATFile(const std::string& file, bool verbose = false);
 
-        void parseFile();
+            void parseFile();
 
-        /**
+            /**
 		 * @return True, when a symbol with the given name exists
 		 */
-        bool hasSymbolName(const std::string& symName);
+            bool hasSymbolName(const std::string& symName);
 
-        /**
+            /**
 		 * @return The symbol connected to the given name
 		 */
-        PARSymbol& getSymbolByName(const std::string& symName);
-        size_t getSymbolIndexByName(const std::string& symName);
-        PARSymbol& getSymbolByIndex(size_t idx);
+            PARSymbol& getSymbolByName(const std::string& symName);
+            size_t getSymbolIndexByName(const std::string& symName);
+            PARSymbol& getSymbolByIndex(size_t idx);
 
-        /**
+            /**
 		 * Goes through all symbols and calls the given callback for every instance of the specified class
 		 */
-        void iterateSymbolsOfClass(const std::string& className, std::function<void(size_t, PARSymbol&)> callback);
+            void iterateSymbolsOfClass(const std::string& className, std::function<void(size_t, PARSymbol&)> callback);
 
-        /**
+            /**
 		 * @return Object containing information about the opcode currently on the stack
 		 */
-        PARStackOpCode getStackOpCode(size_t pc);
+            PARStackOpCode getStackOpCode(size_t pc);
 
-        /**
+            /**
 		 * Adds a symbol and returns it's index. Note that if you change the name of this, the new symbol
 		 * won't be added to the SymbolByName-Map
 		 */
-        size_t addSymbol();
+            size_t addSymbol();
 
-        const PARSymTable& getSymTable() { return m_SymTable; }
-        const PARStack& getStack() { return m_Stack; }
+            const PARSymTable& getSymTable() { return m_SymTable; }
+            const PARStack& getStack() { return m_Stack; }
 
-    private:
-        void readSymTable();
-        void readStack();
+        private:
+            void readSymTable();
+            void readStack();
 
-        ZenParser m_Parser;
+            ZenParser m_Parser;
 
-        PARSymTable m_SymTable;
-        PARStack m_Stack;
+            PARSymTable m_SymTable;
+            PARStack m_Stack;
 
-        bool m_Verbose;
-    };
+            bool m_Verbose;
+        };
 
-}  // namespace ZenLoad
+    }  // namespace ZenLoad
+}  // namespace ZenLib

--- a/zenload/manParser.cpp
+++ b/zenload/manParser.cpp
@@ -3,108 +3,111 @@
 #include "manParser.h"
 #include "zenParser.h"
 
-namespace ZenLoad
+namespace ZenLib
 {
-    static const float SAMPLE_ROT_BITS = float(1 << 16) - 1.0f;
-    static const float SAMPLE_ROT_SCALER = (float(1.0f) / SAMPLE_ROT_BITS) * 2.0f * ZMath::Pi;
-    static const float SAMPLE_QUAT_SCALER = (1.0f / SAMPLE_ROT_BITS) * 2.1f;
-    static const uint16_t SAMPLE_QUAT_MIDDLE = (1 << 15) - 1;
-
-    ManParser::ManParser(ZenParser& zen)
-        : m_Zen(zen)
+    namespace ZenLoad
     {
-    }
+        static const float SAMPLE_ROT_BITS = float(1 << 16) - 1.0f;
+        static const float SAMPLE_ROT_SCALER = (float(1.0f) / SAMPLE_ROT_BITS) * 2.0f * ZMath::Pi;
+        static const float SAMPLE_QUAT_SCALER = (1.0f / SAMPLE_ROT_BITS) * 2.1f;
+        static const uint16_t SAMPLE_QUAT_MIDDLE = (1 << 15) - 1;
 
-    ManParser::EChunkType ManParser::parse()
-    {
-        if (m_Zen.getSeek() >= m_Zen.getFileSize())
+        ManParser::ManParser(ZenParser& zen)
+            : m_Zen(zen)
+        {
+        }
+
+        ManParser::EChunkType ManParser::parse()
+        {
+            if (m_Zen.getSeek() >= m_Zen.getFileSize())
+                return CHUNK_EOF;
+
+            BinaryChunkInfo chunkInfo;
+            m_Zen.readStructure(chunkInfo);
+
+            // store position after header so that we can skip the chunk
+            size_t chunkEnd = m_Zen.getSeek() + chunkInfo.length;
+
+            switch (chunkInfo.id)
+            {
+                case CHUNK_HEADER:
+                    readHeader();
+                    return CHUNK_HEADER;
+                case CHUNK_RAWDATA:
+                    readRawData();
+                    return CHUNK_RAWDATA;
+                default:
+                    m_Zen.setSeek(chunkEnd);
+                    return parse();  // skip unknown chunk
+            }
+
             return CHUNK_EOF;
-
-        BinaryChunkInfo chunkInfo;
-        m_Zen.readStructure(chunkInfo);
-
-        // store position after header so that we can skip the chunk
-        size_t chunkEnd = m_Zen.getSeek() + chunkInfo.length;
-
-        switch (chunkInfo.id)
-        {
-            case CHUNK_HEADER:
-                readHeader();
-                return CHUNK_HEADER;
-            case CHUNK_RAWDATA:
-                readRawData();
-                return CHUNK_RAWDATA;
-            default:
-                m_Zen.setSeek(chunkEnd);
-                return parse();  // skip unknown chunk
         }
 
-        return CHUNK_EOF;
-    }
-
-    void ManParser::readHeader()
-    {
-        m_Header.version = m_Zen.readBinaryWord();
-
-        m_Header.aniName = m_Zen.readLine(true);
-
-        m_Header.layer = m_Zen.readBinaryDWord();
-        m_Header.numFrames = m_Zen.readBinaryDWord();
-        m_Header.numNodes = m_Zen.readBinaryDWord();
-        m_Header.fpsRate = m_Zen.readBinaryFloat();
-        m_Header.fpsRateSource = m_Zen.readBinaryFloat();
-        m_Header.samplePosRangeMin = m_Zen.readBinaryFloat();
-        m_Header.samplePosScaler = m_Zen.readBinaryFloat();
-        m_Zen.readBinaryRaw(m_Header.aniBBox, sizeof(m_Header.aniBBox));
-        m_Header.nextAniName = m_Zen.readLine(true);
-    }
-
-    static void SampleUnpackTrans(const uint16_t* in, ZMath::float3& out, float samplePosScaler, float samplePosRangeMin)
-    {
-        out.x = float(in[0]) * samplePosScaler + samplePosRangeMin;
-        out.y = float(in[1]) * samplePosScaler + samplePosRangeMin;
-        out.z = float(in[2]) * samplePosScaler + samplePosRangeMin;
-    }
-
-    static void SampleUnpackQuat(const uint16_t* in, ZMath::float4& out)
-    {
-        out.x = (int(in[0]) - SAMPLE_QUAT_MIDDLE) * SAMPLE_QUAT_SCALER;
-        out.y = (int(in[1]) - SAMPLE_QUAT_MIDDLE) * SAMPLE_QUAT_SCALER;
-        out.z = (int(in[2]) - SAMPLE_QUAT_MIDDLE) * SAMPLE_QUAT_SCALER;
-
-        float len_q = out.x * out.x + out.y * out.y + out.z * out.z;
-
-        if (len_q > 1.0f)
+        void ManParser::readHeader()
         {
-            float l = 1.0f / sqrtf(len_q);
-            out.x *= l;
-            out.y *= l;
-            out.z *= l;
-            out.w = 0;
+            m_Header.version = m_Zen.readBinaryWord();
+
+            m_Header.aniName = m_Zen.readLine(true);
+
+            m_Header.layer = m_Zen.readBinaryDWord();
+            m_Header.numFrames = m_Zen.readBinaryDWord();
+            m_Header.numNodes = m_Zen.readBinaryDWord();
+            m_Header.fpsRate = m_Zen.readBinaryFloat();
+            m_Header.fpsRateSource = m_Zen.readBinaryFloat();
+            m_Header.samplePosRangeMin = m_Zen.readBinaryFloat();
+            m_Header.samplePosScaler = m_Zen.readBinaryFloat();
+            m_Zen.readBinaryRaw(m_Header.aniBBox, sizeof(m_Header.aniBBox));
+            m_Header.nextAniName = m_Zen.readLine(true);
         }
-        else
+
+        static void SampleUnpackTrans(const uint16_t* in, ZMath::float3& out, float samplePosScaler, float samplePosRangeMin)
         {
-            out.w = sqrtf(1.0f - len_q);
+            out.x = float(in[0]) * samplePosScaler + samplePosRangeMin;
+            out.y = float(in[1]) * samplePosScaler + samplePosRangeMin;
+            out.z = float(in[2]) * samplePosScaler + samplePosRangeMin;
         }
-    }
 
-    void ManParser::readRawData()
-    {
-        m_Header.nodeChecksum = m_Zen.readBinaryDWord();
-
-        m_NodeIndex.resize(m_Header.numNodes);
-        m_Zen.readBinaryRaw(m_NodeIndex.data(), m_NodeIndex.size() * sizeof(uint32_t));
-
-        uint32_t numSamples = m_Header.numNodes * m_Header.numFrames;
-        m_Samples.resize(numSamples);
-
-        for (size_t i = 0; i < numSamples; i++)
+        static void SampleUnpackQuat(const uint16_t* in, ZMath::float4& out)
         {
-            zTMdl_AniSample sample;
-            m_Zen.readBinaryRaw(&sample, sizeof(zTMdl_AniSample));
-            SampleUnpackTrans(sample.position, m_Samples[i].position, m_Header.samplePosScaler, m_Header.samplePosRangeMin);
-            SampleUnpackQuat(sample.rotation, m_Samples[i].rotation);
-        }
-    }
+            out.x = (int(in[0]) - SAMPLE_QUAT_MIDDLE) * SAMPLE_QUAT_SCALER;
+            out.y = (int(in[1]) - SAMPLE_QUAT_MIDDLE) * SAMPLE_QUAT_SCALER;
+            out.z = (int(in[2]) - SAMPLE_QUAT_MIDDLE) * SAMPLE_QUAT_SCALER;
 
-}  // namespace ZenLoad
+            float len_q = out.x * out.x + out.y * out.y + out.z * out.z;
+
+            if (len_q > 1.0f)
+            {
+                float l = 1.0f / sqrtf(len_q);
+                out.x *= l;
+                out.y *= l;
+                out.z *= l;
+                out.w = 0;
+            }
+            else
+            {
+                out.w = sqrtf(1.0f - len_q);
+            }
+        }
+
+        void ManParser::readRawData()
+        {
+            m_Header.nodeChecksum = m_Zen.readBinaryDWord();
+
+            m_NodeIndex.resize(m_Header.numNodes);
+            m_Zen.readBinaryRaw(m_NodeIndex.data(), m_NodeIndex.size() * sizeof(uint32_t));
+
+            uint32_t numSamples = m_Header.numNodes * m_Header.numFrames;
+            m_Samples.resize(numSamples);
+
+            for (size_t i = 0; i < numSamples; i++)
+            {
+                zTMdl_AniSample sample;
+                m_Zen.readBinaryRaw(&sample, sizeof(zTMdl_AniSample));
+                SampleUnpackTrans(sample.position, m_Samples[i].position, m_Header.samplePosScaler, m_Header.samplePosRangeMin);
+                SampleUnpackQuat(sample.rotation, m_Samples[i].rotation);
+            }
+        }
+
+    }  // namespace ZenLoad
+}  // namespace ZenLib

--- a/zenload/manParser.h
+++ b/zenload/manParser.h
@@ -3,68 +3,71 @@
 
 #include <zenload/zCModelAni.h>
 
-namespace ZenLoad
+namespace ZenLib
 {
-    class zCModelAni;
-    class ZenParser;
-
-    /** Streaming parser for .MAN files.
- */
-    class ManParser
+    namespace ZenLoad
     {
-    public:
-        typedef std::vector<zCModelAniSample> Samples;
-        typedef std::vector<uint32_t> NodeIndex;
+        class zCModelAni;
+        class ZenParser;
 
-        enum EChunkType
+        /** Streaming parser for .MAN files.
+ */
+        class ManParser
         {
-            CHUNK_ERROR,
-            CHUNK_EOF,
+        public:
+            typedef std::vector<zCModelAniSample> Samples;
+            typedef std::vector<uint32_t> NodeIndex;
 
-            CHUNK_HEADER = 0xA020,
-            CHUNK_RAWDATA = 0xA090,
+            enum EChunkType
+            {
+                CHUNK_ERROR,
+                CHUNK_EOF,
 
-        };
+                CHUNK_HEADER = 0xA020,
+                CHUNK_RAWDATA = 0xA090,
 
-        ManParser(ZenParser& zen);
+            };
 
-        /** Returns the parsed header.
+            ManParser(ZenParser& zen);
+
+            /** Returns the parsed header.
      *
      * Call this if parse() returns CHUNK_HEADER.
      *
      * @return The header read during the last call to parse().
      */
-        const zCModelAniHeader& header() const { return m_Header; }
+            const zCModelAniHeader& header() const { return m_Header; }
 
-        /** Returns the parsed samples.
+            /** Returns the parsed samples.
      *
      * Call this if parse() returns CHUNK_RAWDATA.
      *
      * @return The samples read during the last call to parse().
      */
-        const Samples& samples() const { return m_Samples; }
+            const Samples& samples() const { return m_Samples; }
 
-        /** Returns the parsed nodes.
+            /** Returns the parsed nodes.
      *
      * Call this if parse() returns CHUNK_RAWDATA.
      *
      * @return The nodes read during the last call to parse().
      */
-        const NodeIndex& nodeIndex() const { return m_NodeIndex; }
+            const NodeIndex& nodeIndex() const { return m_NodeIndex; }
 
-        EChunkType parse();
+            EChunkType parse();
 
-    private:
-        ZenParser& m_Zen;
+        private:
+            ZenParser& m_Zen;
 
-        zCModelAniHeader m_Header;
-        Samples m_Samples;
-        NodeIndex m_NodeIndex;
+            zCModelAniHeader m_Header;
+            Samples m_Samples;
+            NodeIndex m_NodeIndex;
 
-        void readHeader();
-        void readRawData();
-    };
+            void readHeader();
+            void readRawData();
+        };
 
-}  // namespace ZenLoad
+    }  // namespace ZenLoad
+}  // namespace ZenLib
 
 #endif  // MANPARSER_H

--- a/zenload/modelAnimationParser.cpp
+++ b/zenload/modelAnimationParser.cpp
@@ -4,109 +4,112 @@
 
 #include "zenParser.h"
 
-namespace ZenLoad
+namespace ZenLib
 {
-    static const float SAMPLE_ROT_BITS = float(1 << 16) - 1.0f;
-    static const float SAMPLE_ROT_SCALER = (float(1.0f) / SAMPLE_ROT_BITS) * 2.0f * ZMath::Pi;
-    static const float SAMPLE_QUAT_SCALER = (1.0f / SAMPLE_ROT_BITS) * 2.1f;
-    static const uint16_t SAMPLE_QUAT_MIDDLE = (1 << 15) - 1;
-
-    ModelAnimationParser::ModelAnimationParser(ZenParser& zen)
-        : m_Zen(zen)
+    namespace ZenLoad
     {
-    }
+        static const float SAMPLE_ROT_BITS = float(1 << 16) - 1.0f;
+        static const float SAMPLE_ROT_SCALER = (float(1.0f) / SAMPLE_ROT_BITS) * 2.0f * ZMath::Pi;
+        static const float SAMPLE_QUAT_SCALER = (1.0f / SAMPLE_ROT_BITS) * 2.1f;
+        static const uint16_t SAMPLE_QUAT_MIDDLE = (1 << 15) - 1;
 
-    ModelAnimationParser::EChunkType ModelAnimationParser::parse()
-    {
-        if (m_Zen.getSeek() >= m_Zen.getFileSize())
+        ModelAnimationParser::ModelAnimationParser(ZenParser& zen)
+            : m_Zen(zen)
+        {
+        }
+
+        ModelAnimationParser::EChunkType ModelAnimationParser::parse()
+        {
+            if (m_Zen.getSeek() >= m_Zen.getFileSize())
+                return CHUNK_EOF;
+
+            BinaryChunkInfo chunkInfo;
+            m_Zen.readStructure(chunkInfo);
+
+            // store position after header so that we can skip the chunk
+            size_t chunkEnd = m_Zen.getSeek() + chunkInfo.length;
+
+            switch (chunkInfo.id)
+            {
+                case CHUNK_HEADER:
+                    readHeader();
+                    return CHUNK_HEADER;
+                case CHUNK_RAWDATA:
+                    readRawData();
+                    return CHUNK_RAWDATA;
+                default:
+                    m_Zen.setSeek(chunkEnd);
+                    return parse();  // skip unknown chunk
+            }
+
             return CHUNK_EOF;
-
-        BinaryChunkInfo chunkInfo;
-        m_Zen.readStructure(chunkInfo);
-
-        // store position after header so that we can skip the chunk
-        size_t chunkEnd = m_Zen.getSeek() + chunkInfo.length;
-
-        switch (chunkInfo.id)
-        {
-            case CHUNK_HEADER:
-                readHeader();
-                return CHUNK_HEADER;
-            case CHUNK_RAWDATA:
-                readRawData();
-                return CHUNK_RAWDATA;
-            default:
-                m_Zen.setSeek(chunkEnd);
-                return parse();  // skip unknown chunk
         }
 
-        return CHUNK_EOF;
-    }
-
-    void ModelAnimationParser::readHeader()
-    {
-        m_Header.version = m_Zen.readBinaryWord();
-
-        m_Header.aniName = m_Zen.readLine(false);
-
-        m_Header.layer = m_Zen.readBinaryDWord();
-        m_Header.numFrames = m_Zen.readBinaryDWord();
-        m_Header.numNodes = m_Zen.readBinaryDWord();
-        m_Header.fpsRate = m_Zen.readBinaryFloat();
-        m_Header.fpsRateSource = m_Zen.readBinaryFloat();
-        m_Header.samplePosRangeMin = m_Zen.readBinaryFloat();
-        m_Header.samplePosScaler = m_Zen.readBinaryFloat();
-        m_Zen.readBinaryRaw(m_Header.aniBBox, sizeof(m_Header.aniBBox));
-        m_Header.nextAniName = m_Zen.readLine(false);
-    }
-
-    static void SampleUnpackTrans(const uint16_t* in, ZMath::float3& out, float samplePosScaler, float samplePosRangeMin)
-    {
-        out.x = float(in[0]) * samplePosScaler + samplePosRangeMin;
-        out.y = float(in[1]) * samplePosScaler + samplePosRangeMin;
-        out.z = float(in[2]) * samplePosScaler + samplePosRangeMin;
-    }
-
-    static void SampleUnpackQuat(const uint16_t* in, ZMath::float4& out)
-    {
-        out.x = (int(in[0]) - SAMPLE_QUAT_MIDDLE) * SAMPLE_QUAT_SCALER;
-        out.y = (int(in[1]) - SAMPLE_QUAT_MIDDLE) * SAMPLE_QUAT_SCALER;
-        out.z = (int(in[2]) - SAMPLE_QUAT_MIDDLE) * SAMPLE_QUAT_SCALER;
-
-        float len_q = out.x * out.x + out.y * out.y + out.z * out.z;
-
-        if (len_q > 1.0f)
+        void ModelAnimationParser::readHeader()
         {
-            float l = 1.0f / sqrtf(len_q);
-            out.x *= l;
-            out.y *= l;
-            out.z *= l;
-            out.w = 0;
+            m_Header.version = m_Zen.readBinaryWord();
+
+            m_Header.aniName = m_Zen.readLine(false);
+
+            m_Header.layer = m_Zen.readBinaryDWord();
+            m_Header.numFrames = m_Zen.readBinaryDWord();
+            m_Header.numNodes = m_Zen.readBinaryDWord();
+            m_Header.fpsRate = m_Zen.readBinaryFloat();
+            m_Header.fpsRateSource = m_Zen.readBinaryFloat();
+            m_Header.samplePosRangeMin = m_Zen.readBinaryFloat();
+            m_Header.samplePosScaler = m_Zen.readBinaryFloat();
+            m_Zen.readBinaryRaw(m_Header.aniBBox, sizeof(m_Header.aniBBox));
+            m_Header.nextAniName = m_Zen.readLine(false);
         }
-        else
+
+        static void SampleUnpackTrans(const uint16_t* in, ZMath::float3& out, float samplePosScaler, float samplePosRangeMin)
         {
-            out.w = sqrtf(1.0f - len_q);
+            out.x = float(in[0]) * samplePosScaler + samplePosRangeMin;
+            out.y = float(in[1]) * samplePosScaler + samplePosRangeMin;
+            out.z = float(in[2]) * samplePosScaler + samplePosRangeMin;
         }
-    }
 
-    void ModelAnimationParser::readRawData()
-    {
-        m_Header.nodeChecksum = m_Zen.readBinaryDWord();
-
-        m_NodeIndex.resize(m_Header.numNodes);
-        m_Zen.readBinaryRaw(m_NodeIndex.data(), m_NodeIndex.size() * sizeof(uint32_t));
-
-        uint32_t numSamples = m_Header.numNodes * m_Header.numFrames;
-        m_Samples.resize(numSamples);
-
-        for (size_t i = 0; i < numSamples; i++)
+        static void SampleUnpackQuat(const uint16_t* in, ZMath::float4& out)
         {
-            zTMdl_AniSample sample;
-            m_Zen.readBinaryRaw(&sample, sizeof(zTMdl_AniSample));
-            SampleUnpackTrans(sample.position, m_Samples[i].position, m_Header.samplePosScaler, m_Header.samplePosRangeMin);
-            m_Samples[i].position *= m_Scale;
-            SampleUnpackQuat(sample.rotation, m_Samples[i].rotation);
-        }
-    }
+            out.x = (int(in[0]) - SAMPLE_QUAT_MIDDLE) * SAMPLE_QUAT_SCALER;
+            out.y = (int(in[1]) - SAMPLE_QUAT_MIDDLE) * SAMPLE_QUAT_SCALER;
+            out.z = (int(in[2]) - SAMPLE_QUAT_MIDDLE) * SAMPLE_QUAT_SCALER;
 
-}  // namespace ZenLoad
+            float len_q = out.x * out.x + out.y * out.y + out.z * out.z;
+
+            if (len_q > 1.0f)
+            {
+                float l = 1.0f / sqrtf(len_q);
+                out.x *= l;
+                out.y *= l;
+                out.z *= l;
+                out.w = 0;
+            }
+            else
+            {
+                out.w = sqrtf(1.0f - len_q);
+            }
+        }
+
+        void ModelAnimationParser::readRawData()
+        {
+            m_Header.nodeChecksum = m_Zen.readBinaryDWord();
+
+            m_NodeIndex.resize(m_Header.numNodes);
+            m_Zen.readBinaryRaw(m_NodeIndex.data(), m_NodeIndex.size() * sizeof(uint32_t));
+
+            uint32_t numSamples = m_Header.numNodes * m_Header.numFrames;
+            m_Samples.resize(numSamples);
+
+            for (size_t i = 0; i < numSamples; i++)
+            {
+                zTMdl_AniSample sample;
+                m_Zen.readBinaryRaw(&sample, sizeof(zTMdl_AniSample));
+                SampleUnpackTrans(sample.position, m_Samples[i].position, m_Header.samplePosScaler, m_Header.samplePosRangeMin);
+                m_Samples[i].position *= m_Scale;
+                SampleUnpackQuat(sample.rotation, m_Samples[i].rotation);
+            }
+        }
+
+    }  // namespace ZenLoad
+}  // namespace ZenLib

--- a/zenload/modelAnimationParser.h
+++ b/zenload/modelAnimationParser.h
@@ -3,72 +3,75 @@
 
 #include <zenload/zCModelAni.h>
 
-namespace ZenLoad
+namespace ZenLib
 {
-    class zCModelAni;
-    class ZenParser;
-
-    /** Streaming parser for .MAN files.
- */
-    class ModelAnimationParser
+    namespace ZenLoad
     {
-    public:
-        typedef std::vector<zCModelAniSample> Samples;
-        typedef std::vector<uint32_t> NodeIndex;
+        class zCModelAni;
+        class ZenParser;
 
-        enum EChunkType
+        /** Streaming parser for .MAN files.
+ */
+        class ModelAnimationParser
         {
-            CHUNK_ERROR,
-            CHUNK_EOF,
+        public:
+            typedef std::vector<zCModelAniSample> Samples;
+            typedef std::vector<uint32_t> NodeIndex;
 
-            CHUNK_HEADER = 0xA020,
-            CHUNK_RAWDATA = 0xA090,
+            enum EChunkType
+            {
+                CHUNK_ERROR,
+                CHUNK_EOF,
 
-        };
+                CHUNK_HEADER = 0xA020,
+                CHUNK_RAWDATA = 0xA090,
 
-        ModelAnimationParser(ZenParser& zen);
+            };
 
-        void setScale(float scale) { m_Scale = scale; }
+            ModelAnimationParser(ZenParser& zen);
 
-        /** Returns the parsed header.
+            void setScale(float scale) { m_Scale = scale; }
+
+            /** Returns the parsed header.
      *
      * Call this if parse() returns CHUNK_HEADER.
      *
      * @return The header read during the last call to parse().
      */
-        const zCModelAniHeader& getHeader() const { return m_Header; }
+            const zCModelAniHeader& getHeader() const { return m_Header; }
 
-        /** Returns the parsed samples.
+            /** Returns the parsed samples.
      *
      * Call this if parse() returns CHUNK_RAWDATA.
      *
      * @return The samples read during the last call to parse().
      */
-        const Samples& getSamples() const { return m_Samples; }
+            const Samples& getSamples() const { return m_Samples; }
 
-        /** Returns the parsed nodes.
+            /** Returns the parsed nodes.
      *
      * Call this if parse() returns CHUNK_RAWDATA.
      *
      * @return The nodes read during the last call to parse().
      */
-        const NodeIndex& getNodeIndex() const { return m_NodeIndex; }
+            const NodeIndex& getNodeIndex() const { return m_NodeIndex; }
 
-        EChunkType parse();
+            EChunkType parse();
 
-    private:
-        ZenParser& m_Zen;
+        private:
+            ZenParser& m_Zen;
 
-        float m_Scale = 1.0f;
+            float m_Scale = 1.0f;
 
-        zCModelAniHeader m_Header;
-        Samples m_Samples;
-        NodeIndex m_NodeIndex;
+            zCModelAniHeader m_Header;
+            Samples m_Samples;
+            NodeIndex m_NodeIndex;
 
-        void readHeader();
-        void readRawData();
-    };
+            void readHeader();
+            void readRawData();
+        };
 
-}  // namespace ZenLoad
+    }  // namespace ZenLoad
+}  // namespace ZenLib
 
 #endif  // MANPARSER_H

--- a/zenload/modelScriptParser.cpp
+++ b/zenload/modelScriptParser.cpp
@@ -7,1021 +7,1024 @@
 
 #include <utils/logger.h>
 
-namespace ZenLoad
+namespace ZenLib
 {
-    ModelScriptParser::ModelScriptParser(ZenParser& zen)
-        : m_Zen(zen)
+    namespace ZenLoad
     {
-    }
+        ModelScriptParser::ModelScriptParser(ZenParser& zen)
+            : m_Zen(zen)
+        {
+        }
 
-    ModelScriptParser::~ModelScriptParser()
-    {
-    }
+        ModelScriptParser::~ModelScriptParser()
+        {
+        }
 
-    ModelScriptBinParser::ModelScriptBinParser(ZenParser& zen)
-        : ModelScriptParser(zen)
-    {
-    }
+        ModelScriptBinParser::ModelScriptBinParser(ZenParser& zen)
+            : ModelScriptParser(zen)
+        {
+        }
 
-    ModelScriptBinParser::EChunkType ModelScriptBinParser::parse()
-    {
-        if (m_Zen.getSeek() >= m_Zen.getFileSize())
+        ModelScriptBinParser::EChunkType ModelScriptBinParser::parse()
+        {
+            if (m_Zen.getSeek() >= m_Zen.getFileSize())
+                return CHUNK_EOF;
+
+            BinaryChunkInfo chunk;
+            m_Zen.readStructure(chunk);
+
+            // store position after header so that we can skip the chunk
+            size_t chunk_end = m_Zen.getSeek() + chunk.length;
+
+            switch (chunk.id)
+            {
+                case CHUNK_MESH_AND_TREE:
+                    readMeshAndTree();
+                    m_Zen.setSeek(chunk_end);
+                    return CHUNK_MESH_AND_TREE;
+                    break;
+                case CHUNK_REGISTER_MESH:
+                    readRegisterMesh();
+                    m_Zen.setSeek(chunk_end);
+                    return CHUNK_REGISTER_MESH;
+                    break;
+                case CHUNK_ANI:
+                    readAni();
+                    m_Zen.setSeek(chunk_end);
+                    return CHUNK_ANI;
+                case CHUNK_ANI_ALIAS:
+                    readAlias();
+                    m_Zen.setSeek(chunk_end);
+                    return CHUNK_ANI_ALIAS;
+                case CHUNK_EVENT_SFX:
+                    readSfx();
+                    m_Zen.setSeek(chunk_end);
+                    return CHUNK_EVENT_SFX;
+                case CHUNK_EVENT_SFX_GRND:
+                    readSfx();
+                    m_Zen.setSeek(chunk_end);
+                    return CHUNK_EVENT_SFX_GRND;
+                case CHUNK_EVENT_PFX:
+                    readPfx();
+                    m_Zen.setSeek(chunk_end);
+                    return CHUNK_EVENT_PFX;
+                case CHUNK_EVENT_PFX_STOP:
+                    readPfxStop();
+                    m_Zen.setSeek(chunk_end);
+                    return CHUNK_EVENT_PFX_STOP;
+                default:
+                    m_Zen.setSeek(chunk_end);
+                    return parse();  // skip unknown chunk
+            }
+
             return CHUNK_EOF;
-
-        BinaryChunkInfo chunk;
-        m_Zen.readStructure(chunk);
-
-        // store position after header so that we can skip the chunk
-        size_t chunk_end = m_Zen.getSeek() + chunk.length;
-
-        switch (chunk.id)
-        {
-            case CHUNK_MESH_AND_TREE:
-                readMeshAndTree();
-                m_Zen.setSeek(chunk_end);
-                return CHUNK_MESH_AND_TREE;
-                break;
-            case CHUNK_REGISTER_MESH:
-                readRegisterMesh();
-                m_Zen.setSeek(chunk_end);
-                return CHUNK_REGISTER_MESH;
-                break;
-            case CHUNK_ANI:
-                readAni();
-                m_Zen.setSeek(chunk_end);
-                return CHUNK_ANI;
-            case CHUNK_ANI_ALIAS:
-                readAlias();
-                m_Zen.setSeek(chunk_end);
-                return CHUNK_ANI_ALIAS;
-            case CHUNK_EVENT_SFX:
-                readSfx();
-                m_Zen.setSeek(chunk_end);
-                return CHUNK_EVENT_SFX;
-            case CHUNK_EVENT_SFX_GRND:
-                readSfx();
-                m_Zen.setSeek(chunk_end);
-                return CHUNK_EVENT_SFX_GRND;
-            case CHUNK_EVENT_PFX:
-                readPfx();
-                m_Zen.setSeek(chunk_end);
-                return CHUNK_EVENT_PFX;
-            case CHUNK_EVENT_PFX_STOP:
-                readPfxStop();
-                m_Zen.setSeek(chunk_end);
-                return CHUNK_EVENT_PFX_STOP;
-            default:
-                m_Zen.setSeek(chunk_end);
-                return parse();  // skip unknown chunk
         }
 
-        return CHUNK_EOF;
-    }
-
-    static uint32_t makeAniFlags(ZenParser& zen)
-    {
-        uint32_t flags = 0;
-        std::string flag_str = zen.readLine(true);
-        for (auto ch : flag_str)
+        static uint32_t makeAniFlags(ZenParser& zen)
         {
-            switch (ch)
+            uint32_t flags = 0;
+            std::string flag_str = zen.readLine(true);
+            for (auto ch : flag_str)
             {
-                case 'M':
-                    flags |= MSB_MOVE_MODEL;
-                    break;
-                case 'R':
-                    flags |= MSB_ROTATE_MODEL;
-                    break;
-                case 'E':
-                    flags |= MSB_QUEUE_ANI;
-                    break;
-                case 'F':
-                    flags |= MSB_FLY;
-                    break;
-                case 'I':
-                    flags |= MSB_IDLE;
-                    break;
-            }
-        }
-        return flags;
-    }
-
-    static EModelScriptAniDir makeAniDir(ZenParser& zen)
-    {
-        std::string str = zen.readLine();
-        return (!str.empty() && str[0] == 'R') ? MSB_BACKWARD : MSB_FORWARD;
-    }
-
-    void ModelScriptBinParser::readMeshAndTree()
-    {
-        bool dontUseMesh = m_Zen.readBinaryDWord() != 0;
-        std::string meshNameASC = m_Zen.readLine();
-
-        // This should absolutely have an extension of .ASC, but sometimes doesn't.
-        // Add it, if it's not there.
-        if (meshNameASC.find_first_of('.') == std::string::npos)
-        {
-            meshNameASC += ".ASC";
-        }
-
-        if (!dontUseMesh)
-        {
-            m_MeshesASC.push_back(meshNameASC);
-        }
-
-        m_MeshAndTree = meshNameASC;
-    }
-
-    void ModelScriptBinParser::readRegisterMesh()
-    {
-        // Reads "Some_Mesh.ASC"
-        std::string mesh = m_Zen.readLine();
-
-        m_MeshesASC.push_back(mesh);
-    }
-
-    void ModelScriptBinParser::readAni()
-    {
-        m_Ani.m_Name = m_Zen.readLine();
-        m_Ani.m_Layer = m_Zen.readBinaryDWord();
-        m_Ani.m_Next = m_Zen.readLine();
-        m_Ani.m_BlendIn = m_Zen.readBinaryFloat();
-        m_Ani.m_BlendOut = m_Zen.readBinaryFloat();
-        m_Ani.m_Flags = makeAniFlags(m_Zen);
-        m_Ani.m_Asc = m_Zen.readLine();
-        m_Ani.m_Dir = makeAniDir(m_Zen);
-        m_Ani.m_FirstFrame = m_Zen.readBinaryDWord();
-        m_Ani.m_LastFrame = m_Zen.readBinaryDWord();
-        m_Ani.m_MaxFps = m_Zen.readBinaryFloat();
-        m_Ani.m_Speed = m_Zen.readBinaryFloat();
-        m_Ani.m_ColVolScale = m_Zen.readBinaryFloat();
-    }
-
-    void ModelScriptBinParser::readAlias()
-    {
-        m_Alias.m_Name = m_Zen.readLine(true);
-        m_Alias.m_Layer = m_Zen.readBinaryDWord();
-        m_Alias.m_Next = m_Zen.readLine(true);
-        m_Alias.m_BlendIn = m_Zen.readBinaryFloat();
-        m_Alias.m_BlendOut = m_Zen.readBinaryFloat();
-        m_Alias.m_Flags = makeAniFlags(m_Zen);
-        m_Alias.m_Alias = m_Zen.readLine(true);
-        m_Ani.m_Dir = makeAniDir(m_Zen);
-    }
-
-    void ModelScriptBinParser::readSfx()
-    {
-        m_Sfx.emplace_back();
-        m_Sfx.back().m_Frame = m_Zen.readBinaryDWord();
-        m_Sfx.back().m_Name = m_Zen.readLine(true);
-
-        float range = m_Zen.readBinaryFloat();
-        float emptySlot = m_Zen.readBinaryFloat();
-
-        m_Sfx.back().m_Range = range / 100.0f;        // Convert to meters
-        m_Sfx.back().m_EmptySlot = emptySlot > 0.0f;  // They encoded this as float for some reason...
-    }
-    void ModelScriptBinParser::readPfx()
-    {
-        m_Pfx.emplace_back();
-
-        m_Pfx.back().m_Frame = m_Zen.readBinaryDWord();
-
-        m_Pfx.back().m_Num = m_Zen.readBinaryDWord();
-        m_Pfx.back().m_Name = m_Zen.readLine(true);
-        m_Pfx.back().m_Pos = m_Zen.readLine(true);
-        //Like EmptySlot in readSfx encoded in float. No " " around value might be a hint that no string is used
-        m_Pfx.back().m_isAttached = m_Zen.readBinaryFloat() > 0.0f;
-    }
-
-    void ModelScriptBinParser::readPfxStop()
-    {
-        m_PfxStop.emplace_back();
-        m_PfxStop.back().m_Frame = m_Zen.readBinaryDWord();
-        m_PfxStop.back().m_Num = m_Zen.readBinaryDWord();
-    }
-
-    ModelScriptTextParser::ModelScriptTextParser(ZenParser& zen)
-        : ModelScriptParser(zen)
-        , m_Line(1)
-    {
-        // read current token into next
-        token();
-
-        m_Context.push_back(ContextFile);
-
-        //LogInfo() << "MDS\n" << reinterpret_cast<const char*>(&zen.getData()[0]);
-    }
-
-    bool ModelScriptTextParser::isEof() const
-    {
-        return m_Zen.getSeek() >= m_Zen.getFileSize();
-    }
-
-    ModelScriptTextParser::Result ModelScriptTextParser::token()
-    {
-        Result res = skipSpace();
-        if (res != Success)
-            return res;
-
-        m_Token = m_NextToken;
-        m_NextToken.text.clear();
-        m_NextToken.line = m_Line;
-
-        while (!isEof())
-        {
-            char ch = m_Zen.readBinaryByte();
-            if (ch == '"')
-            {
-                while (true)
+                switch (ch)
                 {
-                    if (isEof())
-                    {
-                        LogError() << "parser error in line " << m_Line << ": unexpected end in quoted string";
-                        return Error;
-                    }
-
-                    ch = m_Zen.readBinaryByte();
-                    if (ch == '"')
-                        return Success;  // Need to return early here, because emtpy strings ( "" ) happen, which should not be seen as empty lines
-
-                    if (ch == '\n')
-                    {
-                        LogError() << "parser error in line " << m_Line << ": unexpected newline in quoted string";
-                        return Error;
-                    }
-
-                    m_NextToken.text.push_back(ch);
+                    case 'M':
+                        flags |= MSB_MOVE_MODEL;
+                        break;
+                    case 'R':
+                        flags |= MSB_ROTATE_MODEL;
+                        break;
+                    case 'E':
+                        flags |= MSB_QUEUE_ANI;
+                        break;
+                    case 'F':
+                        flags |= MSB_FLY;
+                        break;
+                    case 'I':
+                        flags |= MSB_IDLE;
+                        break;
                 }
-
-                continue;
             }
-            else if (ch == '/' && (!m_Strict || ((m_Zen.getSeek() < m_Zen.getFileSize() - 1) && (m_Zen.getData()[m_Zen.getSeek()] == '/'))))  // Single / were supported by the original parser as well
-            {
-                while (m_Zen.readBinaryByte() != '\n')
-                {
-                    if (isEof())
-                        return End;
-                }
+            return flags;
+        }
 
-                m_Line++;
-                skipSpace();  // Skip any empty lines after the comment
-                continue;     // Don't want comments inside the tokens
-            }
-            else if (isspace(ch) || ch == '(' || ch == ')' || ch == '{' || ch == '}')
+        static EModelScriptAniDir makeAniDir(ZenParser& zen)
+        {
+            std::string str = zen.readLine();
+            return (!str.empty() && str[0] == 'R') ? MSB_BACKWARD : MSB_FORWARD;
+        }
+
+        void ModelScriptBinParser::readMeshAndTree()
+        {
+            bool dontUseMesh = m_Zen.readBinaryDWord() != 0;
+            std::string meshNameASC = m_Zen.readLine();
+
+            // This should absolutely have an extension of .ASC, but sometimes doesn't.
+            // Add it, if it's not there.
+            if (meshNameASC.find_first_of('.') == std::string::npos)
             {
-                if (m_NextToken.text.empty())
+                meshNameASC += ".ASC";
+            }
+
+            if (!dontUseMesh)
+            {
+                m_MeshesASC.push_back(meshNameASC);
+            }
+
+            m_MeshAndTree = meshNameASC;
+        }
+
+        void ModelScriptBinParser::readRegisterMesh()
+        {
+            // Reads "Some_Mesh.ASC"
+            std::string mesh = m_Zen.readLine();
+
+            m_MeshesASC.push_back(mesh);
+        }
+
+        void ModelScriptBinParser::readAni()
+        {
+            m_Ani.m_Name = m_Zen.readLine();
+            m_Ani.m_Layer = m_Zen.readBinaryDWord();
+            m_Ani.m_Next = m_Zen.readLine();
+            m_Ani.m_BlendIn = m_Zen.readBinaryFloat();
+            m_Ani.m_BlendOut = m_Zen.readBinaryFloat();
+            m_Ani.m_Flags = makeAniFlags(m_Zen);
+            m_Ani.m_Asc = m_Zen.readLine();
+            m_Ani.m_Dir = makeAniDir(m_Zen);
+            m_Ani.m_FirstFrame = m_Zen.readBinaryDWord();
+            m_Ani.m_LastFrame = m_Zen.readBinaryDWord();
+            m_Ani.m_MaxFps = m_Zen.readBinaryFloat();
+            m_Ani.m_Speed = m_Zen.readBinaryFloat();
+            m_Ani.m_ColVolScale = m_Zen.readBinaryFloat();
+        }
+
+        void ModelScriptBinParser::readAlias()
+        {
+            m_Alias.m_Name = m_Zen.readLine(true);
+            m_Alias.m_Layer = m_Zen.readBinaryDWord();
+            m_Alias.m_Next = m_Zen.readLine(true);
+            m_Alias.m_BlendIn = m_Zen.readBinaryFloat();
+            m_Alias.m_BlendOut = m_Zen.readBinaryFloat();
+            m_Alias.m_Flags = makeAniFlags(m_Zen);
+            m_Alias.m_Alias = m_Zen.readLine(true);
+            m_Ani.m_Dir = makeAniDir(m_Zen);
+        }
+
+        void ModelScriptBinParser::readSfx()
+        {
+            m_Sfx.emplace_back();
+            m_Sfx.back().m_Frame = m_Zen.readBinaryDWord();
+            m_Sfx.back().m_Name = m_Zen.readLine(true);
+
+            float range = m_Zen.readBinaryFloat();
+            float emptySlot = m_Zen.readBinaryFloat();
+
+            m_Sfx.back().m_Range = range / 100.0f;        // Convert to meters
+            m_Sfx.back().m_EmptySlot = emptySlot > 0.0f;  // They encoded this as float for some reason...
+        }
+        void ModelScriptBinParser::readPfx()
+        {
+            m_Pfx.emplace_back();
+
+            m_Pfx.back().m_Frame = m_Zen.readBinaryDWord();
+
+            m_Pfx.back().m_Num = m_Zen.readBinaryDWord();
+            m_Pfx.back().m_Name = m_Zen.readLine(true);
+            m_Pfx.back().m_Pos = m_Zen.readLine(true);
+            //Like EmptySlot in readSfx encoded in float. No " " around value might be a hint that no string is used
+            m_Pfx.back().m_isAttached = m_Zen.readBinaryFloat() > 0.0f;
+        }
+
+        void ModelScriptBinParser::readPfxStop()
+        {
+            m_PfxStop.emplace_back();
+            m_PfxStop.back().m_Frame = m_Zen.readBinaryDWord();
+            m_PfxStop.back().m_Num = m_Zen.readBinaryDWord();
+        }
+
+        ModelScriptTextParser::ModelScriptTextParser(ZenParser& zen)
+            : ModelScriptParser(zen)
+            , m_Line(1)
+        {
+            // read current token into next
+            token();
+
+            m_Context.push_back(ContextFile);
+
+            //LogInfo() << "MDS\n" << reinterpret_cast<const char*>(&zen.getData()[0]);
+        }
+
+        bool ModelScriptTextParser::isEof() const
+        {
+            return m_Zen.getSeek() >= m_Zen.getFileSize();
+        }
+
+        ModelScriptTextParser::Result ModelScriptTextParser::token()
+        {
+            Result res = skipSpace();
+            if (res != Success)
+                return res;
+
+            m_Token = m_NextToken;
+            m_NextToken.text.clear();
+            m_NextToken.line = m_Line;
+
+            while (!isEof())
+            {
+                char ch = m_Zen.readBinaryByte();
+                if (ch == '"')
                 {
-                    if (!isspace(ch))
+                    while (true)
+                    {
+                        if (isEof())
+                        {
+                            LogError() << "parser error in line " << m_Line << ": unexpected end in quoted string";
+                            return Error;
+                        }
+
+                        ch = m_Zen.readBinaryByte();
+                        if (ch == '"')
+                            return Success;  // Need to return early here, because emtpy strings ( "" ) happen, which should not be seen as empty lines
+
+                        if (ch == '\n')
+                        {
+                            LogError() << "parser error in line " << m_Line << ": unexpected newline in quoted string";
+                            return Error;
+                        }
+
                         m_NextToken.text.push_back(ch);
+                    }
+
+                    continue;
                 }
-                else
+                else if (ch == '/' && (!m_Strict || ((m_Zen.getSeek() < m_Zen.getFileSize() - 1) && (m_Zen.getData()[m_Zen.getSeek()] == '/'))))  // Single / were supported by the original parser as well
                 {
-                    // we already have token text, the next token will be the special char
-                    m_Zen.setSeek(m_Zen.getSeek() - 1);
+                    while (m_Zen.readBinaryByte() != '\n')
+                    {
+                        if (isEof())
+                            return End;
+                    }
+
+                    m_Line++;
+                    skipSpace();  // Skip any empty lines after the comment
+                    continue;     // Don't want comments inside the tokens
                 }
-                break;
+                else if (isspace(ch) || ch == '(' || ch == ')' || ch == '{' || ch == '}')
+                {
+                    if (m_NextToken.text.empty())
+                    {
+                        if (!isspace(ch))
+                            m_NextToken.text.push_back(ch);
+                    }
+                    else
+                    {
+                        // we already have token text, the next token will be the special char
+                        m_Zen.setSeek(m_Zen.getSeek() - 1);
+                    }
+                    break;
+                }
+
+                m_NextToken.text.push_back(toupper(ch));
             }
 
-            m_NextToken.text.push_back(toupper(ch));
+            return m_NextToken.text.empty() ? End : Success;
         }
 
-        return m_NextToken.text.empty() ? End : Success;
-    }
-
-    ModelScriptTextParser::Result ModelScriptTextParser::skipSpace()
-    {
-        while (true)
+        ModelScriptTextParser::Result ModelScriptTextParser::skipSpace()
         {
-            if (isEof())
-                return End;
-
-            auto& zd = m_Zen.getData()[m_Zen.getSeek()];
-            if (!isspace(zd) && zd != '\n')
-                break;
-
-            if (zd == '\n')
-                m_Line++;
-
-            m_Zen.readBinaryByte();
-        }
-
-        return Success;
-    }
-
-    ModelScriptTextParser::Result ModelScriptTextParser::expectChar(char ch)
-    {
-        Result res = token();
-        if (res != Success)
-        {
-            LogError() << "unexpected end in line " << m_Line << ", expected " << ch;
-            return Error;
-        }
-
-        if (m_Token.text.empty() || m_Token.text[0] != ch)
-        {
-            LogError() << "invalid token '" << m_Token.text << "' in line " << m_Line << ", expected " << ch;
-            return Error;
-        }
-
-        return Success;
-    }
-
-    bool ModelScriptTextParser::nextIs(char ch) const
-    {
-        return !m_NextToken.text.empty() && m_NextToken.text[0] == ch;
-    }
-
-    ModelScriptTextParser::Result ModelScriptTextParser::parseObjectStart()
-    {
-        return expectChar('{');
-    }
-
-    ModelScriptTextParser::Result ModelScriptTextParser::parseObjectEnd()
-    {
-        return expectChar('}');
-    }
-
-    ModelScriptBinParser::EChunkType ModelScriptTextParser::parse()
-    {
-        if (isEof())
-            return CHUNK_EOF;
-
-        // token is consumed by the functions below
-        Result res = token();
-        if (res != Success)
-            return CHUNK_ERROR;
-
-        if (!m_Token.text.empty() && m_Token.text[0] == '}')
-        {
-            // skip '}'
-            if (!token())
-                return CHUNK_ERROR;
-
-            if (m_Context.empty())
+            while (true)
             {
-                LogError() << "unexpected '}' at line " << m_Line;
-                return CHUNK_ERROR;
+                if (isEof())
+                    return End;
+
+                auto& zd = m_Zen.getData()[m_Zen.getSeek()];
+                if (!isspace(zd) && zd != '\n')
+                    break;
+
+                if (zd == '\n')
+                    m_Line++;
+
+                m_Zen.readBinaryByte();
             }
 
-            m_Context.pop_back();
-
-            return parse();
-        }
-
-        switch (m_Context.back())
-        {
-            case ContextFile:
-                return parseFileChunk();
-            case ContextModel:
-                return parseModelChunk();
-            case ContextAniEnum:
-                return parseAniEnumChunk();
-        }
-
-        return CHUNK_EOF;
-    }
-
-    ModelScriptTextParser::Result ModelScriptTextParser::parseArguments()
-    {
-        if (!nextIs('('))
-        {
-            // no args, just object name
             return Success;
         }
 
-        Result res = expectChar('(');
-        if (res != Success)
-            return res;
-
-        m_Args.clear();
-        m_ArgCount = 0;
-        while (true)
+        ModelScriptTextParser::Result ModelScriptTextParser::expectChar(char ch)
         {
-            res = token();
+            Result res = token();
             if (res != Success)
             {
-                if (res == End)
-                {
-                    LogError() << "invalid end in argument list in line " << m_Line;
-                    return Error;
-                }
-                return res;
-            }
-
-            if (m_ArgCount < m_Args.size())
-            {
-                std::string& arg = m_Args[m_ArgCount];
-                arg.clear();
-                arg.insert(arg.begin(), m_Token.text.begin(), m_Token.text.end());
-            }
-            else
-                m_Args.emplace_back(m_Token.text);
-
-            m_ArgCount++;
-
-            if (!m_NextToken.text.empty() && m_NextToken.text[0] == ')')
-                break;
-        }
-
-        return expectChar(')');
-    }
-
-    ModelScriptParser::EChunkType ModelScriptTextParser::parseFileChunk()
-    {
-        if (m_Token.text == "MODEL")
-        {
-            if (!parseModelStart())
-                return CHUNK_ERROR;
-
-            return CHUNK_MODEL;
-        }
-
-        if (!m_Strict && !m_Token.text.empty() && m_Token.text[0] == '(')
-        {
-            // fixes duplicate '}' after anim, which will make the parser think
-            // it's on the file level
-            m_Context.push_back(ContextAniEnum);
-            return parseAniEnumChunk();
-        }
-
-        LogError() << "invalid token '" << m_Token.text << "' in file at line " << m_Line;
-        return CHUNK_ERROR;
-    }
-
-    bool ModelScriptTextParser::parseModelStart()
-    {
-        Result res = parseArguments();
-        if (res != Success)
-            return false;
-
-        // TODO: assign
-
-        res = parseObjectStart();
-        if (res != Success)
-            return false;
-
-        m_Context.push_back(ContextModel);
-
-        return true;
-    }
-
-    ModelScriptParser::EChunkType ModelScriptTextParser::parseModelChunk()
-    {
-        if (m_Token.text == "MESHANDTREE")
-        {
-            Result res = parseArguments();
-
-            // Second arg would be DONT_USE_MESH.
-            if (m_ArgCount == 1)
-            {
-                m_MeshesASC.push_back(m_Args[0]);
-            }
-
-            m_MeshAndTree = m_Args[0];
-
-            // TODO
-            return (res != Success) ? CHUNK_ERROR : CHUNK_MESH_AND_TREE;
-        }
-        else if (m_Token.text == "REGISTERMESH")
-        {
-            Result res = parseArguments();
-
-            if (m_ArgCount == 1)
-            {
-                m_MeshesASC.push_back(m_Args[0]);
-            }
-
-            return (res != Success) ? CHUNK_ERROR : CHUNK_REGISTER_MESH;
-        }
-        else if (m_Token.text == "ANIENUM")
-        {
-            if (!parseAniEnumStart())
-                return CHUNK_ERROR;
-
-            return CHUNK_ANI_ENUM;
-        }
-
-        LogError() << "invalid token '" << m_Token.text << "' in Model at line " << m_Line;
-        return CHUNK_ERROR;
-    }
-
-    bool ModelScriptTextParser::parseAniEnumStart()
-    {
-        Result res = parseArguments();
-        if (res != Success)
-            return false;
-
-        // TODO: assign
-
-        res = parseObjectStart();
-        if (res != Success)
-            return false;
-
-        m_Context.push_back(ContextAniEnum);
-
-        return true;
-    }
-
-    ModelScriptTextParser::EChunkType ModelScriptTextParser::parseAniEnumChunk()
-    {
-        if (m_Token.text == "ANI")
-        {
-            return (parseAni() != Success) ? CHUNK_ERROR : CHUNK_ANI;
-        }
-        else if (m_Token.text == "ANIALIAS")
-        {
-            return (parseAniAlias() != Success) ? CHUNK_ERROR : CHUNK_ANI_ALIAS;
-        }
-        else if (m_Token.text == "ANIBLEND")
-        {
-            return (parseAniBlend() != Success) ? CHUNK_ERROR : CHUNK_ANI_BLEND;
-        }
-        else if (m_Token.text == "MODELTAG")
-        {
-            return (parseModelTag() != Success) ? CHUNK_ERROR : CHUNK_MODEL_TAG;
-        }
-        else if (m_Token.text == "ANIDISABLE")
-        {
-            return (parseAniDisable() != Success) ? CHUNK_ERROR : CHUNK_MODEL_TAG;
-        }
-        else if (m_Token.text == "ANICOMB")
-        {
-            return (parseAniComb() != Success) ? CHUNK_ERROR : CHUNK_MODEL_TAG;
-        }
-
-        LogError() << "invalid token '" << m_Token.text << "' in aniEnum at line " << m_Line;
-        return CHUNK_ERROR;
-    }
-
-    ModelScriptTextParser::Result ModelScriptTextParser::parseAniEvents()
-    {
-        if (!nextIs('{'))
-            return Success;  // no events
-
-        Result res = parseObjectStart();
-        if (res != Success)
-            return Error;
-        while (true)
-        {
-            // Need to check this first, to fix parsing of empty { } blocks
-            if (nextIs('}'))
-                break;
-
-            res = token();
-            if (res != Success)
-                break;
-
-            if (m_Token.text == "*EVENTSWAPMESH")
-            {
-                res = parseSwapMeshEvent();
-                if (res != Success)
-                    break;
-            }
-            else if (m_Token.text == "*EVENTPFX")
-            {
-                //gets never called...
-                res = parsePfxEvent();
-                if (res != Success)
-                    break;
-            }
-            else if (m_Token.text == "*EVENTPFXSTOP")
-            {
-                res = parsePfxStopEvent();
-                if (res != Success)
-                    break;
-            }
-            else if (m_Token.text == "*EVENTSFX")
-            {
-                res = parseSfxEvent();
-                if (res != Success)
-                    break;
-            }
-            else if (m_Token.text == "*EVENTSFXGRND")
-            {
-                res = parseSfxGrndEvent();
-                if (res != Success)
-                    break;
-            }
-            else if (m_Token.text == "*EVENTTAG")
-            {
-                res = parseTagEvent();
-                if (res != Success)
-                    break;
-            }
-            else if (m_Token.text == "*EVENTMMSTARTANI")
-            {
-                res = parseMMStartAniEvent();
-                if (res != Success)
-                    break;
-            }
-            else if (m_Token.text == "*EVENTCAMTREMOR")
-            {
-                res = parseCamTremorEvent();
-                if (res != Success)
-                    break;
-            }
-            else
-            {
-                LogError() << "invalid token '" << m_Token.text << "' in ani at line " << m_Line;
+                LogError() << "unexpected end in line " << m_Line << ", expected " << ch;
                 return Error;
             }
-        }
 
-        return parseObjectEnd();
-    }
-
-    ModelScriptTextParser::Result ModelScriptTextParser::parseAni()
-    {
-        Result res = parseArguments();
-        if (res != Success)
-            return Error;
-
-        // Most of the ani-chunks have 10 args, but they can have an additional one for FPS and some have only 8, omitting start and end-frame
-        if (m_ArgCount < 8)
-        {
-            LogError() << "invalid number of arguments for ani at line " << m_Line;
-            return Error;
-        }
-
-        m_Ani.m_Name = m_Args[0];
-
-        std::transform(m_Ani.m_Name.begin(), m_Ani.m_Name.end(), m_Ani.m_Name.begin(), ::toupper);
-
-        m_Ani.m_Layer = std::stoi(m_Args[1]);
-        m_Ani.m_Next = m_Args[2];
-        std::transform(m_Ani.m_Next.begin(), m_Ani.m_Next.end(), m_Ani.m_Next.begin(), ::toupper);
-
-        std::string& flags = m_Args[5];
-
-        m_Ani.m_Flags = 0;
-        for (size_t i = 0; i < flags.size(); i++)
-        {
-            switch (flags[i])
+            if (m_Token.text.empty() || m_Token.text[0] != ch)
             {
-                case 'M':
-                    m_Ani.m_Flags |= EModelScriptAniFlags::MSB_MOVE_MODEL;
-                    break;
-
-                case 'R':
-                    m_Ani.m_Flags |= EModelScriptAniFlags::MSB_ROTATE_MODEL;
-                    break;
-
-                case 'E':
-                    m_Ani.m_Flags |= EModelScriptAniFlags::MSB_QUEUE_ANI;
-                    break;
-
-                case 'F':
-                    m_Ani.m_Flags |= EModelScriptAniFlags::MSB_FLY;
-                    break;
-
-                case 'I':
-                    m_Ani.m_Flags |= EModelScriptAniFlags::MSB_IDLE;
-                    break;
-
-                case '.':
-                    // This is used as a placeholder
-                    break;
-
-                default:
-                    LogWarn() << "Anim: Unknown animation-flag: " << flags[i];
+                LogError() << "invalid token '" << m_Token.text << "' in line " << m_Line << ", expected " << ch;
+                return Error;
             }
+
+            return Success;
         }
 
-        if (m_Args.size() >= 10)
+        bool ModelScriptTextParser::nextIs(char ch) const
         {
-            std::string firstFrame = m_Args[8];
-            std::string lastFrame = m_Args[9];
-
-            m_Ani.m_FirstFrame = std::stoi(firstFrame);
-            m_Ani.m_LastFrame = std::stoi(lastFrame);
+            return !m_NextToken.text.empty() && m_NextToken.text[0] == ch;
         }
 
-        /*m_Ani.m_BlendIn = m_Args[3];*/
-        /*m_Ani.m_BlendOut = m_Args[4];*/
-        /*m_Ani.m_Flags = m_Args[5];*/
-        /*m_Ani.m_Asc = m_Args[6];*/
-        /**/
-        /*m_Ani.mStartFrame = m_Args[8];*/
-        /*m_Ani.mEndFrame = m_Args[9];*/
-        // TODO: Read FPS
-
-        return parseAniEvents();
-    }
-
-    ModelScriptTextParser::Result ModelScriptTextParser::parseAniAlias()
-    {
-        Result res = parseArguments();
-        if (res != Success)
-            return Error;
-
-        if (m_ArgCount < 8)
+        ModelScriptTextParser::Result ModelScriptTextParser::parseObjectStart()
         {
-            LogError() << "invalid number of arguments for aniAlias at line " << m_Line;
-            return Error;
+            return expectChar('{');
         }
 
-        m_Alias.m_Name = m_Args[0];
-        std::transform(m_Alias.m_Name.begin(), m_Alias.m_Name.end(), m_Alias.m_Name.begin(), ::toupper);
-
-        m_Ani.m_Layer = std::stoi(m_Args[1]);
-
-        m_Alias.m_Next = m_Args[2];
-        std::transform(m_Alias.m_Next.begin(), m_Alias.m_Next.end(), m_Alias.m_Next.begin(), ::toupper);
-
-        m_Alias.m_Alias = m_Args[6];
-        std::transform(m_Alias.m_Alias.begin(), m_Alias.m_Alias.end(), m_Alias.m_Alias.begin(), ::toupper);
-
-        m_Alias.m_Dir = (!m_Args[7].empty() && m_Args[7][0] == 'R') ? MSB_BACKWARD : MSB_FORWARD;
-
-        std::string& flags = m_Args[5];
-
-        m_Alias.m_Flags = 0;
-        for (size_t i = 0; i < flags.size(); i++)
+        ModelScriptTextParser::Result ModelScriptTextParser::parseObjectEnd()
         {
-            switch (flags[i])
+            return expectChar('}');
+        }
+
+        ModelScriptBinParser::EChunkType ModelScriptTextParser::parse()
+        {
+            if (isEof())
+                return CHUNK_EOF;
+
+            // token is consumed by the functions below
+            Result res = token();
+            if (res != Success)
+                return CHUNK_ERROR;
+
+            if (!m_Token.text.empty() && m_Token.text[0] == '}')
             {
-                case 'M':
-                    m_Alias.m_Flags |= EModelScriptAniFlags::MSB_MOVE_MODEL;
-                    break;
+                // skip '}'
+                if (!token())
+                    return CHUNK_ERROR;
 
-                case 'R':
-                    m_Alias.m_Flags |= EModelScriptAniFlags::MSB_ROTATE_MODEL;
-                    break;
-
-                case 'E':
-                    m_Alias.m_Flags |= EModelScriptAniFlags::MSB_QUEUE_ANI;
-                    break;
-
-                case 'F':
-                    m_Alias.m_Flags |= EModelScriptAniFlags::MSB_FLY;
-                    break;
-
-                case 'I':
-                    m_Alias.m_Flags |= EModelScriptAniFlags::MSB_IDLE;
-                    break;
-
-                case '.':
-                    // This is used as a placeholder
-                    break;
-
-                default:
-                    LogWarn() << "Anim: Unknown anialias-flag: " << flags[i];
-            }
-        }
-
-        return parseAniEvents();
-    }
-
-    ModelScriptTextParser::Result ModelScriptTextParser::parseAniBlend()
-    {
-        Result res = parseArguments();
-        if (res != Success)
-            return Error;
-
-        if (m_ArgCount < 2 || m_ArgCount > 4)
-        {
-            LogError() << "invalid number of arguments for aniBlend at line " << m_Line;
-            return Error;
-        }
-
-        m_Blend.m_Name = m_Args[0];
-        std::transform(m_Blend.m_Name.begin(), m_Blend.m_Name.end(), m_Blend.m_Name.begin(), ::toupper);
-
-        m_Blend.m_Next = m_Args[1];
-        std::transform(m_Blend.m_Next.begin(), m_Blend.m_Next.end(), m_Blend.m_Next.begin(), ::toupper);
-
-        // There doesn't seem to be any layer information on the aniBlends
-        m_Blend.m_Layer = 1;
-
-        if (m_ArgCount <= 2)
-        {
-            m_Blend.m_BlendIn = 0.0f;
-            m_Blend.m_BlendOut = 0.0f;
-        }
-        else
-        {
-            m_Blend.m_BlendIn = std::stof(m_Args[2]);
-            m_Blend.m_BlendOut = std::stof(m_Args[3]);
-        }
-
-        return parseAniEvents();
-    }
-
-    ModelScriptTextParser::Result ModelScriptTextParser::parseSwapMeshEvent()
-    {
-        Result res = parseArguments();
-        if (res != Success)
-            return Error;
-
-        // TODO: assign
-
-        return Success;
-    }
-
-    inline bool isStringNumber(const std::string& s)
-    {
-        return s.find_first_not_of("0123456789") == std::string::npos;
-    }
-    ModelScriptTextParser::Result ModelScriptTextParser::parsePfxEvent()
-    {
-        Result res = parseArguments();
-        if (res != Success || m_Args.size() < 3 || m_Args.size() > 5)
-            return Error;
-
-        m_Pfx.emplace_back();
-        unsigned int currentArgIndex = 0;
-        //Base case: no node name and no attach
-        m_Pfx.back().m_Frame = (uint32_t)std::stoi(m_Args[currentArgIndex]);
-        ++currentArgIndex;
-        //If pfx event has no handle number, no pfx end event exists for it
-        if (isStringNumber(m_Args[currentArgIndex]))
-        {
-            m_Pfx.back().m_Num = (uint32_t)std::stoi(m_Args[currentArgIndex]);
-            ++currentArgIndex;
-        }
-        else
-        {
-            m_Pfx.back().m_Num = 0;
-        }
-        m_Pfx.back().m_Name = m_Args[currentArgIndex];
-        ++currentArgIndex;
-
-        switch (m_Args.size())
-        {
-            //No attach
-            case 4:
-                m_Pfx.back().m_Pos = m_Args[currentArgIndex];
-                break;
-            case 5:
-                m_Pfx.back().m_Pos = m_Args[currentArgIndex];
-                if (m_Args[currentArgIndex] == "ATTACH")
+                if (m_Context.empty())
                 {
-                    //FIXME attach is encoded as float in other parsing function. Is this different here?
-                    m_Pfx.back().m_isAttached = true;
+                    LogError() << "unexpected '}' at line " << m_Line;
+                    return CHUNK_ERROR;
+                }
+
+                m_Context.pop_back();
+
+                return parse();
+            }
+
+            switch (m_Context.back())
+            {
+                case ContextFile:
+                    return parseFileChunk();
+                case ContextModel:
+                    return parseModelChunk();
+                case ContextAniEnum:
+                    return parseAniEnumChunk();
+            }
+
+            return CHUNK_EOF;
+        }
+
+        ModelScriptTextParser::Result ModelScriptTextParser::parseArguments()
+        {
+            if (!nextIs('('))
+            {
+                // no args, just object name
+                return Success;
+            }
+
+            Result res = expectChar('(');
+            if (res != Success)
+                return res;
+
+            m_Args.clear();
+            m_ArgCount = 0;
+            while (true)
+            {
+                res = token();
+                if (res != Success)
+                {
+                    if (res == End)
+                    {
+                        LogError() << "invalid end in argument list in line " << m_Line;
+                        return Error;
+                    }
+                    return res;
+                }
+
+                if (m_ArgCount < m_Args.size())
+                {
+                    std::string& arg = m_Args[m_ArgCount];
+                    arg.clear();
+                    arg.insert(arg.begin(), m_Token.text.begin(), m_Token.text.end());
+                }
+                else
+                    m_Args.emplace_back(m_Token.text);
+
+                m_ArgCount++;
+
+                if (!m_NextToken.text.empty() && m_NextToken.text[0] == ')')
+                    break;
+            }
+
+            return expectChar(')');
+        }
+
+        ModelScriptParser::EChunkType ModelScriptTextParser::parseFileChunk()
+        {
+            if (m_Token.text == "MODEL")
+            {
+                if (!parseModelStart())
+                    return CHUNK_ERROR;
+
+                return CHUNK_MODEL;
+            }
+
+            if (!m_Strict && !m_Token.text.empty() && m_Token.text[0] == '(')
+            {
+                // fixes duplicate '}' after anim, which will make the parser think
+                // it's on the file level
+                m_Context.push_back(ContextAniEnum);
+                return parseAniEnumChunk();
+            }
+
+            LogError() << "invalid token '" << m_Token.text << "' in file at line " << m_Line;
+            return CHUNK_ERROR;
+        }
+
+        bool ModelScriptTextParser::parseModelStart()
+        {
+            Result res = parseArguments();
+            if (res != Success)
+                return false;
+
+            // TODO: assign
+
+            res = parseObjectStart();
+            if (res != Success)
+                return false;
+
+            m_Context.push_back(ContextModel);
+
+            return true;
+        }
+
+        ModelScriptParser::EChunkType ModelScriptTextParser::parseModelChunk()
+        {
+            if (m_Token.text == "MESHANDTREE")
+            {
+                Result res = parseArguments();
+
+                // Second arg would be DONT_USE_MESH.
+                if (m_ArgCount == 1)
+                {
+                    m_MeshesASC.push_back(m_Args[0]);
+                }
+
+                m_MeshAndTree = m_Args[0];
+
+                // TODO
+                return (res != Success) ? CHUNK_ERROR : CHUNK_MESH_AND_TREE;
+            }
+            else if (m_Token.text == "REGISTERMESH")
+            {
+                Result res = parseArguments();
+
+                if (m_ArgCount == 1)
+                {
+                    m_MeshesASC.push_back(m_Args[0]);
+                }
+
+                return (res != Success) ? CHUNK_ERROR : CHUNK_REGISTER_MESH;
+            }
+            else if (m_Token.text == "ANIENUM")
+            {
+                if (!parseAniEnumStart())
+                    return CHUNK_ERROR;
+
+                return CHUNK_ANI_ENUM;
+            }
+
+            LogError() << "invalid token '" << m_Token.text << "' in Model at line " << m_Line;
+            return CHUNK_ERROR;
+        }
+
+        bool ModelScriptTextParser::parseAniEnumStart()
+        {
+            Result res = parseArguments();
+            if (res != Success)
+                return false;
+
+            // TODO: assign
+
+            res = parseObjectStart();
+            if (res != Success)
+                return false;
+
+            m_Context.push_back(ContextAniEnum);
+
+            return true;
+        }
+
+        ModelScriptTextParser::EChunkType ModelScriptTextParser::parseAniEnumChunk()
+        {
+            if (m_Token.text == "ANI")
+            {
+                return (parseAni() != Success) ? CHUNK_ERROR : CHUNK_ANI;
+            }
+            else if (m_Token.text == "ANIALIAS")
+            {
+                return (parseAniAlias() != Success) ? CHUNK_ERROR : CHUNK_ANI_ALIAS;
+            }
+            else if (m_Token.text == "ANIBLEND")
+            {
+                return (parseAniBlend() != Success) ? CHUNK_ERROR : CHUNK_ANI_BLEND;
+            }
+            else if (m_Token.text == "MODELTAG")
+            {
+                return (parseModelTag() != Success) ? CHUNK_ERROR : CHUNK_MODEL_TAG;
+            }
+            else if (m_Token.text == "ANIDISABLE")
+            {
+                return (parseAniDisable() != Success) ? CHUNK_ERROR : CHUNK_MODEL_TAG;
+            }
+            else if (m_Token.text == "ANICOMB")
+            {
+                return (parseAniComb() != Success) ? CHUNK_ERROR : CHUNK_MODEL_TAG;
+            }
+
+            LogError() << "invalid token '" << m_Token.text << "' in aniEnum at line " << m_Line;
+            return CHUNK_ERROR;
+        }
+
+        ModelScriptTextParser::Result ModelScriptTextParser::parseAniEvents()
+        {
+            if (!nextIs('{'))
+                return Success;  // no events
+
+            Result res = parseObjectStart();
+            if (res != Success)
+                return Error;
+            while (true)
+            {
+                // Need to check this first, to fix parsing of empty { } blocks
+                if (nextIs('}'))
+                    break;
+
+                res = token();
+                if (res != Success)
+                    break;
+
+                if (m_Token.text == "*EVENTSWAPMESH")
+                {
+                    res = parseSwapMeshEvent();
+                    if (res != Success)
+                        break;
+                }
+                else if (m_Token.text == "*EVENTPFX")
+                {
+                    //gets never called...
+                    res = parsePfxEvent();
+                    if (res != Success)
+                        break;
+                }
+                else if (m_Token.text == "*EVENTPFXSTOP")
+                {
+                    res = parsePfxStopEvent();
+                    if (res != Success)
+                        break;
+                }
+                else if (m_Token.text == "*EVENTSFX")
+                {
+                    res = parseSfxEvent();
+                    if (res != Success)
+                        break;
+                }
+                else if (m_Token.text == "*EVENTSFXGRND")
+                {
+                    res = parseSfxGrndEvent();
+                    if (res != Success)
+                        break;
+                }
+                else if (m_Token.text == "*EVENTTAG")
+                {
+                    res = parseTagEvent();
+                    if (res != Success)
+                        break;
+                }
+                else if (m_Token.text == "*EVENTMMSTARTANI")
+                {
+                    res = parseMMStartAniEvent();
+                    if (res != Success)
+                        break;
+                }
+                else if (m_Token.text == "*EVENTCAMTREMOR")
+                {
+                    res = parseCamTremorEvent();
+                    if (res != Success)
+                        break;
                 }
                 else
                 {
-                    LogWarn() << "Unknown string at the end of PFX Start Event " << m_Args[currentArgIndex];
+                    LogError() << "invalid token '" << m_Token.text << "' in ani at line " << m_Line;
+                    return Error;
                 }
-                break;
-            default:
-                LogWarn() << "Parsed malformed PFX Start Event";
-        }
-        return Success;
-    }
-
-    ModelScriptTextParser::Result ModelScriptTextParser::parsePfxStopEvent()
-    {
-        Result res = parseArguments();
-        if (res != Success || m_Args.size() != 2)
-            return Error;
-
-        m_PfxStop.emplace_back();
-        m_PfxStop.back().m_Frame = (uint32_t)std::stoi(m_Args[0]);
-        m_PfxStop.back().m_Num = (uint32_t)std::stoi(m_Args[1]);
-
-        return Success;
-    }
-
-    ModelScriptTextParser::Result ModelScriptTextParser::parseSfxEvent()
-    {
-        Result res = parseArguments();
-        if (res != Success || m_Args.size() < 2 || m_Args.size() > 4)
-            return Error;
-
-        m_Sfx.emplace_back();
-        m_Sfx.back().m_Frame = (uint32_t)std::stoi(m_Args[0]);
-        m_Sfx.back().m_Name = m_Args[1];
-
-        for (size_t i = 2; i < std::min(m_Args.size(), static_cast<size_t>(4)); i++)
-        {
-            // Look for optional arguments (First 2 args are required)
-            if (m_Args[i].find("R:") != std::string::npos)
-            {
-                m_Sfx.back().m_Range = std::stof(m_Args[i].substr(m_Args[i].find("R:") + 2));  // 2: Skip R:
             }
-            else if (m_Args[i] == "EMPTY_SLOT")
+
+            return parseObjectEnd();
+        }
+
+        ModelScriptTextParser::Result ModelScriptTextParser::parseAni()
+        {
+            Result res = parseArguments();
+            if (res != Success)
+                return Error;
+
+            // Most of the ani-chunks have 10 args, but they can have an additional one for FPS and some have only 8, omitting start and end-frame
+            if (m_ArgCount < 8)
             {
-                m_Sfx.back().m_EmptySlot = true;
+                LogError() << "invalid number of arguments for ani at line " << m_Line;
+                return Error;
+            }
+
+            m_Ani.m_Name = m_Args[0];
+
+            std::transform(m_Ani.m_Name.begin(), m_Ani.m_Name.end(), m_Ani.m_Name.begin(), ::toupper);
+
+            m_Ani.m_Layer = std::stoi(m_Args[1]);
+            m_Ani.m_Next = m_Args[2];
+            std::transform(m_Ani.m_Next.begin(), m_Ani.m_Next.end(), m_Ani.m_Next.begin(), ::toupper);
+
+            std::string& flags = m_Args[5];
+
+            m_Ani.m_Flags = 0;
+            for (size_t i = 0; i < flags.size(); i++)
+            {
+                switch (flags[i])
+                {
+                    case 'M':
+                        m_Ani.m_Flags |= EModelScriptAniFlags::MSB_MOVE_MODEL;
+                        break;
+
+                    case 'R':
+                        m_Ani.m_Flags |= EModelScriptAniFlags::MSB_ROTATE_MODEL;
+                        break;
+
+                    case 'E':
+                        m_Ani.m_Flags |= EModelScriptAniFlags::MSB_QUEUE_ANI;
+                        break;
+
+                    case 'F':
+                        m_Ani.m_Flags |= EModelScriptAniFlags::MSB_FLY;
+                        break;
+
+                    case 'I':
+                        m_Ani.m_Flags |= EModelScriptAniFlags::MSB_IDLE;
+                        break;
+
+                    case '.':
+                        // This is used as a placeholder
+                        break;
+
+                    default:
+                        LogWarn() << "Anim: Unknown animation-flag: " << flags[i];
+                }
+            }
+
+            if (m_Args.size() >= 10)
+            {
+                std::string firstFrame = m_Args[8];
+                std::string lastFrame = m_Args[9];
+
+                m_Ani.m_FirstFrame = std::stoi(firstFrame);
+                m_Ani.m_LastFrame = std::stoi(lastFrame);
+            }
+
+            /*m_Ani.m_BlendIn = m_Args[3];*/
+            /*m_Ani.m_BlendOut = m_Args[4];*/
+            /*m_Ani.m_Flags = m_Args[5];*/
+            /*m_Ani.m_Asc = m_Args[6];*/
+            /**/
+            /*m_Ani.mStartFrame = m_Args[8];*/
+            /*m_Ani.mEndFrame = m_Args[9];*/
+            // TODO: Read FPS
+
+            return parseAniEvents();
+        }
+
+        ModelScriptTextParser::Result ModelScriptTextParser::parseAniAlias()
+        {
+            Result res = parseArguments();
+            if (res != Success)
+                return Error;
+
+            if (m_ArgCount < 8)
+            {
+                LogError() << "invalid number of arguments for aniAlias at line " << m_Line;
+                return Error;
+            }
+
+            m_Alias.m_Name = m_Args[0];
+            std::transform(m_Alias.m_Name.begin(), m_Alias.m_Name.end(), m_Alias.m_Name.begin(), ::toupper);
+
+            m_Ani.m_Layer = std::stoi(m_Args[1]);
+
+            m_Alias.m_Next = m_Args[2];
+            std::transform(m_Alias.m_Next.begin(), m_Alias.m_Next.end(), m_Alias.m_Next.begin(), ::toupper);
+
+            m_Alias.m_Alias = m_Args[6];
+            std::transform(m_Alias.m_Alias.begin(), m_Alias.m_Alias.end(), m_Alias.m_Alias.begin(), ::toupper);
+
+            m_Alias.m_Dir = (!m_Args[7].empty() && m_Args[7][0] == 'R') ? MSB_BACKWARD : MSB_FORWARD;
+
+            std::string& flags = m_Args[5];
+
+            m_Alias.m_Flags = 0;
+            for (size_t i = 0; i < flags.size(); i++)
+            {
+                switch (flags[i])
+                {
+                    case 'M':
+                        m_Alias.m_Flags |= EModelScriptAniFlags::MSB_MOVE_MODEL;
+                        break;
+
+                    case 'R':
+                        m_Alias.m_Flags |= EModelScriptAniFlags::MSB_ROTATE_MODEL;
+                        break;
+
+                    case 'E':
+                        m_Alias.m_Flags |= EModelScriptAniFlags::MSB_QUEUE_ANI;
+                        break;
+
+                    case 'F':
+                        m_Alias.m_Flags |= EModelScriptAniFlags::MSB_FLY;
+                        break;
+
+                    case 'I':
+                        m_Alias.m_Flags |= EModelScriptAniFlags::MSB_IDLE;
+                        break;
+
+                    case '.':
+                        // This is used as a placeholder
+                        break;
+
+                    default:
+                        LogWarn() << "Anim: Unknown anialias-flag: " << flags[i];
+                }
+            }
+
+            return parseAniEvents();
+        }
+
+        ModelScriptTextParser::Result ModelScriptTextParser::parseAniBlend()
+        {
+            Result res = parseArguments();
+            if (res != Success)
+                return Error;
+
+            if (m_ArgCount < 2 || m_ArgCount > 4)
+            {
+                LogError() << "invalid number of arguments for aniBlend at line " << m_Line;
+                return Error;
+            }
+
+            m_Blend.m_Name = m_Args[0];
+            std::transform(m_Blend.m_Name.begin(), m_Blend.m_Name.end(), m_Blend.m_Name.begin(), ::toupper);
+
+            m_Blend.m_Next = m_Args[1];
+            std::transform(m_Blend.m_Next.begin(), m_Blend.m_Next.end(), m_Blend.m_Next.begin(), ::toupper);
+
+            // There doesn't seem to be any layer information on the aniBlends
+            m_Blend.m_Layer = 1;
+
+            if (m_ArgCount <= 2)
+            {
+                m_Blend.m_BlendIn = 0.0f;
+                m_Blend.m_BlendOut = 0.0f;
             }
             else
             {
-                LogWarn() << "MODELSCRIPT: Invalid eventSFX-Option: " << m_Args[i];
+                m_Blend.m_BlendIn = std::stof(m_Args[2]);
+                m_Blend.m_BlendOut = std::stof(m_Args[3]);
             }
+
+            return parseAniEvents();
         }
 
-        return Success;
-    }
-
-    ModelScriptTextParser::Result ModelScriptTextParser::parseSfxGrndEvent()
-    {
-        Result res = parseArguments();
-        if (res != Success || m_Args.size() < 2 || m_Args.size() > 4)
-            return Error;
-
-        m_SfxGround.emplace_back();
-        m_SfxGround.back().m_Frame = (uint32_t)std::stoi(m_Args[0]);
-        m_SfxGround.back().m_Name = m_Args[1];
-
-        for (size_t i = 2; i < std::min(m_Args.size(), static_cast<size_t>(4)); i++)
+        ModelScriptTextParser::Result ModelScriptTextParser::parseSwapMeshEvent()
         {
-            // Look for optional arguments (First 2 args are required)
-            if (m_Args[i].find("R:") != std::string::npos)
+            Result res = parseArguments();
+            if (res != Success)
+                return Error;
+
+            // TODO: assign
+
+            return Success;
+        }
+
+        inline bool isStringNumber(const std::string& s)
+        {
+            return s.find_first_not_of("0123456789") == std::string::npos;
+        }
+        ModelScriptTextParser::Result ModelScriptTextParser::parsePfxEvent()
+        {
+            Result res = parseArguments();
+            if (res != Success || m_Args.size() < 3 || m_Args.size() > 5)
+                return Error;
+
+            m_Pfx.emplace_back();
+            unsigned int currentArgIndex = 0;
+            //Base case: no node name and no attach
+            m_Pfx.back().m_Frame = (uint32_t)std::stoi(m_Args[currentArgIndex]);
+            ++currentArgIndex;
+            //If pfx event has no handle number, no pfx end event exists for it
+            if (isStringNumber(m_Args[currentArgIndex]))
             {
-                m_Sfx.back().m_Range = std::stof(m_Args[i].substr(m_Args[i].find("R:") + 2));  // 2: Skip R:
-            }
-            else if (m_Args[i] == "EMPTY_SLOT")
-            {
-                m_Sfx.back().m_EmptySlot = true;
+                m_Pfx.back().m_Num = (uint32_t)std::stoi(m_Args[currentArgIndex]);
+                ++currentArgIndex;
             }
             else
             {
-                LogWarn() << "MODELSCRIPT: Invalid eventSFX-Option: " << m_Args[i];
+                m_Pfx.back().m_Num = 0;
             }
+            m_Pfx.back().m_Name = m_Args[currentArgIndex];
+            ++currentArgIndex;
+
+            switch (m_Args.size())
+            {
+                //No attach
+                case 4:
+                    m_Pfx.back().m_Pos = m_Args[currentArgIndex];
+                    break;
+                case 5:
+                    m_Pfx.back().m_Pos = m_Args[currentArgIndex];
+                    if (m_Args[currentArgIndex] == "ATTACH")
+                    {
+                        //FIXME attach is encoded as float in other parsing function. Is this different here?
+                        m_Pfx.back().m_isAttached = true;
+                    }
+                    else
+                    {
+                        LogWarn() << "Unknown string at the end of PFX Start Event " << m_Args[currentArgIndex];
+                    }
+                    break;
+                default:
+                    LogWarn() << "Parsed malformed PFX Start Event";
+            }
+            return Success;
         }
 
-        return Success;
-    }
-
-    ModelScriptTextParser::Result ModelScriptTextParser::parseTagEvent()
-    {
-        Result res = parseArguments();
-        if (res != Success || m_Args.size() < 2)
-            return Error;
-
-        m_Tag.emplace_back();
-
-        // atoi is used here since some original MDS files have invalid arguments, which relay on atoi returning 0
-        // on anything that is not a number. For example, t_BSANVIL_S1_2_S0 in HUMANS.MDS has a double opening
-        // brace on one of the EventTags.
-        m_Tag.back().m_Frame = (uint32_t)atoi(m_Args[0].c_str());
-        m_Tag.back().m_Tag = m_Args[1];
-
-        if (m_Args.size() >= 3)
+        ModelScriptTextParser::Result ModelScriptTextParser::parsePfxStopEvent()
         {
-            m_Tag.back().m_Argument = m_Args[2];
+            Result res = parseArguments();
+            if (res != Success || m_Args.size() != 2)
+                return Error;
+
+            m_PfxStop.emplace_back();
+            m_PfxStop.back().m_Frame = (uint32_t)std::stoi(m_Args[0]);
+            m_PfxStop.back().m_Num = (uint32_t)std::stoi(m_Args[1]);
+
+            return Success;
         }
 
-        return Success;
-    }
+        ModelScriptTextParser::Result ModelScriptTextParser::parseSfxEvent()
+        {
+            Result res = parseArguments();
+            if (res != Success || m_Args.size() < 2 || m_Args.size() > 4)
+                return Error;
 
-    ModelScriptTextParser::Result ModelScriptTextParser::parseMMStartAniEvent()
-    {
-        Result res = parseArguments();
-        if (res != Success)
-            return Error;
+            m_Sfx.emplace_back();
+            m_Sfx.back().m_Frame = (uint32_t)std::stoi(m_Args[0]);
+            m_Sfx.back().m_Name = m_Args[1];
 
-        m_MMStartAni.emplace_back();
+            for (size_t i = 2; i < std::min(m_Args.size(), static_cast<size_t>(4)); i++)
+            {
+                // Look for optional arguments (First 2 args are required)
+                if (m_Args[i].find("R:") != std::string::npos)
+                {
+                    m_Sfx.back().m_Range = std::stof(m_Args[i].substr(m_Args[i].find("R:") + 2));  // 2: Skip R:
+                }
+                else if (m_Args[i] == "EMPTY_SLOT")
+                {
+                    m_Sfx.back().m_EmptySlot = true;
+                }
+                else
+                {
+                    LogWarn() << "MODELSCRIPT: Invalid eventSFX-Option: " << m_Args[i];
+                }
+            }
 
-        m_MMStartAni.back().m_Frame = (uint32_t)atoi(m_Args[0].c_str());
-        m_MMStartAni.back().m_Animation = m_Args[1];
+            return Success;
+        }
 
-        return Success;
-    }
+        ModelScriptTextParser::Result ModelScriptTextParser::parseSfxGrndEvent()
+        {
+            Result res = parseArguments();
+            if (res != Success || m_Args.size() < 2 || m_Args.size() > 4)
+                return Error;
 
-    ModelScriptTextParser::Result ModelScriptTextParser::parseModelTag()
-    {
-        Result res = parseArguments();
-        if (res != Success)
-            return Error;
+            m_SfxGround.emplace_back();
+            m_SfxGround.back().m_Frame = (uint32_t)std::stoi(m_Args[0]);
+            m_SfxGround.back().m_Name = m_Args[1];
 
-        // TODO: assign
+            for (size_t i = 2; i < std::min(m_Args.size(), static_cast<size_t>(4)); i++)
+            {
+                // Look for optional arguments (First 2 args are required)
+                if (m_Args[i].find("R:") != std::string::npos)
+                {
+                    m_Sfx.back().m_Range = std::stof(m_Args[i].substr(m_Args[i].find("R:") + 2));  // 2: Skip R:
+                }
+                else if (m_Args[i] == "EMPTY_SLOT")
+                {
+                    m_Sfx.back().m_EmptySlot = true;
+                }
+                else
+                {
+                    LogWarn() << "MODELSCRIPT: Invalid eventSFX-Option: " << m_Args[i];
+                }
+            }
 
-        return Success;
-    }
+            return Success;
+        }
 
-    ModelScriptTextParser::Result ModelScriptTextParser::parseAniDisable()
-    {
-        Result res = parseArguments();
-        if (res != Success)
-            return Error;
+        ModelScriptTextParser::Result ModelScriptTextParser::parseTagEvent()
+        {
+            Result res = parseArguments();
+            if (res != Success || m_Args.size() < 2)
+                return Error;
 
-        // TODO: assign
+            m_Tag.emplace_back();
 
-        return Success;
-    }
+            // atoi is used here since some original MDS files have invalid arguments, which relay on atoi returning 0
+            // on anything that is not a number. For example, t_BSANVIL_S1_2_S0 in HUMANS.MDS has a double opening
+            // brace on one of the EventTags.
+            m_Tag.back().m_Frame = (uint32_t)atoi(m_Args[0].c_str());
+            m_Tag.back().m_Tag = m_Args[1];
 
-    ModelScriptTextParser::Result ModelScriptTextParser::parseAniComb()
-    {
-        Result res = parseArguments();
-        if (res != Success)
-            return Error;
+            if (m_Args.size() >= 3)
+            {
+                m_Tag.back().m_Argument = m_Args[2];
+            }
 
-        // TODO: assign
+            return Success;
+        }
 
-        return parseAniEvents();
-    }
+        ModelScriptTextParser::Result ModelScriptTextParser::parseMMStartAniEvent()
+        {
+            Result res = parseArguments();
+            if (res != Success)
+                return Error;
 
-    ModelScriptTextParser::Result ModelScriptTextParser::parseCamTremorEvent()
-    {
-        Result res = parseArguments();
-        if (res != Success)
-            return Error;
+            m_MMStartAni.emplace_back();
 
-        // TODO: assign
+            m_MMStartAni.back().m_Frame = (uint32_t)atoi(m_Args[0].c_str());
+            m_MMStartAni.back().m_Animation = m_Args[1];
 
-        return Success;
-    }
+            return Success;
+        }
 
-}  // namespace ZenLoad
+        ModelScriptTextParser::Result ModelScriptTextParser::parseModelTag()
+        {
+            Result res = parseArguments();
+            if (res != Success)
+                return Error;
+
+            // TODO: assign
+
+            return Success;
+        }
+
+        ModelScriptTextParser::Result ModelScriptTextParser::parseAniDisable()
+        {
+            Result res = parseArguments();
+            if (res != Success)
+                return Error;
+
+            // TODO: assign
+
+            return Success;
+        }
+
+        ModelScriptTextParser::Result ModelScriptTextParser::parseAniComb()
+        {
+            Result res = parseArguments();
+            if (res != Success)
+                return Error;
+
+            // TODO: assign
+
+            return parseAniEvents();
+        }
+
+        ModelScriptTextParser::Result ModelScriptTextParser::parseCamTremorEvent()
+        {
+            Result res = parseArguments();
+            if (res != Success)
+                return Error;
+
+            // TODO: assign
+
+            return Success;
+        }
+
+    }  // namespace ZenLoad
+} // namespace ZenLib

--- a/zenload/modelScriptParser.h
+++ b/zenload/modelScriptParser.h
@@ -5,253 +5,256 @@
 #include <zenload/zCModelAni.h>
 #include <zenload/zCModelScript.h>
 
-namespace ZenLoad
+namespace ZenLib
 {
-    class ZenParser;
-
-    class ModelScriptParser
+    namespace ZenLoad
     {
-    public:
-        enum EChunkType
+        class ZenParser;
+
+        class ModelScriptParser
         {
-            CHUNK_ERROR,
-            CHUNK_EOF,
+        public:
+            enum EChunkType
+            {
+                CHUNK_ERROR,
+                CHUNK_EOF,
 
-            // CHUNK_MODEL_SCRIPT          = 0xF000,
-            // CHUNK_MODEL_SCRIPT_END      = 0xFFFF,
-            // CHUNK_SOURCE                = 0xF100,
-            CHUNK_MODEL = 0xF200,
-            // CHUNK_MODEL_END             = 0xF2FF,
-            CHUNK_MESH_AND_TREE = 0xF300,
-            CHUNK_REGISTER_MESH = 0xF400,
-            CHUNK_ANI_ENUM = 0xF500,
-            // CHUNK_ANI_ENUM_END          = 0xF5FF,
-            // CHUNK_ANI_MAX_FPS           = 0xF510,
-            CHUNK_ANI = 0xF520,
-            CHUNK_ANI_ALIAS = 0xF530,
-            CHUNK_ANI_BLEND = 0xF540,
-            // CHUNK_ANI_SYNC              = 0xF550,
-            // CHUNK_ANI_BATCH             = 0xF560,
-            // CHUNK_ANI_COMB              = 0xF570,
-            // CHUNK_ANI_DISABLE           = 0xF580,
-            CHUNK_MODEL_TAG = 0xF590,
-            // CHUNK_ANI_EVENTS            = 0xF5A0,
-            // CHUNK_ANI_EVENTS_END        = 0xF5AF,
-            CHUNK_EVENT_SFX = 0xF5A1,
-            CHUNK_EVENT_SFX_GRND = 0xF5A2,
-            // CHUNK_EVENT_TAG             = 0xF5A3,
-            CHUNK_EVENT_PFX = 0xF5A4,
-            CHUNK_EVENT_PFX_STOP = 0xF5A5,
-            // CHUNK_EVENT_PFX_GRND        = 0xF5A6,
-            // CHUNK_EVENT_SET_MESH        = 0xF5A7,
-            // CHUNK_EVENT_SWAP_MESH       = 0xF5A8,
-            // CHUNK_EVENT_MMSTARTANI      = 0xF5A9,
-            // CHUNK_EVENT_CAMTREMOR       = 0xF5AA
-        };
+                // CHUNK_MODEL_SCRIPT          = 0xF000,
+                // CHUNK_MODEL_SCRIPT_END      = 0xFFFF,
+                // CHUNK_SOURCE                = 0xF100,
+                CHUNK_MODEL = 0xF200,
+                // CHUNK_MODEL_END             = 0xF2FF,
+                CHUNK_MESH_AND_TREE = 0xF300,
+                CHUNK_REGISTER_MESH = 0xF400,
+                CHUNK_ANI_ENUM = 0xF500,
+                // CHUNK_ANI_ENUM_END          = 0xF5FF,
+                // CHUNK_ANI_MAX_FPS           = 0xF510,
+                CHUNK_ANI = 0xF520,
+                CHUNK_ANI_ALIAS = 0xF530,
+                CHUNK_ANI_BLEND = 0xF540,
+                // CHUNK_ANI_SYNC              = 0xF550,
+                // CHUNK_ANI_BATCH             = 0xF560,
+                // CHUNK_ANI_COMB              = 0xF570,
+                // CHUNK_ANI_DISABLE           = 0xF580,
+                CHUNK_MODEL_TAG = 0xF590,
+                // CHUNK_ANI_EVENTS            = 0xF5A0,
+                // CHUNK_ANI_EVENTS_END        = 0xF5AF,
+                CHUNK_EVENT_SFX = 0xF5A1,
+                CHUNK_EVENT_SFX_GRND = 0xF5A2,
+                // CHUNK_EVENT_TAG             = 0xF5A3,
+                CHUNK_EVENT_PFX = 0xF5A4,
+                CHUNK_EVENT_PFX_STOP = 0xF5A5,
+                // CHUNK_EVENT_PFX_GRND        = 0xF5A6,
+                // CHUNK_EVENT_SET_MESH        = 0xF5A7,
+                // CHUNK_EVENT_SWAP_MESH       = 0xF5A8,
+                // CHUNK_EVENT_MMSTARTANI      = 0xF5A9,
+                // CHUNK_EVENT_CAMTREMOR       = 0xF5AA
+            };
 
-        typedef std::vector<zCModelAniSample> Samples;
-        typedef std::vector<uint32_t> NodeIndex;
+            typedef std::vector<zCModelAniSample> Samples;
+            typedef std::vector<uint32_t> NodeIndex;
 
-        ModelScriptParser(ZenParser& zen);
-        virtual ~ModelScriptParser();
+            ModelScriptParser(ZenParser& zen);
+            virtual ~ModelScriptParser();
 
-        /** Returns the parsed animation alias.
+            /** Returns the parsed animation alias.
      *
      * Call this if parse() returns CHUNK_ANI.
      *
      * @return The ani read during the last call to parse().
      */
-        const zCModelScriptAni& ani() const { return m_Ani; }
+            const zCModelScriptAni& ani() const { return m_Ani; }
 
-        /** Returns the parsed animation alias.
+            /** Returns the parsed animation alias.
      *
      * Call this if parse() returns CHUNK_ANI_ALIAS.
      *
      * @return The alias read during the last call to parse().
      */
-        const zCModelScriptAniAlias& alias() const { return m_Alias; }
+            const zCModelScriptAniAlias& alias() const { return m_Alias; }
 
-        /** Returns the parsed animation blend.
+            /** Returns the parsed animation blend.
      *
      * Call this if parse() returns CHUNK_ANI_BLEND.
      *
      * @return The alias read during the last call to parse().
      */
-        const zCModelScriptAniBlend& blend() const { return m_Blend; }
+            const zCModelScriptAniBlend& blend() const { return m_Blend; }
 
-        /** Returns the sfx event.
+            /** Returns the sfx event.
      *
      * Call this if parse() returns CHUNK_EVENT_SFX or CHUNK_EVENT_SFX_GRND.
      * Also call it after an ani-chunk was parsed, in case this is a textfole
      *
      * @return The event read during the last call to parse().
      */
-        std::vector<zCModelScriptEventSfx>& sfx() { return m_Sfx; }
-        std::vector<zCModelScriptEventSfx>& sfxGround() { return m_SfxGround; }
-        std::vector<zCModelScriptEventTag>& tag() { return m_Tag; }
+            std::vector<zCModelScriptEventSfx>& sfx() { return m_Sfx; }
+            std::vector<zCModelScriptEventSfx>& sfxGround() { return m_SfxGround; }
+            std::vector<zCModelScriptEventTag>& tag() { return m_Tag; }
 
-        std::vector<zCModelScriptEventPfx>& pfx() { return m_Pfx; }
-        std::vector<zCModelScriptEventPfxStop>& pfxStop() { return m_PfxStop; }
-        std::vector<zCModelScriptEventMMStartAni>& mmStartAni() { return m_MMStartAni; }
+            std::vector<zCModelScriptEventPfx>& pfx() { return m_Pfx; }
+            std::vector<zCModelScriptEventPfxStop>& pfxStop() { return m_PfxStop; }
+            std::vector<zCModelScriptEventMMStartAni>& mmStartAni() { return m_MMStartAni; }
 
-        /** 
+            /** 
      * @return All meshes which could be used with these animations
      */
-        std::vector<std::string>& meshesASC() { return m_MeshesASC; }
+            std::vector<std::string>& meshesASC() { return m_MeshesASC; }
 
-        /**
+            /**
          * @return Skeleton hierarchy to be used with the model script.
          */
-        const std::string& meshAndTree() const { return m_MeshAndTree; }
+            const std::string& meshAndTree() const { return m_MeshAndTree; }
 
-        /** Reads the next chunk.
+            /** Reads the next chunk.
      *
      * @return The chunk type or CHUNK_ERROR / CHUNK_EOF.
      *
      */
-        virtual EChunkType parse() = 0;
+            virtual EChunkType parse() = 0;
 
-    protected:
-        ZenParser& m_Zen;
+        protected:
+            ZenParser& m_Zen;
 
-        zCModelScriptAni m_Ani;
-        zCModelScriptAniAlias m_Alias;
-        zCModelScriptAniBlend m_Blend;
-        std::vector<zCModelScriptEventPfx> m_Pfx;
-        std::vector<zCModelScriptEventPfxStop> m_PfxStop;
-        std::vector<zCModelScriptEventSfx> m_Sfx;
-        std::vector<zCModelScriptEventSfx> m_SfxGround;
-        std::vector<zCModelScriptEventTag> m_Tag;
-        std::vector<zCModelScriptEventMMStartAni> m_MMStartAni;
-        std::vector<std::string> m_MeshesASC;
-        std::string m_MeshAndTree;
-    };
+            zCModelScriptAni m_Ani;
+            zCModelScriptAniAlias m_Alias;
+            zCModelScriptAniBlend m_Blend;
+            std::vector<zCModelScriptEventPfx> m_Pfx;
+            std::vector<zCModelScriptEventPfxStop> m_PfxStop;
+            std::vector<zCModelScriptEventSfx> m_Sfx;
+            std::vector<zCModelScriptEventSfx> m_SfxGround;
+            std::vector<zCModelScriptEventTag> m_Tag;
+            std::vector<zCModelScriptEventMMStartAni> m_MMStartAni;
+            std::vector<std::string> m_MeshesASC;
+            std::string m_MeshAndTree;
+        };
 
-    /** Streaming parser for .MSB files.
+        /** Streaming parser for .MSB files.
  */
-    class ModelScriptBinParser : public ModelScriptParser
-    {
-    public:
-        ModelScriptBinParser(ZenParser& zen);
+        class ModelScriptBinParser : public ModelScriptParser
+        {
+        public:
+            ModelScriptBinParser(ZenParser& zen);
 
-        EChunkType parse() override;
+            EChunkType parse() override;
 
-    private:
-        void readAni();
-        void readAlias();
-        void readSfx();
-        void readPfx();
-        void readPfxStop();
-        void readRegisterMesh();
-        void readMeshAndTree();
-    };
+        private:
+            void readAni();
+            void readAlias();
+            void readSfx();
+            void readPfx();
+            void readPfxStop();
+            void readRegisterMesh();
+            void readMeshAndTree();
+        };
 
-    /** Streaming parser for .MDS files.
+        /** Streaming parser for .MDS files.
  */
-    class ModelScriptTextParser : public ModelScriptParser
-    {
-    public:
-        ModelScriptTextParser(ZenParser& zen);
-
-        void setStrict(bool strict) { m_Strict = strict; }
-
-        EChunkType parse() override;
-
-    private:
-        enum Result
+        class ModelScriptTextParser : public ModelScriptParser
         {
-            Error,
-            End,
-            Success
+        public:
+            ModelScriptTextParser(ZenParser& zen);
+
+            void setStrict(bool strict) { m_Strict = strict; }
+
+            EChunkType parse() override;
+
+        private:
+            enum Result
+            {
+                Error,
+                End,
+                Success
+            };
+
+            enum TokenType
+            {
+                TokenText,
+                TokenOpenParen,
+                TokenCloseParen,
+            };
+
+            enum Context
+            {
+                ContextFile,
+                ContextModel,
+                ContextAniEnum
+            };
+
+            struct Token
+            {
+                TokenType type = TokenText;
+                unsigned line = 0;
+                std::string text;
+            };
+
+            Token m_Token;
+            Token m_NextToken;
+            unsigned m_Line = 1;
+
+            std::vector<std::string> m_Args;
+            unsigned m_ArgCount = 0;
+
+            std::vector<Context> m_Context;
+
+            bool m_Strict = false;
+
+            bool isEof() const;
+
+            Result token();
+
+            Result skipSpace();
+
+            Result expectChar(char ch);
+
+            bool nextIs(char ch) const;
+
+            Result parseObjectStart();
+
+            Result parseObjectEnd();
+
+            Result parseArguments();
+
+            EChunkType parseFileChunk();
+
+            bool parseModelStart();
+
+            EChunkType parseModelChunk();
+
+            bool parseAniEnumStart();
+
+            Result parseModelTag();
+
+            Result parseAniDisable();
+
+            Result parseAniComb();
+
+            EChunkType parseAniEnumChunk();
+
+            Result parseAni();
+
+            Result parseAniAlias();
+
+            Result parseAniBlend();
+
+            Result parseAniEvents();
+
+            Result parseTagEvent();
+
+            Result parseMMStartAniEvent();
+
+            Result parseCamTremorEvent();
+
+            Result parseSfxEvent();
+
+            Result parseSfxGrndEvent();
+
+            Result parseSwapMeshEvent();
+
+            Result parsePfxEvent();
+
+            Result parsePfxStopEvent();
         };
 
-        enum TokenType
-        {
-            TokenText,
-            TokenOpenParen,
-            TokenCloseParen,
-        };
-
-        enum Context
-        {
-            ContextFile,
-            ContextModel,
-            ContextAniEnum
-        };
-
-        struct Token
-        {
-            TokenType type = TokenText;
-            unsigned line = 0;
-            std::string text;
-        };
-
-        Token m_Token;
-        Token m_NextToken;
-        unsigned m_Line = 1;
-
-        std::vector<std::string> m_Args;
-        unsigned m_ArgCount = 0;
-
-        std::vector<Context> m_Context;
-
-        bool m_Strict = false;
-
-        bool isEof() const;
-
-        Result token();
-
-        Result skipSpace();
-
-        Result expectChar(char ch);
-
-        bool nextIs(char ch) const;
-
-        Result parseObjectStart();
-
-        Result parseObjectEnd();
-
-        Result parseArguments();
-
-        EChunkType parseFileChunk();
-
-        bool parseModelStart();
-
-        EChunkType parseModelChunk();
-
-        bool parseAniEnumStart();
-
-        Result parseModelTag();
-
-        Result parseAniDisable();
-
-        Result parseAniComb();
-
-        EChunkType parseAniEnumChunk();
-
-        Result parseAni();
-
-        Result parseAniAlias();
-
-        Result parseAniBlend();
-
-        Result parseAniEvents();
-
-        Result parseTagEvent();
-
-        Result parseMMStartAniEvent();
-
-        Result parseCamTremorEvent();
-
-        Result parseSfxEvent();
-
-        Result parseSfxGrndEvent();
-
-        Result parseSwapMeshEvent();
-
-        Result parsePfxEvent();
-
-        Result parsePfxStopEvent();
-    };
-
-}  // namespace ZenLoad
+    }  // namespace ZenLoad
+}  // namespace ZenLib

--- a/zenload/msbParser.cpp
+++ b/zenload/msbParser.cpp
@@ -3,112 +3,115 @@
 #include "msbParser.h"
 #include "zenParser.h"
 
-namespace ZenLoad
+namespace ZenLib
 {
-    MsbParser::MsbParser(ZenParser& zen)
-        : m_Zen(zen)
+    namespace ZenLoad
     {
-    }
-
-    MsbParser::EChunkType MsbParser::parse()
-    {
-        if (m_Zen.getSeek() >= m_Zen.getFileSize())
-            return CHUNK_EOF;
-
-        BinaryChunkInfo chunkInfo;
-        m_Zen.readStructure(chunkInfo);
-
-        // store position after header so that we can skip the chunk
-        size_t chunkEnd = m_Zen.getSeek() + chunkInfo.length;
-
-        switch (chunkInfo.id)
+        MsbParser::MsbParser(ZenParser& zen)
+            : m_Zen(zen)
         {
-            case CHUNK_ANI:
-                readAni();
-                return CHUNK_ANI;
-            case CHUNK_ANI_ALIAS:
-                readAlias();
-                return CHUNK_ANI_ALIAS;
-            case CHUNK_EVENT_SFX:
-                readSfx();
-                return CHUNK_EVENT_SFX;
-            default:
-                m_Zen.setSeek(chunkEnd);
-                return parse();  // skip unknown chunk
         }
 
-        return CHUNK_EOF;
-    }
-
-    static uint32_t makeAniFlags(ZenParser& zen)
-    {
-        uint32_t flags = 0;
-        std::string flag_str = zen.readString();
-        for (auto ch : flag_str)
+        MsbParser::EChunkType MsbParser::parse()
         {
-            switch (ch)
+            if (m_Zen.getSeek() >= m_Zen.getFileSize())
+                return CHUNK_EOF;
+
+            BinaryChunkInfo chunkInfo;
+            m_Zen.readStructure(chunkInfo);
+
+            // store position after header so that we can skip the chunk
+            size_t chunkEnd = m_Zen.getSeek() + chunkInfo.length;
+
+            switch (chunkInfo.id)
             {
-                case 'M':
-                    flags |= MSB_MOVE_MODEL;
-                    break;
-                case 'R':
-                    flags |= MSB_ROTATE_MODEL;
-                    break;
-                case 'E':
-                    flags |= MSB_QUEUE_ANI;
-                    break;
-                case 'F':
-                    flags |= MSB_FLY;
-                    break;
-                case 'I':
-                    flags |= MSB_IDLE;
-                    break;
+                case CHUNK_ANI:
+                    readAni();
+                    return CHUNK_ANI;
+                case CHUNK_ANI_ALIAS:
+                    readAlias();
+                    return CHUNK_ANI_ALIAS;
+                case CHUNK_EVENT_SFX:
+                    readSfx();
+                    return CHUNK_EVENT_SFX;
+                default:
+                    m_Zen.setSeek(chunkEnd);
+                    return parse();  // skip unknown chunk
             }
+
+            return CHUNK_EOF;
         }
-        return flags;
-    }
 
-    static EMsbAniDir makeAniDir(ZenParser& zen)
-    {
-        std::string str = zen.readString();
-        return (!str.empty() && str[0] == 'R') ? MSB_BACKWARD : MSB_FORWARD;
-    }
+        static uint32_t makeAniFlags(ZenParser& zen)
+        {
+            uint32_t flags = 0;
+            std::string flag_str = zen.readString();
+            for (auto ch : flag_str)
+            {
+                switch (ch)
+                {
+                    case 'M':
+                        flags |= MSB_MOVE_MODEL;
+                        break;
+                    case 'R':
+                        flags |= MSB_ROTATE_MODEL;
+                        break;
+                    case 'E':
+                        flags |= MSB_QUEUE_ANI;
+                        break;
+                    case 'F':
+                        flags |= MSB_FLY;
+                        break;
+                    case 'I':
+                        flags |= MSB_IDLE;
+                        break;
+                }
+            }
+            return flags;
+        }
 
-    void MsbParser::readAni()
-    {
-        m_Ani.m_Name = m_Zen.readLine(true);
-        m_Ani.m_Layer = m_Zen.readBinaryDWord();
-        m_Ani.m_Next = m_Zen.readLine(true);
-        m_Ani.m_BlendIn = m_Zen.readBinaryFloat();
-        m_Ani.m_BlendOut = m_Zen.readBinaryFloat();
-        m_Ani.m_Flags = makeAniFlags(m_Zen);
-        m_Ani.m_Asc = m_Zen.readLine(true);
-        m_Ani.m_Dir = makeAniDir(m_Zen);
-        m_Ani.m_FirstFrame = m_Zen.readBinaryDWord();
-        m_Ani.m_LastFrame = m_Zen.readBinaryDWord();
-        m_Ani.m_MaxFps = m_Zen.readBinaryFloat();
-        m_Ani.m_Speed = m_Zen.readBinaryFloat();
-        m_Ani.m_ColVolScale = m_Zen.readBinaryFloat();
-    }
+        static EMsbAniDir makeAniDir(ZenParser& zen)
+        {
+            std::string str = zen.readString();
+            return (!str.empty() && str[0] == 'R') ? MSB_BACKWARD : MSB_FORWARD;
+        }
 
-    void MsbParser::readAlias()
-    {
-        m_Alias.m_Name = m_Zen.readLine(true);
-        m_Alias.m_Layer = m_Zen.readBinaryDWord();
-        m_Alias.m_Next = m_Zen.readLine(true);
-        m_Alias.m_BlendIn = m_Zen.readBinaryFloat();
-        m_Alias.m_BlendOut = m_Zen.readBinaryFloat();
-        m_Alias.m_Flags = makeAniFlags(m_Zen);
-        m_Alias.m_Alias = m_Zen.readLine(true);
-        m_Ani.m_Dir = makeAniDir(m_Zen);
-    }
+        void MsbParser::readAni()
+        {
+            m_Ani.m_Name = m_Zen.readLine(true);
+            m_Ani.m_Layer = m_Zen.readBinaryDWord();
+            m_Ani.m_Next = m_Zen.readLine(true);
+            m_Ani.m_BlendIn = m_Zen.readBinaryFloat();
+            m_Ani.m_BlendOut = m_Zen.readBinaryFloat();
+            m_Ani.m_Flags = makeAniFlags(m_Zen);
+            m_Ani.m_Asc = m_Zen.readLine(true);
+            m_Ani.m_Dir = makeAniDir(m_Zen);
+            m_Ani.m_FirstFrame = m_Zen.readBinaryDWord();
+            m_Ani.m_LastFrame = m_Zen.readBinaryDWord();
+            m_Ani.m_MaxFps = m_Zen.readBinaryFloat();
+            m_Ani.m_Speed = m_Zen.readBinaryFloat();
+            m_Ani.m_ColVolScale = m_Zen.readBinaryFloat();
+        }
 
-    void MsbParser::readSfx()
-    {
-        m_Sfx.m_Frame = m_Zen.readBinaryDWord();
-        m_Sfx.m_Name = m_Zen.readLine(true);
-        m_Sfx.m_Value1 = m_Zen.readLine(true);
-        m_Sfx.m_Value2 = m_Zen.readLine(true);
-    }
+        void MsbParser::readAlias()
+        {
+            m_Alias.m_Name = m_Zen.readLine(true);
+            m_Alias.m_Layer = m_Zen.readBinaryDWord();
+            m_Alias.m_Next = m_Zen.readLine(true);
+            m_Alias.m_BlendIn = m_Zen.readBinaryFloat();
+            m_Alias.m_BlendOut = m_Zen.readBinaryFloat();
+            m_Alias.m_Flags = makeAniFlags(m_Zen);
+            m_Alias.m_Alias = m_Zen.readLine(true);
+            m_Ani.m_Dir = makeAniDir(m_Zen);
+        }
 
-}  // namespace ZenLoad
+        void MsbParser::readSfx()
+        {
+            m_Sfx.m_Frame = m_Zen.readBinaryDWord();
+            m_Sfx.m_Name = m_Zen.readLine(true);
+            m_Sfx.m_Value1 = m_Zen.readLine(true);
+            m_Sfx.m_Value2 = m_Zen.readLine(true);
+        }
+
+    }  // namespace ZenLoad
+}  // namespace ZenLib

--- a/zenload/msbParser.h
+++ b/zenload/msbParser.h
@@ -4,189 +4,192 @@
 
 #include <zenload/zCModelAni.h>
 
-namespace ZenLoad
+namespace ZenLib
 {
-    // TODO: these should be general flags?
-    enum EMsbAniFlags
+    namespace ZenLoad
     {
-        /// Animation moves model in world space
-        MSB_MOVE_MODEL = 0x00000001,
-        /// Animation rotates model in world space
-        MSB_ROTATE_MODEL = 0x00000002,
-        /// Animation is queued after the current any on layer instead of started immediately
-        MSB_QUEUE_ANI = 0x00000004,
-        /// Don't stick to ground
-        MSB_FLY = 0x00000008,
-        /// Idle animation
-        MSB_IDLE = 0x00000010,
-    };
-
-    // TODO: should general enum?
-    enum EMsbAniDir
-    {
-        MSB_FORWARD,
-        MSB_BACKWARD
-    };
-
-    struct zCMsbAni
-    {
-        /// Add + ".MAN" for the animation data
-        std::string m_Name;
-        uint32_t m_Layer = 0;
-        std::string m_Next;
-        float m_BlendIn = 0;
-        float m_BlendOut = 0;
-        uint32_t m_Flags = 0;
-        std::string m_Asc;
-        EMsbAniDir m_Dir = MSB_FORWARD;
-        uint32_t m_FirstFrame = 0;
-        uint32_t m_LastFrame = 0;
-        float m_MaxFps = 0.0f;
-        float m_Speed = 0.0f;
-        float m_ColVolScale = 1.0f;
-    };
-
-    struct zCMsbAniAlias
-    {
-        /// Add + ".MAN" for the animation data
-        std::string m_Name;
-        uint32_t m_Layer = 0;
-        std::string m_Next;
-        float m_BlendIn = 0;
-        float m_BlendOut = 0;
-        uint32_t m_Flags = 0;
-        std::string m_Alias;
-        EMsbAniDir m_Dir = MSB_FORWARD;
-    };
-
-    struct zCMsbAniBlend
-    {
-        std::string m_Name;
-        uint32_t m_Layer = 0;
-        std::string m_Next;
-        float m_BlendIn = 0;
-        float m_BlendOut = 0;
-    };
-
-    struct zCMsbAniSync
-    {
-        std::string m_Name;
-        uint32_t m_Layer = 0;
-        std::string m_Next;
-    };
-
-    struct zCMsbAniCombine
-    {
-        std::string m_Name;
-        uint32_t m_Layer = 0;
-        std::string m_Next;
-        float m_BlendIn = 0;
-        float m_BlendOut = 0;
-        uint32_t m_Flags = 0;
-        std::string m_Asc;
-        uint32_t m_LastFrame = 0;
-    };
-
-    struct zCMsbAniDisable
-    {
-        std::string m_Name;
-    };
-
-    struct zCMsbTag
-    {
-        std::string m_Tag;
-        std::string m_Values[ANIEVENT_MAXSTRING];
-    };
-
-    struct zCMsbEventSfx
-    {
-        uint32_t m_Frame = 0;
-        std::string m_Name;
-        std::string m_Value1;
-        std::string m_Value2;
-    };
-
-    class ZenParser;
-
-    /** Streaming parser for .MAN files.
- */
-    class MsbParser
-    {
-    public:
-        typedef std::vector<zCModelAniSample> Samples;
-        typedef std::vector<uint32_t> NodeIndex;
-
-        enum EChunkType
+        // TODO: these should be general flags?
+        enum EMsbAniFlags
         {
-            CHUNK_ERROR,
-            CHUNK_EOF,
-
-            CHUNK_MODEL_SCRIPT = 0xF000,
-            CHUNK_SOURCE = 0xF100,
-            CHUNK_MODEL = 0xF200,
-            CHUNK_MESH_AND_TREE = 0xF300,
-            CHUNK_REGISTER_MESH = 0xF400,
-            CHUNK_ANI_ENUM = 0xF500,
-            CHUNK_ANI_MAX_FPS = 0xF510,
-            CHUNK_ANI = 0xF520,
-            CHUNK_ANI_ALIAS = 0xF530,
-            CHUNK_ANI_BLEND = 0xF540,
-            CHUNK_ANI_SYNC = 0xF550,
-            CHUNK_ANI_BATCH = 0xF560,
-            CHUNK_ANI_COMB = 0xF570,
-            CHUNK_ANI_DISABLE = 0xF580,
-            CHUNK_MODE_LTAG = 0xF590,
-            CHUNK_ANI_EVENTS = 0xF5A0,
-            CHUNK_EVENT_SFX = 0xF5A1,
-            CHUNK_EVENT_SFX_GRND = 0xF5A2,
-            CHUNK_EVENT_TAG = 0xF5A3,
-            CHUNK_EVENT_PFX = 0xF5A4,
-            CHUNK_EVENT_PFX_STOP = 0xF5A5,
-            CHUNK_EVENT_PFX_GRND = 0xF5A6,
-            CHUNK_EVENT_SET_MESH = 0xF5A7,
-            CHUNK_EVENT_SWAP_MESH = 0xF5A8,
-            CHUNK_EVENT_MMSTARTANI = 0xF5A9,
-            CHUNK_EVENT_CAMTREMOR = 0xF5AA
+            /// Animation moves model in world space
+            MSB_MOVE_MODEL = 0x00000001,
+            /// Animation rotates model in world space
+            MSB_ROTATE_MODEL = 0x00000002,
+            /// Animation is queued after the current any on layer instead of started immediately
+            MSB_QUEUE_ANI = 0x00000004,
+            /// Don't stick to ground
+            MSB_FLY = 0x00000008,
+            /// Idle animation
+            MSB_IDLE = 0x00000010,
         };
 
-        MsbParser(ZenParser& zen);
+        // TODO: should general enum?
+        enum EMsbAniDir
+        {
+            MSB_FORWARD,
+            MSB_BACKWARD
+        };
 
-        /** Returns the parsed animation alias.
+        struct zCMsbAni
+        {
+            /// Add + ".MAN" for the animation data
+            std::string m_Name;
+            uint32_t m_Layer = 0;
+            std::string m_Next;
+            float m_BlendIn = 0;
+            float m_BlendOut = 0;
+            uint32_t m_Flags = 0;
+            std::string m_Asc;
+            EMsbAniDir m_Dir = MSB_FORWARD;
+            uint32_t m_FirstFrame = 0;
+            uint32_t m_LastFrame = 0;
+            float m_MaxFps = 0.0f;
+            float m_Speed = 0.0f;
+            float m_ColVolScale = 1.0f;
+        };
+
+        struct zCMsbAniAlias
+        {
+            /// Add + ".MAN" for the animation data
+            std::string m_Name;
+            uint32_t m_Layer = 0;
+            std::string m_Next;
+            float m_BlendIn = 0;
+            float m_BlendOut = 0;
+            uint32_t m_Flags = 0;
+            std::string m_Alias;
+            EMsbAniDir m_Dir = MSB_FORWARD;
+        };
+
+        struct zCMsbAniBlend
+        {
+            std::string m_Name;
+            uint32_t m_Layer = 0;
+            std::string m_Next;
+            float m_BlendIn = 0;
+            float m_BlendOut = 0;
+        };
+
+        struct zCMsbAniSync
+        {
+            std::string m_Name;
+            uint32_t m_Layer = 0;
+            std::string m_Next;
+        };
+
+        struct zCMsbAniCombine
+        {
+            std::string m_Name;
+            uint32_t m_Layer = 0;
+            std::string m_Next;
+            float m_BlendIn = 0;
+            float m_BlendOut = 0;
+            uint32_t m_Flags = 0;
+            std::string m_Asc;
+            uint32_t m_LastFrame = 0;
+        };
+
+        struct zCMsbAniDisable
+        {
+            std::string m_Name;
+        };
+
+        struct zCMsbTag
+        {
+            std::string m_Tag;
+            std::string m_Values[ANIEVENT_MAXSTRING];
+        };
+
+        struct zCMsbEventSfx
+        {
+            uint32_t m_Frame = 0;
+            std::string m_Name;
+            std::string m_Value1;
+            std::string m_Value2;
+        };
+
+        class ZenParser;
+
+        /** Streaming parser for .MAN files.
+ */
+        class MsbParser
+        {
+        public:
+            typedef std::vector<zCModelAniSample> Samples;
+            typedef std::vector<uint32_t> NodeIndex;
+
+            enum EChunkType
+            {
+                CHUNK_ERROR,
+                CHUNK_EOF,
+
+                CHUNK_MODEL_SCRIPT = 0xF000,
+                CHUNK_SOURCE = 0xF100,
+                CHUNK_MODEL = 0xF200,
+                CHUNK_MESH_AND_TREE = 0xF300,
+                CHUNK_REGISTER_MESH = 0xF400,
+                CHUNK_ANI_ENUM = 0xF500,
+                CHUNK_ANI_MAX_FPS = 0xF510,
+                CHUNK_ANI = 0xF520,
+                CHUNK_ANI_ALIAS = 0xF530,
+                CHUNK_ANI_BLEND = 0xF540,
+                CHUNK_ANI_SYNC = 0xF550,
+                CHUNK_ANI_BATCH = 0xF560,
+                CHUNK_ANI_COMB = 0xF570,
+                CHUNK_ANI_DISABLE = 0xF580,
+                CHUNK_MODE_LTAG = 0xF590,
+                CHUNK_ANI_EVENTS = 0xF5A0,
+                CHUNK_EVENT_SFX = 0xF5A1,
+                CHUNK_EVENT_SFX_GRND = 0xF5A2,
+                CHUNK_EVENT_TAG = 0xF5A3,
+                CHUNK_EVENT_PFX = 0xF5A4,
+                CHUNK_EVENT_PFX_STOP = 0xF5A5,
+                CHUNK_EVENT_PFX_GRND = 0xF5A6,
+                CHUNK_EVENT_SET_MESH = 0xF5A7,
+                CHUNK_EVENT_SWAP_MESH = 0xF5A8,
+                CHUNK_EVENT_MMSTARTANI = 0xF5A9,
+                CHUNK_EVENT_CAMTREMOR = 0xF5AA
+            };
+
+            MsbParser(ZenParser& zen);
+
+            /** Returns the parsed animation alias.
      *
      * Call this if parse() returns CHUNK_ANI.
      *
      * @return The ani read during the last call to parse().
      */
-        const zCMsbAni& ani() const { return m_Ani; }
+            const zCMsbAni& ani() const { return m_Ani; }
 
-        /** Returns the parsed animation alias.
+            /** Returns the parsed animation alias.
      *
      * Call this if parse() returns CHUNK_ANI_ALIAS.
      *
      * @return The alias read during the last call to parse().
      */
-        const zCMsbAniAlias& alias() const { return m_Alias; }
+            const zCMsbAniAlias& alias() const { return m_Alias; }
 
-        /** Returns the sfx event.
+            /** Returns the sfx event.
      *
      * Call this if parse() returns CHUNK_EVENT_SFX or CHUNK_EVENT_SFX_GRND.
      *
      * @return The header read during the last call to parse().
      */
-        const zCMsbEventSfx& sfx() const { return m_Sfx; }
+            const zCMsbEventSfx& sfx() const { return m_Sfx; }
 
-        EChunkType parse();
+            EChunkType parse();
 
-    private:
-        ZenParser& m_Zen;
+        private:
+            ZenParser& m_Zen;
 
-        zCMsbAni m_Ani;
-        zCMsbAniAlias m_Alias;
-        zCMsbEventSfx m_Sfx;
+            zCMsbAni m_Ani;
+            zCMsbAniAlias m_Alias;
+            zCMsbEventSfx m_Sfx;
 
-        void readAni();
-        void readAlias();
-        void readSfx();
-    };
+            void readAni();
+            void readAlias();
+            void readSfx();
+        };
 
-}  // namespace ZenLoad
+    }  // namespace ZenLoad
+}  // namespace ZenLib

--- a/zenload/oCWorld.h
+++ b/zenload/oCWorld.h
@@ -5,114 +5,117 @@
 #include "zenParser.h"
 #include "utils/logger.h"
 
-namespace ZenLoad
+namespace ZenLib
 {
-    class oCWorld
+    namespace ZenLoad
     {
-    public:
-        enum class WorldVersionInternal
+        class oCWorld
         {
-            VERSION_G1_08k = 64513,
-            VERSION_G26fix = 0
-        };
-
-        static size_t readVobTree(ZenParser& parser, std::vector<zCVobData>& target, WorldVersion worldversion)
-        {
-            uint32_t numChildren;
-
-            ZenParser::ChunkHeader header;
-            parser.readChunkStart(header);
-
-            if (header.classname == "\xA7")
+        public:
+            enum class WorldVersionInternal
             {
-                parser.skipChunk();
+                VERSION_G1_08k = 64513,
+                VERSION_G26fix = 0
+            };
 
-                // Read how many vobs this one has as child
-                parser.getImpl()->readEntry("", &numChildren, sizeof(numChildren), ZenLoad::ParserImpl::ZVT_INT);
-
-                return 0;
-            }
-
-            // Read vob data, followed by the count of the children of this vob
-            target.emplace_back();
-            zCVob::readObjectData(target.back(), parser, worldversion, header);
-
-            // Save classname of this vob
-            target.back().objectClass = header.classname;
-
-            // Read how many vobs this one has as child
-            parser.getImpl()->readEntry("", &numChildren, sizeof(numChildren), ZenLoad::ParserImpl::ZVT_INT);
-
-            // Add to parent
-
-            // Read children
-            target.back().childVobs.reserve(numChildren);
-
-            size_t num = 1;  // 1 + children
-            for (uint32_t i = 0; i < numChildren; i++)
+            static size_t readVobTree(ZenParser& parser, std::vector<zCVobData>& target, WorldVersion worldversion)
             {
-                num += readVobTree(parser, target.back().childVobs, worldversion);
-            }
+                uint32_t numChildren;
 
-            return num;
-        }
-
-        /**
-		* Reads this object from an internal zen
-		*/
-        static void readObjectData(oCWorldData& info, ZenParser& parser, uint32_t versionInternal)
-        {
-            WorldVersion version;
-            if (versionInternal == static_cast<uint32_t>(WorldVersionInternal::VERSION_G1_08k))
-                version = WorldVersion::VERSION_G1_08k;
-            else
-                version = WorldVersion::VERSION_G26fix;
-
-            info.objectClass = "oCWorld";
-
-            while (!parser.readChunkEnd())
-            {
                 ZenParser::ChunkHeader header;
                 parser.readChunkStart(header);
 
-                LogInfo() << "oCWorld reading chunk: " << header.name;
-
-                if (header.name == "MeshAndBsp")
+                if (header.classname == "\xA7")
                 {
-                    parser.readWorldMesh(info);
-                    parser.readChunkEnd();
-                }
-                else if (header.name == "VobTree")
-                {
-                    //parser.skipChunk();
-                    zCVobData mainVobTree;
-                    uint32_t numChildren;
+                    parser.skipChunk();
 
                     // Read how many vobs this one has as child
                     parser.getImpl()->readEntry("", &numChildren, sizeof(numChildren), ZenLoad::ParserImpl::ZVT_INT);
 
-                    info.rootVobs.reserve(numChildren);
+                    return 0;
+                }
 
-                    // Read children
-                    info.numVobsTotal = 0;
-                    for (uint32_t i = 0; i < numChildren; i++)
-                    {
-                        info.numVobsTotal += readVobTree(parser, info.rootVobs, version);
-                    }
-                    parser.readChunkEnd();
-                }
-                else if (header.name == "WayNet")
+                // Read vob data, followed by the count of the children of this vob
+                target.emplace_back();
+                zCVob::readObjectData(target.back(), parser, worldversion, header);
+
+                // Save classname of this vob
+                target.back().objectClass = header.classname;
+
+                // Read how many vobs this one has as child
+                parser.getImpl()->readEntry("", &numChildren, sizeof(numChildren), ZenLoad::ParserImpl::ZVT_INT);
+
+                // Add to parent
+
+                // Read children
+                target.back().childVobs.reserve(numChildren);
+
+                size_t num = 1;  // 1 + children
+                for (uint32_t i = 0; i < numChildren; i++)
                 {
-                    zCWayNet::readObjectData(info.waynet, parser);
+                    num += readVobTree(parser, target.back().childVobs, worldversion);
                 }
+
+                return num;
+            }
+
+            /**
+		* Reads this object from an internal zen
+		*/
+            static void readObjectData(oCWorldData& info, ZenParser& parser, uint32_t versionInternal)
+            {
+                WorldVersion version;
+                if (versionInternal == static_cast<uint32_t>(WorldVersionInternal::VERSION_G1_08k))
+                    version = WorldVersion::VERSION_G1_08k;
                 else
+                    version = WorldVersion::VERSION_G26fix;
+
+                info.objectClass = "oCWorld";
+
+                while (!parser.readChunkEnd())
                 {
-                    parser.skipChunk();
+                    ZenParser::ChunkHeader header;
+                    parser.readChunkStart(header);
+
+                    LogInfo() << "oCWorld reading chunk: " << header.name;
+
+                    if (header.name == "MeshAndBsp")
+                    {
+                        parser.readWorldMesh(info);
+                        parser.readChunkEnd();
+                    }
+                    else if (header.name == "VobTree")
+                    {
+                        //parser.skipChunk();
+                        zCVobData mainVobTree;
+                        uint32_t numChildren;
+
+                        // Read how many vobs this one has as child
+                        parser.getImpl()->readEntry("", &numChildren, sizeof(numChildren), ZenLoad::ParserImpl::ZVT_INT);
+
+                        info.rootVobs.reserve(numChildren);
+
+                        // Read children
+                        info.numVobsTotal = 0;
+                        for (uint32_t i = 0; i < numChildren; i++)
+                        {
+                            info.numVobsTotal += readVobTree(parser, info.rootVobs, version);
+                        }
+                        parser.readChunkEnd();
+                    }
+                    else if (header.name == "WayNet")
+                    {
+                        zCWayNet::readObjectData(info.waynet, parser);
+                    }
+                    else
+                    {
+                        parser.skipChunk();
+                    }
                 }
             }
-        }
 
-    private:
-    };
+        private:
+        };
 
-}  // namespace ZenLoad
+    }  // namespace ZenLoad
+}  // namespace ZenLib

--- a/zenload/parserImpl.cpp
+++ b/zenload/parserImpl.cpp
@@ -1,6 +1,9 @@
 #include "parserImpl.h"
 
-ZenLoad::ParserImpl::ParserImpl(ZenParser* parser)
-    : m_pParser(parser)
+namespace ZenLib
 {
-}
+    ZenLoad::ParserImpl::ParserImpl(ZenParser* parser)
+        : m_pParser(parser)
+    {
+    }
+}  // namespace ZenLib

--- a/zenload/parserImpl.h
+++ b/zenload/parserImpl.h
@@ -1,85 +1,88 @@
 #pragma once
 #include "zenParser.h"
 
-namespace ZenLoad
+namespace ZenLib
 {
-    class ParserImpl
+    namespace ZenLoad
     {
-    public:
-        /**
+        class ParserImpl
+        {
+        public:
+            /**
 		* @brief Type of data in front of the chunks of the binSave-format
 		*/
-        enum EZenValueType
-        {
-            ZVT_0 = 0,
-            ZVT_STRING = 0x1,
-            ZVT_INT = 0x2,
-            ZVT_FLOAT = 0x3,
-            ZVT_BYTE = 0x4,
-            ZVT_WORD = 0x5,
-            ZVT_BOOL = 0x6,
-            ZVT_VEC3 = 0x7,
-            ZVT_COLOR = 0x8,
-            ZVT_RAW = 0x9,
-            ZVT_HASH = 0x12,
-            ZVT_10,
-            ZVT_11,
-            ZVT_12,
-            ZVT_13,
-            ZVT_14,
-            ZVT_15,
-            ZVT_RAW_FLOAT = 0x10,
-            ZVT_ENUM = 0x11,
-        };
+            enum EZenValueType
+            {
+                ZVT_0 = 0,
+                ZVT_STRING = 0x1,
+                ZVT_INT = 0x2,
+                ZVT_FLOAT = 0x3,
+                ZVT_BYTE = 0x4,
+                ZVT_WORD = 0x5,
+                ZVT_BOOL = 0x6,
+                ZVT_VEC3 = 0x7,
+                ZVT_COLOR = 0x8,
+                ZVT_RAW = 0x9,
+                ZVT_HASH = 0x12,
+                ZVT_10,
+                ZVT_11,
+                ZVT_12,
+                ZVT_13,
+                ZVT_14,
+                ZVT_15,
+                ZVT_RAW_FLOAT = 0x10,
+                ZVT_ENUM = 0x11,
+            };
 
-        ParserImpl(ZenParser* parser);
-        virtual ~ParserImpl() {}
+            ParserImpl(ZenParser* parser);
+            virtual ~ParserImpl() {}
 
-        /**
+            /**
 		 * @brief Read the implementation specific header and stores it in the parsers main-header struct
 		 */
-        virtual void readImplHeader() = 0;
+            virtual void readImplHeader() = 0;
 
-        /**
+            /**
 		 * @brief Read the start of a chunk. [...] Returns true if there actually was a start. 
 		 *		  Otherwise it will leave m_Seek untouched and return false.
 		 */
-        virtual bool readChunkStart(ZenParser::ChunkHeader& header) = 0;
+            virtual bool readChunkStart(ZenParser::ChunkHeader& header) = 0;
 
-        /**
+            /**
 		 * @brief Reads the end of a chunk. Returns true if there actually was an end. 
 		 *		  Otherwise it will leave m_Seek untouched and return false.
 		 */
-        virtual bool readChunkEnd() = 0;
+            virtual bool readChunkEnd() = 0;
 
-        /**
+            /**
 		 * @brief Reads a string
 		 */
-        virtual std::string readString() = 0;
+            virtual std::string readString() = 0;
 
-        /**
+            /**
 		 * @brief Reads data of the expected type. Throws if the read type is not the same as specified and not 0
 		 */
-        virtual void readEntry(const char* name, void* target, size_t targetSize, EZenValueType expectedType = ZVT_0) = 0;
+            virtual void readEntry(const char* name, void* target, size_t targetSize, EZenValueType expectedType = ZVT_0) = 0;
 
-        void readEntry(const char* name, std::string* target)   { readEntry(name, target, 0, ZVT_STRING); }
-        void readEntry(const char* name, int32_t* target)       { readEntry(name, target, sizeof(*target), ZVT_INT); }
-        void readEntry(const char* name, uint8_t* target)       { readEntry(name, target, sizeof(*target), ZVT_BYTE); }
-        void readEntry(const char* name, bool* target)          { readEntry(name, target, sizeof(*target), ZVT_BOOL); }
-        void readEntry(const char* name, uint32_t* target)      { readEntry(name, target, sizeof(*target), ZVT_INT); }
-        void readEntry(const char* name, float* target)         { readEntry(name, target, sizeof(*target), ZVT_FLOAT); }
-        void readEntry(const char* name, ZMath::float3* target) { readEntry(name, target, sizeof(*target), ZVT_VEC3); }
-        void readEntry(const char* name, ZMath::Matrix* target) { readEntry(name, target, sizeof(*target), ZVT_RAW_FLOAT); }
+            void readEntry(const char* name, std::string* target) { readEntry(name, target, 0, ZVT_STRING); }
+            void readEntry(const char* name, int32_t* target) { readEntry(name, target, sizeof(*target), ZVT_INT); }
+            void readEntry(const char* name, uint8_t* target) { readEntry(name, target, sizeof(*target), ZVT_BYTE); }
+            void readEntry(const char* name, bool* target) { readEntry(name, target, sizeof(*target), ZVT_BOOL); }
+            void readEntry(const char* name, uint32_t* target) { readEntry(name, target, sizeof(*target), ZVT_INT); }
+            void readEntry(const char* name, float* target) { readEntry(name, target, sizeof(*target), ZVT_FLOAT); }
+            void readEntry(const char* name, ZMath::float3* target) { readEntry(name, target, sizeof(*target), ZVT_VEC3); }
+            void readEntry(const char* name, ZMath::Matrix* target) { readEntry(name, target, sizeof(*target), ZVT_RAW_FLOAT); }
 
-        /**
+            /**
 		 * @brief Reads the type of a single entry
 		 */
-        virtual void readEntryType(EZenValueType& type, size_t& size) = 0;
+            virtual void readEntryType(EZenValueType& type, size_t& size) = 0;
 
-    protected:
-        /**
+        protected:
+            /**
 		 * @brief Parser-Object this operates on
 		 */
-        ZenParser* m_pParser;
-    };
-}  // namespace ZenLoad
+            ZenParser* m_pParser;
+        };
+    }  // namespace ZenLoad
+}  // namespace ZenLib

--- a/zenload/parserImplASCII.cpp
+++ b/zenload/parserImplASCII.cpp
@@ -2,387 +2,390 @@
 #include <algorithm>
 #include "utils/logger.h"
 
-using namespace ZenLoad;
-
-ParserImplASCII::ParserImplASCII(ZenParser* parser)
-    : ParserImpl(parser)
+namespace ZenLib
 {
-}
+    using namespace ZenLoad;
 
-/**
+    ParserImplASCII::ParserImplASCII(ZenParser* parser)
+        : ParserImpl(parser)
+    {
+    }
+
+    /**
  * @brief Read the start of a chunk. [...]
  */
-bool ParserImplASCII::readChunkStart(ZenParser::ChunkHeader& header)
-{
-    m_pParser->skipSpaces();
-
-    size_t seek = m_pParser->getSeek();
-    try
+    bool ParserImplASCII::readChunkStart(ZenParser::ChunkHeader& header)
     {
-        // Check chunk-header
         m_pParser->skipSpaces();
 
-        // Early exit if this is a chunk-end or not a chunk header
-        if (m_pParser->m_Data[m_pParser->m_Seek] != '[' || m_pParser->m_Data[m_pParser->m_Seek + 1] == ']')
+        size_t seek = m_pParser->getSeek();
+        try
+        {
+            // Check chunk-header
+            m_pParser->skipSpaces();
+
+            // Early exit if this is a chunk-end or not a chunk header
+            if (m_pParser->m_Data[m_pParser->m_Seek] != '[' || m_pParser->m_Data[m_pParser->m_Seek + 1] == ']')
+            {
+                m_pParser->setSeek(seek);
+                return false;
+            }
+
+            //if(m_pParser->m_Data[m_pParser->m_Seek] != '[')
+            //	throw std::runtime_error("Invalid format");
+
+            m_pParser->m_Seek++;
+
+            size_t tmpSeek = m_pParser->m_Seek;
+            while (m_pParser->m_Data[tmpSeek] != ']')
+            {
+                if (m_pParser->m_Data[tmpSeek] == '\r' || m_pParser->m_Data[tmpSeek] == '\n')
+                    throw std::runtime_error("Invalid vob descriptor");
+
+                ++tmpSeek;
+            }
+
+            // Save chunks starting-position (right after chunk-header)
+            header.startPosition = m_pParser->m_Seek;
+
+            // Parse chunk-header
+            std::string vobDescriptor(reinterpret_cast<char*>(&m_pParser->m_Data[m_pParser->m_Seek]), tmpSeek - m_pParser->m_Seek);
+            std::vector<std::string> vec = Utils::split(vobDescriptor, ' ');
+            m_pParser->m_Seek = tmpSeek + 1;
+
+            std::string name;
+            std::string className;
+            int classVersion = 0;
+            int objectID = 0;
+            bool createObject = false;
+            enum State
+            {
+                S_OBJECT_NAME,
+                S_REFERENCE,
+                S_CLASS_NAME,
+                S_CLASS_VERSION,
+                S_OBJECT_ID,
+                S_FINISHED
+            } state = S_OBJECT_NAME;
+
+            for (auto& arg : vec)
+            {
+                switch (state)
+                {
+                    case S_OBJECT_NAME:
+                        if (arg != "%")
+                        {
+                            name = arg;
+                            state = S_REFERENCE;
+                            break;
+                        }
+                        //@fallthrough@
+                    case S_REFERENCE:
+                        if (arg == "%")
+                        {
+                            createObject = true;
+                            state = S_CLASS_NAME;
+                            break;
+                        }
+                        else if (arg == "\xA7")
+                        {
+                            createObject = false;
+                            state = S_CLASS_NAME;
+                            break;
+                        }
+                        else
+                            createObject = true;
+                        //@fallthrough@
+                    case S_CLASS_NAME:
+                        if (!m_pParser->isNumber(arg))
+                        {
+                            className = arg;
+                            state = S_CLASS_VERSION;
+                            break;
+                        }
+                        //@fallthrough@
+                    case S_CLASS_VERSION:
+                        classVersion = std::atoi(arg.c_str());
+                        state = S_OBJECT_ID;
+                        break;
+                    case S_OBJECT_ID:
+                        objectID = std::atoi(arg.c_str());
+                        state = S_FINISHED;
+                        break;
+                    default:
+                        throw std::runtime_error("Strange parser state");
+                }
+            }
+
+            if (state != S_FINISHED)
+                throw std::runtime_error("Parser did not finish");
+
+            header.classname = className;
+            header.createObject = createObject;
+            header.name = name;
+            header.objectID = objectID;
+            header.size = 0;  // Doesn't matter in ASCII
+            header.version = classVersion;
+
+            // Skip the last newline
+            m_pParser->skipSpaces();
+        }
+        catch (std::runtime_error e)
         {
             m_pParser->setSeek(seek);
             return false;
         }
 
-        //if(m_pParser->m_Data[m_pParser->m_Seek] != '[')
-        //	throw std::runtime_error("Invalid format");
-
-        m_pParser->m_Seek++;
-
-        size_t tmpSeek = m_pParser->m_Seek;
-        while (m_pParser->m_Data[tmpSeek] != ']')
-        {
-            if (m_pParser->m_Data[tmpSeek] == '\r' || m_pParser->m_Data[tmpSeek] == '\n')
-                throw std::runtime_error("Invalid vob descriptor");
-
-            ++tmpSeek;
-        }
-
-        // Save chunks starting-position (right after chunk-header)
-        header.startPosition = m_pParser->m_Seek;
-
-        // Parse chunk-header
-        std::string vobDescriptor(reinterpret_cast<char*>(&m_pParser->m_Data[m_pParser->m_Seek]), tmpSeek - m_pParser->m_Seek);
-        std::vector<std::string> vec = Utils::split(vobDescriptor, ' ');
-        m_pParser->m_Seek = tmpSeek + 1;
-
-        std::string name;
-        std::string className;
-        int classVersion = 0;
-        int objectID = 0;
-        bool createObject = false;
-        enum State
-        {
-            S_OBJECT_NAME,
-            S_REFERENCE,
-            S_CLASS_NAME,
-            S_CLASS_VERSION,
-            S_OBJECT_ID,
-            S_FINISHED
-        } state = S_OBJECT_NAME;
-
-        for (auto& arg : vec)
-        {
-            switch (state)
-            {
-                case S_OBJECT_NAME:
-                    if (arg != "%")
-                    {
-                        name = arg;
-                        state = S_REFERENCE;
-                        break;
-                    }
-                    //@fallthrough@
-                case S_REFERENCE:
-                    if (arg == "%")
-                    {
-                        createObject = true;
-                        state = S_CLASS_NAME;
-                        break;
-                    }
-                    else if (arg == "\xA7")
-                    {
-                        createObject = false;
-                        state = S_CLASS_NAME;
-                        break;
-                    }
-                    else
-                        createObject = true;
-                    //@fallthrough@
-                case S_CLASS_NAME:
-                    if (!m_pParser->isNumber(arg))
-                    {
-                        className = arg;
-                        state = S_CLASS_VERSION;
-                        break;
-                    }
-                    //@fallthrough@
-                case S_CLASS_VERSION:
-                    classVersion = std::atoi(arg.c_str());
-                    state = S_OBJECT_ID;
-                    break;
-                case S_OBJECT_ID:
-                    objectID = std::atoi(arg.c_str());
-                    state = S_FINISHED;
-                    break;
-                default:
-                    throw std::runtime_error("Strange parser state");
-            }
-        }
-
-        if (state != S_FINISHED)
-            throw std::runtime_error("Parser did not finish");
-
-        header.classname = className;
-        header.createObject = createObject;
-        header.name = name;
-        header.objectID = objectID;
-        header.size = 0;  // Doesn't matter in ASCII
-        header.version = classVersion;
-
-        // Skip the last newline
-        m_pParser->skipSpaces();
-    }
-    catch (std::runtime_error e)
-    {
-        m_pParser->setSeek(seek);
-        return false;
+        return true;
     }
 
-    return true;
-}
-
-/**
+    /**
  * @brief Read the end of a chunk. []
  */
-bool ParserImplASCII::readChunkEnd()
-{
-    size_t seek = m_pParser->getSeek();
-
-    m_pParser->skipSpaces();
-    std::string l = readString();
-
-    if (l != "[]")
+    bool ParserImplASCII::readChunkEnd()
     {
-        m_pParser->setSeek(seek);  // Next property isn't a string or the end
-        return false;
+        size_t seek = m_pParser->getSeek();
+
+        m_pParser->skipSpaces();
+        std::string l = readString();
+
+        if (l != "[]")
+        {
+            m_pParser->setSeek(seek);  // Next property isn't a string or the end
+            return false;
+        }
+
+        m_pParser->skipSpaces();
+
+        return true;
     }
 
-    m_pParser->skipSpaces();
-
-    return true;
-}
-
-/**
+    /**
  * @brief Read the implementation specific header and stores it in the parsers main-header struct
  */
-void ParserImplASCII::readImplHeader()
-{
-    if (!m_pParser->skipString("objects"))
-        throw std::runtime_error("Object count missing");
+    void ParserImplASCII::readImplHeader()
+    {
+        if (!m_pParser->skipString("objects"))
+            throw std::runtime_error("Object count missing");
 
-    m_pParser->m_Header.objectCount = m_pParser->readIntASCII();
+        m_pParser->m_Header.objectCount = m_pParser->readIntASCII();
 
-    if (!m_pParser->skipString("END"))
-        throw std::runtime_error("No END in header(2)");
+        if (!m_pParser->skipString("END"))
+            throw std::runtime_error("No END in header(2)");
 
-    m_pParser->skipSpaces();
-}
+        m_pParser->skipSpaces();
+    }
 
-/**
+    /**
  * @brief Reads a string
  */
-std::string ParserImplASCII::readString()
-{
-    return m_pParser->readLine();
-}
+    std::string ParserImplASCII::readString()
+    {
+        return m_pParser->readLine();
+    }
 
-/**
+    /**
  * @brief Reads data of the expected type. Throws if the read type is not the same as specified and not 0
  */
-void ParserImplASCII::readEntry(const char* _expectedName, void* target, size_t targetSize, EZenValueType expectedType)
-{
-    // Some tools write
-    std::string expectedName = _expectedName==nullptr ? "" : _expectedName;
-    std::transform(expectedName.begin(), expectedName.end(), expectedName.begin(), ::toupper);
-
-    m_pParser->skipSpaces();
-    std::string line = m_pParser->readLine();
-
-    // Special cases for chunk starts/ends
-    if (line == "[]" || (line.front() == '[' && line.back() == ']'))
+    void ParserImplASCII::readEntry(const char* _expectedName, void* target, size_t targetSize, EZenValueType expectedType)
     {
-        *reinterpret_cast<std::string*>(target) = line;
-        return;
+        // Some tools write
+        std::string expectedName = _expectedName == nullptr ? "" : _expectedName;
+        std::transform(expectedName.begin(), expectedName.end(), expectedName.begin(), ::toupper);
+
+        m_pParser->skipSpaces();
+        std::string line = m_pParser->readLine();
+
+        // Special cases for chunk starts/ends
+        if (line == "[]" || (line.front() == '[' && line.back() == ']'))
+        {
+            *reinterpret_cast<std::string*>(target) = line;
+            return;
+        }
+
+        // Split at =, then at :
+        // parts should then have 3 elements, name, type and value
+        auto parts = Utils::split(line, "=:");
+
+        if (parts.size() < 2)
+            throw std::runtime_error("Failed to parse property: " + expectedName);
+
+        std::string valueName = parts[0];
+        std::transform(valueName.begin(), valueName.end(), valueName.begin(), ::toupper);
+
+        //const std::string& valueName = parts[0];
+        const std::string& type = parts[1];
+        const std::string& value = parts.size() > 2 ? parts[2] : "";
+
+        // Split value as well, if possible
+        auto vparts = Utils::split(value, ' ');
+
+        if (!expectedName.empty() && valueName != expectedName)
+            throw std::runtime_error("Value name does not match expected name. Value:" + valueName + " Expected: " + expectedName);
+
+        switch (expectedType)
+        {
+            case ZVT_0:
+                break;
+            case ZVT_STRING:
+                *reinterpret_cast<std::string*>(target) = value;
+                break;
+            case ZVT_INT:
+                *reinterpret_cast<int32_t*>(target) = std::stoi(value);
+                break;
+            case ZVT_FLOAT:
+                *reinterpret_cast<float*>(target) = std::stof(value);
+                break;
+            case ZVT_BYTE:
+                *reinterpret_cast<uint8_t*>(target) = static_cast<uint8_t>(std::stoi(value));
+                break;
+            case ZVT_WORD:
+                *reinterpret_cast<int16_t*>(target) = static_cast<int16_t>(std::stoi(value));
+                break;
+            case ZVT_BOOL:
+                *reinterpret_cast<bool*>(target) = std::stoi(value) != 0;
+                break;
+            case ZVT_VEC3:
+                *reinterpret_cast<ZMath::float3*>(target) = ZMath::float3(std::stof(vparts[0]), std::stof(vparts[1]), std::stof(vparts[2]));
+                break;
+
+            case ZVT_COLOR:
+                reinterpret_cast<uint8_t*>(target)[0] = std::stoi(vparts[0]);  // FIXME: These are may ordered wrong
+                reinterpret_cast<uint8_t*>(target)[1] = std::stoi(vparts[1]);
+                reinterpret_cast<uint8_t*>(target)[2] = std::stoi(vparts[2]);
+                reinterpret_cast<uint8_t*>(target)[3] = std::stoi(vparts[3]);
+                break;
+
+            case ZVT_RAW_FLOAT:
+            {
+                size_t i = 0;
+                for (auto& v : vparts)
+                {
+                    float* data = reinterpret_cast<float*>(target);
+                    data[i] = std::stof(v);
+                    i++;
+                }
+            }
+            break;
+            case ZVT_RAW:
+            {
+                uint8_t* data = reinterpret_cast<uint8_t*>(target);
+                char c[3];
+                c[2] = 0;
+
+                for (size_t i = 0; i < targetSize; i++)
+                {
+                    if (value.size() < i * 2 + 1)
+                        throw std::runtime_error("Invalid raw dataset");
+
+                    c[0] = value[i * 2];
+                    c[1] = value[i * 2 + 1];
+                    data[i] = static_cast<uint8_t>(std::stoi(std::string(c), 0, 16));
+                }
+            }
+            break;
+            case ZVT_10:
+                break;
+            case ZVT_11:
+                break;
+            case ZVT_12:
+                break;
+            case ZVT_13:
+                break;
+            case ZVT_14:
+                break;
+            case ZVT_15:
+                break;
+            case ZVT_ENUM:
+                *reinterpret_cast<uint8_t*>(target) = std::stoi(value);
+                break;
+            case ZVT_HASH:
+                break;
+        }
     }
 
-    // Split at =, then at :
-    // parts should then have 3 elements, name, type and value
-    auto parts = Utils::split(line, "=:");
-
-    if (parts.size() < 2)
-        throw std::runtime_error("Failed to parse property: " + expectedName);
-
-    std::string valueName = parts[0];
-    std::transform(valueName.begin(), valueName.end(), valueName.begin(), ::toupper);
-
-    //const std::string& valueName = parts[0];
-    const std::string& type = parts[1];
-    const std::string& value = parts.size() > 2 ? parts[2] : "";
-
-    // Split value as well, if possible
-    auto vparts = Utils::split(value, ' ');
-
-    if (!expectedName.empty() && valueName != expectedName)
-        throw std::runtime_error("Value name does not match expected name. Value:" + valueName + " Expected: " + expectedName);
-
-    switch (expectedType)
-    {
-        case ZVT_0:
-            break;
-        case ZVT_STRING:
-            *reinterpret_cast<std::string*>(target) = value;
-            break;
-        case ZVT_INT:
-            *reinterpret_cast<int32_t*>(target) = std::stoi(value);
-            break;
-        case ZVT_FLOAT:
-            *reinterpret_cast<float*>(target) = std::stof(value);
-            break;
-        case ZVT_BYTE:
-            *reinterpret_cast<uint8_t*>(target) = static_cast<uint8_t>(std::stoi(value));
-            break;
-        case ZVT_WORD:
-            *reinterpret_cast<int16_t*>(target) = static_cast<int16_t>(std::stoi(value));
-            break;
-        case ZVT_BOOL:
-            *reinterpret_cast<bool*>(target) = std::stoi(value) != 0;
-            break;
-        case ZVT_VEC3:
-            *reinterpret_cast<ZMath::float3*>(target) = ZMath::float3(std::stof(vparts[0]), std::stof(vparts[1]), std::stof(vparts[2]));
-            break;
-
-        case ZVT_COLOR:
-            reinterpret_cast<uint8_t*>(target)[0] = std::stoi(vparts[0]);  // FIXME: These are may ordered wrong
-            reinterpret_cast<uint8_t*>(target)[1] = std::stoi(vparts[1]);
-            reinterpret_cast<uint8_t*>(target)[2] = std::stoi(vparts[2]);
-            reinterpret_cast<uint8_t*>(target)[3] = std::stoi(vparts[3]);
-            break;
-
-        case ZVT_RAW_FLOAT:
-        {
-            size_t i = 0;
-            for (auto& v : vparts)
-            {
-                float* data = reinterpret_cast<float*>(target);
-                data[i] = std::stof(v);
-                i++;
-            }
-        }
-        break;
-        case ZVT_RAW:
-        {
-            uint8_t* data = reinterpret_cast<uint8_t*>(target);
-            char c[3];
-            c[2] = 0;
-
-            for (size_t i = 0; i < targetSize; i++)
-            {
-                if (value.size() < i * 2 + 1)
-                    throw std::runtime_error("Invalid raw dataset");
-
-                c[0] = value[i * 2];
-                c[1] = value[i * 2 + 1];
-                data[i] = static_cast<uint8_t>(std::stoi(std::string(c), 0, 16));
-            }
-        }
-        break;
-        case ZVT_10:
-            break;
-        case ZVT_11:
-            break;
-        case ZVT_12:
-            break;
-        case ZVT_13:
-            break;
-        case ZVT_14:
-            break;
-        case ZVT_15:
-            break;
-        case ZVT_ENUM:
-            *reinterpret_cast<uint8_t*>(target) = std::stoi(value);
-            break;
-        case ZVT_HASH:
-            break;
-    }
-}
-
-/**
+    /**
 * @brief Reads the type of a single entry
 */
-void ParserImplASCII::readEntryType(EZenValueType& outtype, size_t& size)
-{
-    m_pParser->skipSpaces();
-    std::string line = m_pParser->readLine();
+    void ParserImplASCII::readEntryType(EZenValueType& outtype, size_t& size)
+    {
+        m_pParser->skipSpaces();
+        std::string line = m_pParser->readLine();
 
-    // Special cases for chunk starts/ends
-    if (line == "[]" || (line.front() == '[' && line.back() == ']'))
-    {
-        outtype = ZVT_STRING;
-        size = 0;
-        return;
-    }
+        // Special cases for chunk starts/ends
+        if (line == "[]" || (line.front() == '[' && line.back() == ']'))
+        {
+            outtype = ZVT_STRING;
+            size = 0;
+            return;
+        }
 
-    // Split at =, then at :
-    // parts should then have 3 elements, name, type and value
-    auto parts = Utils::split(line, "=:");
+        // Split at =, then at :
+        // parts should then have 3 elements, name, type and value
+        auto parts = Utils::split(line, "=:");
 
-    if (parts.size() < 2)  // Need at least name and type
-        throw std::runtime_error("Failed to read property type");
+        if (parts.size() < 2)  // Need at least name and type
+            throw std::runtime_error("Failed to read property type");
 
-    const std::string& type = parts[1];
-    size_t cLoc = line.find_first_of(':') == std::string::npos ? 0 : line.find_first_of(':');
+        const std::string& type = parts[1];
+        size_t cLoc = line.find_first_of(':') == std::string::npos ? 0 : line.find_first_of(':');
 
-    if (type == "string")
-    {
-        outtype = ZVT_STRING;
-        size = 0;
+        if (type == "string")
+        {
+            outtype = ZVT_STRING;
+            size = 0;
+        }
+        else if (type == "int")
+        {
+            outtype = ZVT_INT;
+            size = 0;
+        }
+        else if (type == "float")
+        {
+            outtype = ZVT_FLOAT;
+            size = 0;
+        }
+        else if (type == "byte")
+        {
+            outtype = ZVT_BYTE;
+            size = 0;
+        }
+        else if (type == "word")
+        {
+            outtype = ZVT_WORD;
+            size = 0;
+        }
+        else if (type == "bool")
+        {
+            outtype = ZVT_BOOL;
+            size = 0;
+        }
+        else if (type == "vec3")
+        {
+            outtype = ZVT_VEC3;
+            size = 0;
+        }
+        else if (type == "color")
+        {
+            outtype = ZVT_COLOR;
+            size = 0;
+        }
+        else if (type == "rawFloat")
+        {
+            outtype = ZVT_RAW_FLOAT;
+            size = 0;
+        }
+        else if (type == "raw")
+        {
+            outtype = ZVT_RAW;
+            size = 0;
+        }
+        else if (type == "enum")
+        {
+            outtype = ZVT_ENUM;
+            size = 0;
+        }
+        else
+            throw std::runtime_error("Unknown type");
     }
-    else if (type == "int")
-    {
-        outtype = ZVT_INT;
-        size = 0;
-    }
-    else if (type == "float")
-    {
-        outtype = ZVT_FLOAT;
-        size = 0;
-    }
-    else if (type == "byte")
-    {
-        outtype = ZVT_BYTE;
-        size = 0;
-    }
-    else if (type == "word")
-    {
-        outtype = ZVT_WORD;
-        size = 0;
-    }
-    else if (type == "bool")
-    {
-        outtype = ZVT_BOOL;
-        size = 0;
-    }
-    else if (type == "vec3")
-    {
-        outtype = ZVT_VEC3;
-        size = 0;
-    }
-    else if (type == "color")
-    {
-        outtype = ZVT_COLOR;
-        size = 0;
-    }
-    else if (type == "rawFloat")
-    {
-        outtype = ZVT_RAW_FLOAT;
-        size = 0;
-    }
-    else if (type == "raw")
-    {
-        outtype = ZVT_RAW;
-        size = 0;
-    }
-    else if (type == "enum")
-    {
-        outtype = ZVT_ENUM;
-        size = 0;
-    }
-    else
-        throw std::runtime_error("Unknown type");
-}
+}  // namespace ZenLib

--- a/zenload/parserImplASCII.h
+++ b/zenload/parserImplASCII.h
@@ -1,45 +1,48 @@
 #pragma once
 #include "parserImpl.h"
 
-namespace ZenLoad
+namespace ZenLib
 {
-    class ParserImplASCII : public ParserImpl
+    namespace ZenLoad
     {
-        friend ZenParser;
+        class ParserImplASCII : public ParserImpl
+        {
+            friend ZenParser;
 
-    public:
-        ParserImplASCII(ZenParser* parser);
+        public:
+            ParserImplASCII(ZenParser* parser);
 
-        /**
+            /**
 		 * @brief Read the implementation specific header and stores it in the parsers main-header struct
 		 */
-        void readImplHeader() override;
+            void readImplHeader() override;
 
-        /**
+            /**
 		* @brief Read the start of a chunk. [...] Returns true if there actually was a start. 
 		*		  Otherwise it will leave m_Seek untouched and return false.
 		*/
-        bool readChunkStart(ZenParser::ChunkHeader& header) override;
+            bool readChunkStart(ZenParser::ChunkHeader& header) override;
 
-        /**
+            /**
 		* @brief Reads the end of a chunk. Returns true if there actually was an end. 
 		*		  Otherwise it will leave m_Seek untouched and return false.
 		*/
-        bool readChunkEnd() override;
+            bool readChunkEnd() override;
 
-        /**
+            /**
 		 * @brief Reads a string
 		 */
-        std::string readString() override;
+            std::string readString() override;
 
-        /**
+            /**
 		 * @brief Reads data of the expected type. Throws if the read type is not the same as specified and not 0
 		 */
-        void readEntry(const char* name, void* target, size_t targetSize, EZenValueType expectedType = ZVT_0) override;
+            void readEntry(const char* name, void* target, size_t targetSize, EZenValueType expectedType = ZVT_0) override;
 
-        /**
+            /**
 		* @brief Reads the type of a single entry
 		*/
-        void readEntryType(EZenValueType& type, size_t& size) override;
-    };
-}  // namespace ZenLoad
+            void readEntryType(EZenValueType& type, size_t& size) override;
+        };
+    }  // namespace ZenLoad
+}  // namespace ZenLib

--- a/zenload/parserImplBinSafe.cpp
+++ b/zenload/parserImplBinSafe.cpp
@@ -1,396 +1,399 @@
 #include "parserImplBinSafe.h"
 #include <utils/logger.h>
 
-using namespace ZenLoad;
-
-ZenLoad::ParserImplBinSafe::ParserImplBinSafe(ZenParser* parser)
-    : ParserImpl(parser)
+namespace ZenLib
 {
-}
+    using namespace ZenLoad;
 
-/**
+    ZenLoad::ParserImplBinSafe::ParserImplBinSafe(ZenParser* parser)
+        : ParserImpl(parser)
+    {
+    }
+
+    /**
 * @brief Read the start of a chunk. [...]
 */
-bool ParserImplBinSafe::readChunkStart(ZenParser::ChunkHeader& header)
-{
-    size_t seek = m_pParser->getSeek();
-    try
+    bool ParserImplBinSafe::readChunkStart(ZenParser::ChunkHeader& header)
     {
-        EZenValueType type;
-        size_t size;
+        size_t seek = m_pParser->getSeek();
+        try
+        {
+            EZenValueType type;
+            size_t size;
 
-        // Check if this actually will be a string
-        readTypeAndSizeBinSafe(type, size);
-        m_pParser->setSeek(seek);
+            // Check if this actually will be a string
+            readTypeAndSizeBinSafe(type, size);
+            m_pParser->setSeek(seek);
 
-        if (type != ZVT_STRING)
-            return false;  // Next property isn't a string or the end
+            if (type != ZVT_STRING)
+                return false;  // Next property isn't a string or the end
 
-        // Read chunk-header
-        std::string vobDescriptor = readString();
+            // Read chunk-header
+            std::string vobDescriptor = readString();
 
-        // Early exit if this is a chunk-end or not a chunk header
-        if (vobDescriptor.empty() || (vobDescriptor.front() != '[' && vobDescriptor.back() != ']') || vobDescriptor.size() <= 2)
+            // Early exit if this is a chunk-end or not a chunk header
+            if (vobDescriptor.empty() || (vobDescriptor.front() != '[' && vobDescriptor.back() != ']') || vobDescriptor.size() <= 2)
+            {
+                m_pParser->setSeek(seek);
+                return false;
+            }
+
+            vobDescriptor = vobDescriptor.substr(1, vobDescriptor.size() - 2);
+
+            // Special case for camera keyframes
+            if (vobDescriptor.find('%') != std::string::npos && vobDescriptor.find('\xA7') != std::string::npos)
+            {
+                // Make a header with createObject = true and ref as classname
+                auto parts = Utils::split(vobDescriptor, ' ');
+                header.createObject = true;
+                header.classname = "\xA7";
+                header.name = "%";
+                header.size = 0;
+                header.version = 0;
+                header.objectID = std::stoi(parts.back());
+                return true;
+            }
+
+            // Save chunks starting-position (right after chunk-header)
+            header.startPosition = m_pParser->m_Seek;
+
+            // Parse chunk-header
+            std::vector<std::string> vec = Utils::split(vobDescriptor, ' ');
+
+            std::string name;
+            std::string className;
+            int classVersion = 0;
+            int objectID = 0;
+            bool createObject = false;
+            enum State
+            {
+                S_OBJECT_NAME,
+                S_REFERENCE,
+                S_CLASS_NAME,
+                S_CLASS_VERSION,
+                S_OBJECT_ID,
+                S_FINISHED
+            } state = S_OBJECT_NAME;
+
+            for (auto& arg : vec)
+            {
+                switch (state)
+                {
+                    case S_OBJECT_NAME:
+                        if (arg != "%")
+                        {
+                            name = arg;
+                            state = S_REFERENCE;
+                            break;
+                        }
+                        //@fallthrough@
+                    case S_REFERENCE:
+                        if (arg == "%")
+                        {
+                            createObject = true;
+                            state = S_CLASS_NAME;
+                            break;
+                        }
+                        else if (arg == "\xA7")
+                        {
+                            createObject = false;
+                            state = S_CLASS_NAME;
+                            break;
+                        }
+                        else
+                            createObject = true;
+                        //@fallthrough@
+                    case S_CLASS_NAME:
+                        if (!m_pParser->isNumber(arg))
+                        {
+                            className = arg;
+                            state = S_CLASS_VERSION;
+                            break;
+                        }
+                        //@fallthrough@
+                    case S_CLASS_VERSION:
+                        classVersion = std::atoi(arg.c_str());
+                        state = S_OBJECT_ID;
+                        break;
+                    case S_OBJECT_ID:
+                        objectID = std::atoi(arg.c_str());
+                        state = S_FINISHED;
+                        break;
+                    default:
+                        throw std::runtime_error("Strange parser state");
+                }
+            }
+
+            if (state != S_FINISHED)
+                throw std::runtime_error("Parser did not finish");
+
+            header.classname = className;
+            header.createObject = createObject;
+            header.name = name;
+            header.objectID = objectID;
+            header.size = 0;  // Doesn't matter in ASCII
+            header.version = classVersion;
+        }
+        catch (std::runtime_error e)
         {
             m_pParser->setSeek(seek);
             return false;
         }
 
-        vobDescriptor = vobDescriptor.substr(1, vobDescriptor.size() - 2);
-
-        // Special case for camera keyframes
-        if (vobDescriptor.find('%') != std::string::npos && vobDescriptor.find('\xA7') != std::string::npos)
-        {
-            // Make a header with createObject = true and ref as classname
-            auto parts = Utils::split(vobDescriptor, ' ');
-            header.createObject = true;
-            header.classname = "\xA7";
-            header.name = "%";
-            header.size = 0;
-            header.version = 0;
-            header.objectID = std::stoi(parts.back());
-            return true;
-        }
-
-        // Save chunks starting-position (right after chunk-header)
-        header.startPosition = m_pParser->m_Seek;
-
-        // Parse chunk-header
-        std::vector<std::string> vec = Utils::split(vobDescriptor, ' ');
-
-        std::string name;
-        std::string className;
-        int classVersion = 0;
-        int objectID = 0;
-        bool createObject = false;
-        enum State
-        {
-            S_OBJECT_NAME,
-            S_REFERENCE,
-            S_CLASS_NAME,
-            S_CLASS_VERSION,
-            S_OBJECT_ID,
-            S_FINISHED
-        } state = S_OBJECT_NAME;
-
-        for (auto& arg : vec)
-        {
-            switch (state)
-            {
-                case S_OBJECT_NAME:
-                    if (arg != "%")
-                    {
-                        name = arg;
-                        state = S_REFERENCE;
-                        break;
-                    }
-                    //@fallthrough@
-                case S_REFERENCE:
-                    if (arg == "%")
-                    {
-                        createObject = true;
-                        state = S_CLASS_NAME;
-                        break;
-                    }
-                    else if (arg == "\xA7")
-                    {
-                        createObject = false;
-                        state = S_CLASS_NAME;
-                        break;
-                    }
-                    else
-                        createObject = true;
-                    //@fallthrough@
-                case S_CLASS_NAME:
-                    if (!m_pParser->isNumber(arg))
-                    {
-                        className = arg;
-                        state = S_CLASS_VERSION;
-                        break;
-                    }
-                    //@fallthrough@
-                case S_CLASS_VERSION:
-                    classVersion = std::atoi(arg.c_str());
-                    state = S_OBJECT_ID;
-                    break;
-                case S_OBJECT_ID:
-                    objectID = std::atoi(arg.c_str());
-                    state = S_FINISHED;
-                    break;
-                default:
-                    throw std::runtime_error("Strange parser state");
-            }
-        }
-
-        if (state != S_FINISHED)
-            throw std::runtime_error("Parser did not finish");
-
-        header.classname = className;
-        header.createObject = createObject;
-        header.name = name;
-        header.objectID = objectID;
-        header.size = 0;  // Doesn't matter in ASCII
-        header.version = classVersion;
-    }
-    catch (std::runtime_error e)
-    {
-        m_pParser->setSeek(seek);
-        return false;
+        return true;
     }
 
-    return true;
-}
-
-/**
+    /**
 * @brief Read the end of a chunk. []
 */
-bool ParserImplBinSafe::readChunkEnd()
-{
-    size_t seek = m_pParser->getSeek();
-    try
+    bool ParserImplBinSafe::readChunkEnd()
+    {
+        size_t seek = m_pParser->getSeek();
+        try
+        {
+            EZenValueType type;
+            size_t size;
+
+            // Check if this actually will be a string
+            readTypeAndSizeBinSafe(type, size);
+            m_pParser->setSeek(seek);
+
+            if (type != ZVT_STRING)
+                return false;  // Next property isn't a string or the end
+
+            std::string l = readString();
+
+            if (l != "[]")
+            {
+                m_pParser->setSeek(seek);
+                return false;
+            }
+        }
+        catch (std::runtime_error e)
+        {
+            m_pParser->setSeek(seek);
+            return false;  // Next property isn't a string or the end
+        }
+
+        return true;
+    }
+
+    /**
+* @brief Read the implementation specific header and stores it in the parsers main-header struct
+*/
+    void ParserImplBinSafe::readImplHeader()
+    {
+        // Bin-Safe archiver has its own version stored again for some reason
+        m_pParser->m_Header.binSafeHeader.bsVersion = m_pParser->readBinaryDWord();
+
+        // Read object count
+        m_pParser->m_Header.objectCount = m_pParser->readBinaryDWord();
+
+        // Read offset of where to find the global hash-table of all objects
+        m_pParser->m_Header.binSafeHeader.bsHashTableOffset = m_pParser->readBinaryDWord();
+
+        // Read hashtable
+        size_t s = m_pParser->m_Seek;
+        m_pParser->m_Seek = m_pParser->m_Header.binSafeHeader.bsHashTableOffset;
+
+        struct BinSafeEntry
+        {
+            std::string key;
+            uint16_t insertionIndex;
+        };
+
+        std::unordered_map<uint32_t, std::vector<BinSafeEntry>> map;
+        uint32_t htSize = m_pParser->readBinaryDWord();
+        for (uint32_t i = 0; i < htSize; i++)
+        {
+            uint16_t keyLen = m_pParser->readBinaryWord();
+            uint16_t insIdx = m_pParser->readBinaryWord();
+            uint32_t hashValue = m_pParser->readBinaryDWord();
+
+            // Read the keys data from the archive
+            std::vector<uint8_t> keyData(keyLen);
+            m_pParser->readBinaryRaw(keyData.data(), keyLen);
+
+            // Put the source key together with the insertion index into the map
+            //std::string key(keyData.begin(), keyData.end());
+            //map[hashValue].push_back( {key, insIdx} );
+        }
+
+        // Restore old position
+        m_pParser->m_Seek = s;
+    }
+
+    /**
+* @brief Reads a string
+*/
+    std::string ParserImplBinSafe::readString()
     {
         EZenValueType type;
         size_t size;
 
-        // Check if this actually will be a string
+        // These values start with a small header
         readTypeAndSizeBinSafe(type, size);
-        m_pParser->setSeek(seek);
 
         if (type != ZVT_STRING)
-            return false;  // Next property isn't a string or the end
+            throw std::runtime_error("Expected string-type");
 
-        std::string l = readString();
+        std::string str;
+        str.resize(size);
+        m_pParser->readBinaryRaw(&str[0], size);
 
-        if (l != "[]")
-        {
-            m_pParser->setSeek(seek);
-            return false;
-        }
-    }
-    catch (std::runtime_error e)
-    {
-        m_pParser->setSeek(seek);
-        return false;  // Next property isn't a string or the end
-    }
+        // Skip potential hash-value at the end of the string
+        EZenValueType t = static_cast<EZenValueType>(m_pParser->readBinaryByte());
+        if (t != ZVT_HASH)
+            m_pParser->m_Seek -= sizeof(uint8_t);
+        else
+            m_pParser->m_Seek += sizeof(uint32_t);
 
-    return true;
-}
-
-/**
-* @brief Read the implementation specific header and stores it in the parsers main-header struct
-*/
-void ParserImplBinSafe::readImplHeader()
-{
-    // Bin-Safe archiver has its own version stored again for some reason
-    m_pParser->m_Header.binSafeHeader.bsVersion = m_pParser->readBinaryDWord();
-
-    // Read object count
-    m_pParser->m_Header.objectCount = m_pParser->readBinaryDWord();
-
-    // Read offset of where to find the global hash-table of all objects
-    m_pParser->m_Header.binSafeHeader.bsHashTableOffset = m_pParser->readBinaryDWord();
-
-    // Read hashtable
-    size_t s = m_pParser->m_Seek;
-    m_pParser->m_Seek = m_pParser->m_Header.binSafeHeader.bsHashTableOffset;
-
-    struct BinSafeEntry
-    {
-        std::string key;
-        uint16_t insertionIndex;
-    };
-
-    std::unordered_map<uint32_t, std::vector<BinSafeEntry>> map;
-    uint32_t htSize = m_pParser->readBinaryDWord();
-    for (uint32_t i = 0; i < htSize; i++)
-    {
-        uint16_t keyLen = m_pParser->readBinaryWord();
-        uint16_t insIdx = m_pParser->readBinaryWord();
-        uint32_t hashValue = m_pParser->readBinaryDWord();
-
-        // Read the keys data from the archive
-        std::vector<uint8_t> keyData(keyLen);
-        m_pParser->readBinaryRaw(keyData.data(), keyLen);
-
-        // Put the source key together with the insertion index into the map
-        //std::string key(keyData.begin(), keyData.end());
-        //map[hashValue].push_back( {key, insIdx} );
+        return str;
     }
 
-    // Restore old position
-    m_pParser->m_Seek = s;
-}
-
-/**
-* @brief Reads a string
-*/
-std::string ParserImplBinSafe::readString()
-{
-    EZenValueType type;
-    size_t size;
-
-    // These values start with a small header
-    readTypeAndSizeBinSafe(type, size);
-
-    if (type != ZVT_STRING)
-        throw std::runtime_error("Expected string-type");
-
-    std::string str;
-    str.resize(size);
-    m_pParser->readBinaryRaw(&str[0], size);
-
-    // Skip potential hash-value at the end of the string
-    EZenValueType t = static_cast<EZenValueType>(m_pParser->readBinaryByte());
-    if (t != ZVT_HASH)
-        m_pParser->m_Seek -= sizeof(uint8_t);
-    else
-        m_pParser->m_Seek += sizeof(uint32_t);
-
-    return str;
-}
-
-/**
+    /**
 * @brief reads the small header in front of datatypes
 */
-void ParserImplBinSafe::readTypeAndSizeBinSafe(EZenValueType& type, size_t& size)
-{
-    type = static_cast<EZenValueType>(m_pParser->readBinaryByte());
-    size = 0;
-
-    switch (type)
+    void ParserImplBinSafe::readTypeAndSizeBinSafe(EZenValueType& type, size_t& size)
     {
-        case ZVT_VEC3:
-            size = sizeof(float) * 3;
-            break;
+        type = static_cast<EZenValueType>(m_pParser->readBinaryByte());
+        size = 0;
 
-        case ZVT_BYTE:
-            size = sizeof(uint8_t);
-            break;
+        switch (type)
+        {
+            case ZVT_VEC3:
+                size = sizeof(float) * 3;
+                break;
 
-        case ZVT_WORD:
-            size = sizeof(uint16_t);
-            break;
+            case ZVT_BYTE:
+                size = sizeof(uint8_t);
+                break;
 
-        case ZVT_RAW:
-        case ZVT_RAW_FLOAT:
-        case ZVT_STRING:
-            size = m_pParser->readBinaryWord();
-            break;
+            case ZVT_WORD:
+                size = sizeof(uint16_t);
+                break;
 
-        case ZVT_INT:
-        case ZVT_ENUM:
-        case ZVT_BOOL:
-        case ZVT_HASH:
-        case ZVT_FLOAT:
-        case ZVT_COLOR:
-            size = sizeof(uint32_t);  // FIXME: Bool might be only 8 bytes
-            break;
+            case ZVT_RAW:
+            case ZVT_RAW_FLOAT:
+            case ZVT_STRING:
+                size = m_pParser->readBinaryWord();
+                break;
 
-        default:
-            throw std::runtime_error(std::string("BinSafe: Datatype not implemented"));
+            case ZVT_INT:
+            case ZVT_ENUM:
+            case ZVT_BOOL:
+            case ZVT_HASH:
+            case ZVT_FLOAT:
+            case ZVT_COLOR:
+                size = sizeof(uint32_t);  // FIXME: Bool might be only 8 bytes
+                break;
+
+            default:
+                throw std::runtime_error(std::string("BinSafe: Datatype not implemented"));
+        }
     }
-}
 
-/**
+    /**
 * @brief Reads data of the expected type. Throws if the read type is not the same as specified and not 0
 */
-void ParserImplBinSafe::readEntry(const char *expectedName, void* target, size_t targetSize, EZenValueType expectedType)
-{
-    EZenValueType type;
-    size_t size;
-
-    // Read type and size of the entry
-    readTypeAndSizeBinSafe(type, size);
-
-    // These are the same in size
-    if (expectedType == ZVT_INT)
+    void ParserImplBinSafe::readEntry(const char* expectedName, void* target, size_t targetSize, EZenValueType expectedType)
     {
-        if (type == ZVT_COLOR)
-            type = ZVT_INT;
+        EZenValueType type;
+        size_t size;
 
-        if (type == ZVT_ENUM && size == sizeof(uint32_t))
-            type = ZVT_INT;  // Enum seems the be there in both 1 and 4 byte?
-    }
+        // Read type and size of the entry
+        readTypeAndSizeBinSafe(type, size);
 
-    if (expectedType != ZVT_BYTE || type != ZVT_ENUM)  // International CSLibs have this
-        if (expectedType != ZVT_0 && type != expectedType)
-            throw std::runtime_error("Valuetype name does not match expected type. Value:" + std::string(expectedName));
-
-    switch (type)
-    {
-        case ZVT_0:
-            break;
-        case ZVT_STRING:
+        // These are the same in size
+        if (expectedType == ZVT_INT)
         {
-            std::string str;
-            str.resize(size);
-            m_pParser->readBinaryRaw(&str[0], size);
-            *reinterpret_cast<std::string*>(target) = str;
+            if (type == ZVT_COLOR)
+                type = ZVT_INT;
+
+            if (type == ZVT_ENUM && size == sizeof(uint32_t))
+                type = ZVT_INT;  // Enum seems the be there in both 1 and 4 byte?
         }
-        break;
 
-        case ZVT_HASH:
-        case ZVT_INT:
-            *reinterpret_cast<uint32_t*>(target) = m_pParser->readBinaryDWord();
-            break;
-        case ZVT_FLOAT:
-            *reinterpret_cast<float*>(target) = m_pParser->readBinaryFloat();
-            break;
-        case ZVT_BYTE:
-            *reinterpret_cast<uint8_t*>(target) = m_pParser->readBinaryByte();
-            break;
-        case ZVT_WORD:
-            *reinterpret_cast<int16_t*>(target) = m_pParser->readBinaryWord();
-            break;
-        case ZVT_BOOL:
-            *reinterpret_cast<bool*>(target) = m_pParser->readBinaryDWord() != 0;
-            break;
-        case ZVT_VEC3:
-            reinterpret_cast<ZMath::float3*>(target)->x = m_pParser->readBinaryFloat();
-            reinterpret_cast<ZMath::float3*>(target)->y = m_pParser->readBinaryFloat();
-            reinterpret_cast<ZMath::float3*>(target)->z = m_pParser->readBinaryFloat();
+        if (expectedType != ZVT_BYTE || type != ZVT_ENUM)  // International CSLibs have this
+            if (expectedType != ZVT_0 && type != expectedType)
+                throw std::runtime_error("Valuetype name does not match expected type. Value:" + std::string(expectedName));
+
+        switch (type)
+        {
+            case ZVT_0:
+                break;
+            case ZVT_STRING:
+            {
+                std::string str;
+                str.resize(size);
+                m_pParser->readBinaryRaw(&str[0], size);
+                *reinterpret_cast<std::string*>(target) = str;
+            }
             break;
 
-        case ZVT_COLOR:
-            reinterpret_cast<uint8_t*>(target)[0] = m_pParser->readBinaryByte();  // FIXME: These are may ordered wrong
-            reinterpret_cast<uint8_t*>(target)[1] = m_pParser->readBinaryByte();
-            reinterpret_cast<uint8_t*>(target)[2] = m_pParser->readBinaryByte();
-            reinterpret_cast<uint8_t*>(target)[3] = m_pParser->readBinaryByte();
-            break;
+            case ZVT_HASH:
+            case ZVT_INT:
+                *reinterpret_cast<uint32_t*>(target) = m_pParser->readBinaryDWord();
+                break;
+            case ZVT_FLOAT:
+                *reinterpret_cast<float*>(target) = m_pParser->readBinaryFloat();
+                break;
+            case ZVT_BYTE:
+                *reinterpret_cast<uint8_t*>(target) = m_pParser->readBinaryByte();
+                break;
+            case ZVT_WORD:
+                *reinterpret_cast<int16_t*>(target) = m_pParser->readBinaryWord();
+                break;
+            case ZVT_BOOL:
+                *reinterpret_cast<bool*>(target) = m_pParser->readBinaryDWord() != 0;
+                break;
+            case ZVT_VEC3:
+                reinterpret_cast<ZMath::float3*>(target)->x = m_pParser->readBinaryFloat();
+                reinterpret_cast<ZMath::float3*>(target)->y = m_pParser->readBinaryFloat();
+                reinterpret_cast<ZMath::float3*>(target)->z = m_pParser->readBinaryFloat();
+                break;
 
-        case ZVT_RAW_FLOAT:
-        case ZVT_RAW:
-            m_pParser->readBinaryRaw(target, size);
-            break;
-        case ZVT_10:
-            break;
-        case ZVT_11:
-            break;
-        case ZVT_12:
-            break;
-        case ZVT_13:
-            break;
-        case ZVT_14:
-            break;
-        case ZVT_15:
-            break;
-        case ZVT_ENUM:
-            *reinterpret_cast<uint8_t*>(target) = m_pParser->readBinaryDWord();
-            break;
+            case ZVT_COLOR:
+                reinterpret_cast<uint8_t*>(target)[0] = m_pParser->readBinaryByte();  // FIXME: These are may ordered wrong
+                reinterpret_cast<uint8_t*>(target)[1] = m_pParser->readBinaryByte();
+                reinterpret_cast<uint8_t*>(target)[2] = m_pParser->readBinaryByte();
+                reinterpret_cast<uint8_t*>(target)[3] = m_pParser->readBinaryByte();
+                break;
+
+            case ZVT_RAW_FLOAT:
+            case ZVT_RAW:
+                m_pParser->readBinaryRaw(target, size);
+                break;
+            case ZVT_10:
+                break;
+            case ZVT_11:
+                break;
+            case ZVT_12:
+                break;
+            case ZVT_13:
+                break;
+            case ZVT_14:
+                break;
+            case ZVT_15:
+                break;
+            case ZVT_ENUM:
+                *reinterpret_cast<uint8_t*>(target) = m_pParser->readBinaryDWord();
+                break;
+        }
+
+        // Skip potential hash-value at the end of the entry
+        EZenValueType t = static_cast<EZenValueType>(m_pParser->readBinaryByte());
+        if (t != ZVT_HASH)
+            m_pParser->m_Seek -= sizeof(uint8_t);
+        else
+            m_pParser->m_Seek += sizeof(uint32_t);
     }
 
-    // Skip potential hash-value at the end of the entry
-    EZenValueType t = static_cast<EZenValueType>(m_pParser->readBinaryByte());
-    if (t != ZVT_HASH)
-        m_pParser->m_Seek -= sizeof(uint8_t);
-    else
-        m_pParser->m_Seek += sizeof(uint32_t);
-}
-
-/**
+    /**
 * @brief Reads the type of a single entry
 */
-void ParserImplBinSafe::readEntryType(EZenValueType& outtype, size_t& size)
-{
-    readTypeAndSizeBinSafe(outtype, size);
-}
+    void ParserImplBinSafe::readEntryType(EZenValueType& outtype, size_t& size)
+    {
+        readTypeAndSizeBinSafe(outtype, size);
+    }
+}  // namespace ZenLib

--- a/zenload/parserImplBinSafe.h
+++ b/zenload/parserImplBinSafe.h
@@ -1,51 +1,54 @@
 #pragma once
 #include "parserImpl.h"
 
-namespace ZenLoad
+namespace ZenLib
 {
-    class ParserImplBinSafe : public ParserImpl
+    namespace ZenLoad
     {
-        friend ZenParser;
+        class ParserImplBinSafe : public ParserImpl
+        {
+            friend ZenParser;
 
-    public:
-        ParserImplBinSafe(ZenParser* parser);
+        public:
+            ParserImplBinSafe(ZenParser* parser);
 
-        /**
+            /**
 		* @brief Read the implementation specific header and stores it in the parsers main-header struct
 		*/
-        void readImplHeader() override;
+            void readImplHeader() override;
 
-        /**
+            /**
 		* @brief Read the start of a chunk. [...] Returns true if there actually was a start. 
 		*		  Otherwise it will leave m_Seek untouched and return false.
 		*/
-        bool readChunkStart(ZenParser::ChunkHeader& header) override;
+            bool readChunkStart(ZenParser::ChunkHeader& header) override;
 
-        /**
+            /**
 		 * @brief Reads the end of a chunk. Returns true if there actually was an end. 
 		 *		  Otherwise it will leave m_Seek untouched and return false.
 		 */
-        bool readChunkEnd() override;
+            bool readChunkEnd() override;
 
-        /**
+            /**
 		* @brief Reads a string
 		*/
-        std::string readString() override;
+            std::string readString() override;
 
-        /**
+            /**
 		* @brief Reads data of the expected type. Throws if the read type is not the same as specified and not 0
 		*/
-        void readEntry(const char* name, void* target, size_t targetSize, EZenValueType expectedType = ZVT_0) override;
+            void readEntry(const char* name, void* target, size_t targetSize, EZenValueType expectedType = ZVT_0) override;
 
-        /**
+            /**
 		* @brief Reads the type of a single entry
 		*/
-        void readEntryType(EZenValueType& type, size_t& size) override;
+            void readEntryType(EZenValueType& type, size_t& size) override;
 
-    private:
-        /**
+        private:
+            /**
 		 * @brief reads the small header in front of datatypes
 		 */
-        void readTypeAndSizeBinSafe(EZenValueType& type, size_t& size);
-    };
-}  // namespace ZenLoad
+            void readTypeAndSizeBinSafe(EZenValueType& type, size_t& size);
+        };
+    }  // namespace ZenLoad
+}  // namespace ZenLib

--- a/zenload/parserImplBinary.cpp
+++ b/zenload/parserImplBinary.cpp
@@ -1,123 +1,126 @@
 #include "parserImplBinary.h"
 #include "utils/logger.h"
 
-using namespace ZenLoad;
-
-ParserImplBinary::ParserImplBinary(ZenParser* parser)
-    : ParserImpl(parser)
+namespace ZenLib
 {
-}
+    using namespace ZenLoad;
 
-/**
+    ParserImplBinary::ParserImplBinary(ZenParser* parser)
+        : ParserImpl(parser)
+    {
+    }
+
+    /**
  * @brief Read the start of a chunk. [...]
  */
-bool ParserImplBinary::readChunkStart(ZenParser::ChunkHeader& header)
-{
-    // Skip chunk headers - we know these are zCMaterial
-    uint32_t chunksize = m_pParser->readBinaryDWord();
-    uint16_t version = m_pParser->readBinaryWord();
-    uint32_t objectIndex = m_pParser->readBinaryDWord();
+    bool ParserImplBinary::readChunkStart(ZenParser::ChunkHeader& header)
+    {
+        // Skip chunk headers - we know these are zCMaterial
+        uint32_t chunksize = m_pParser->readBinaryDWord();
+        uint16_t version = m_pParser->readBinaryWord();
+        uint32_t objectIndex = m_pParser->readBinaryDWord();
 
-    m_pParser->skipSpaces();
+        m_pParser->skipSpaces();
 
-    // Skip chunk-header
-    std::string name = m_pParser->readLine();
-    std::string classname = m_pParser->readLine();
+        // Skip chunk-header
+        std::string name = m_pParser->readLine();
+        std::string classname = m_pParser->readLine();
 
-    header.classname = classname;
-    header.createObject = true;  // TODO: References shouldn't be used in binary zens...
-    header.name = name;
-    header.objectID = objectIndex;
-    header.size = chunksize;
-    header.version = version;
+        header.classname = classname;
+        header.createObject = true;  // TODO: References shouldn't be used in binary zens...
+        header.name = name;
+        header.objectID = objectIndex;
+        header.size = chunksize;
+        header.version = version;
 
-    return true;
-}
+        return true;
+    }
 
-/**
+    /**
  * @brief Read the end of a chunk. []
  */
-bool ParserImplBinary::readChunkEnd()
-{
-    return true;
-}
+    bool ParserImplBinary::readChunkEnd()
+    {
+        return true;
+    }
 
-/**
+    /**
  * @brief Read the implementation specific header and stores it in the parsers main-header struct
  */
-void ParserImplBinary::readImplHeader()
-{
-    if (!m_pParser->skipString("objects"))
-        throw std::runtime_error("Object count missing");
+    void ParserImplBinary::readImplHeader()
+    {
+        if (!m_pParser->skipString("objects"))
+            throw std::runtime_error("Object count missing");
 
-    m_pParser->m_Header.objectCount = m_pParser->readIntASCII();
+        m_pParser->m_Header.objectCount = m_pParser->readIntASCII();
 
-    if (!m_pParser->skipString("END"))
-        throw std::runtime_error("No END in header(2)");
+        if (!m_pParser->skipString("END"))
+            throw std::runtime_error("No END in header(2)");
 
-    m_pParser->skipNewLines();
-}
+        m_pParser->skipNewLines();
+    }
 
-/**
+    /**
  * @brief Reads a string
  */
-std::string ParserImplBinary::readString()
-{
-    std::string ret = m_pParser->readLine();
-    return ret;
-}
+    std::string ParserImplBinary::readString()
+    {
+        std::string ret = m_pParser->readLine();
+        return ret;
+    }
 
-/**
+    /**
  * @brief Reads data of the expected type. Throws if the read type is not the same as specified and not 0
  */
-void ParserImplBinary::readEntry(const char* /*expectedName*/, void* target, size_t targetSize, EZenValueType expectedType)
-{
-    // Special case for strings, they're read until 0-bytes
-    if (expectedType == ZVT_STRING)
+    void ParserImplBinary::readEntry(const char* /*expectedName*/, void* target, size_t targetSize, EZenValueType expectedType)
     {
-        *reinterpret_cast<std::string*>(target) = readString();
-        return;
+        // Special case for strings, they're read until 0-bytes
+        if (expectedType == ZVT_STRING)
+        {
+            *reinterpret_cast<std::string*>(target) = readString();
+            return;
+        }
+
+        size_t size = 0;
+        switch (expectedType)
+        {
+            // 32-bit
+            case ZVT_INT:
+            case ZVT_FLOAT:
+            case ZVT_VEC3:
+            case ZVT_COLOR:
+                size = sizeof(uint32_t);
+                break;
+
+            // 16-bit
+            case ZVT_WORD:
+                size = sizeof(uint16_t);
+                break;
+
+            // Raw
+            case ZVT_RAW_FLOAT:
+            case ZVT_RAW:
+                size = targetSize;
+                break;
+
+            // Byte sized
+            case ZVT_BOOL:
+            case ZVT_BYTE:
+            case ZVT_ENUM:
+                size = sizeof(uint8_t);
+                break;
+
+            default:
+                break;
+        }
+
+        m_pParser->readBinaryRaw(target, size);
     }
 
-    size_t size = 0;
-    switch (expectedType)
-    {
-        // 32-bit
-        case ZVT_INT:
-        case ZVT_FLOAT:
-        case ZVT_VEC3:
-        case ZVT_COLOR:
-            size = sizeof(uint32_t);
-            break;
-            
-        // 16-bit
-        case ZVT_WORD:
-            size = sizeof(uint16_t);
-            break;
-
-        // Raw
-        case ZVT_RAW_FLOAT:
-        case ZVT_RAW:
-            size = targetSize;
-            break;
-
-        // Byte sized
-        case ZVT_BOOL:
-        case ZVT_BYTE:
-        case ZVT_ENUM:
-            size = sizeof(uint8_t);
-            break;
-
-        default:
-            break;
-    }
-
-    m_pParser->readBinaryRaw(target, size);
-}
-
-/**
+    /**
 * @brief Reads the type of a single entry
 */
-void ParserImplBinary::readEntryType(EZenValueType& outtype, size_t& size)
-{
-}
+    void ParserImplBinary::readEntryType(EZenValueType& outtype, size_t& size)
+    {
+    }
+}  // namespace ZenLib

--- a/zenload/parserImplBinary.h
+++ b/zenload/parserImplBinary.h
@@ -1,45 +1,48 @@
 #pragma once
 #include "parserImpl.h"
 
-namespace ZenLoad
+namespace ZenLib
 {
-    class ParserImplBinary : public ParserImpl
+    namespace ZenLoad
     {
-        friend ZenParser;
+        class ParserImplBinary : public ParserImpl
+        {
+            friend ZenParser;
 
-    public:
-        ParserImplBinary(ZenParser* parser);
+        public:
+            ParserImplBinary(ZenParser* parser);
 
-        /**
+            /**
 		 * @brief Read the implementation specific header and stores it in the parsers main-header struct
 		 */
-        void readImplHeader() override;
+            void readImplHeader() override;
 
-        /**
+            /**
 		* @brief Read the start of a chunk. [...] Returns true if there actually was a start. 
 		*		  Otherwise it will leave m_Seek untouched and return false.
 		*/
-        bool readChunkStart(ZenParser::ChunkHeader& header) override;
+            bool readChunkStart(ZenParser::ChunkHeader& header) override;
 
-        /**
+            /**
 		* @brief Reads the end of a chunk. Returns true if there actually was an end. 
 		*		  Otherwise it will leave m_Seek untouched and return false.
 		*/
-        bool readChunkEnd() override;
+            bool readChunkEnd() override;
 
-        /**
+            /**
 		 * @brief Reads a string
 		 */
-        std::string readString() override;
+            std::string readString() override;
 
-        /**
+            /**
 		 * @brief Reads data of the expected type. Throws if the read type is not the same as specified and not 0
 		 */
-        void readEntry(const char* name, void* target, size_t targetSize, EZenValueType expectedType = ZVT_0) override;
+            void readEntry(const char* name, void* target, size_t targetSize, EZenValueType expectedType = ZVT_0) override;
 
-        /**
+            /**
 		* @brief Reads the type of a single entry
 		*/
-        void readEntryType(EZenValueType& type, size_t& size) override;
-    };
-}  // namespace ZenLoad
+            void readEntryType(EZenValueType& type, size_t& size) override;
+        };
+    }  // namespace ZenLoad
+}  // namespace ZenLib

--- a/zenload/zCBspTree.h
+++ b/zenload/zCBspTree.h
@@ -6,257 +6,261 @@
 #include "zenParser.h"
 #include <assert.h>
 
-namespace ZenLoad
+namespace ZenLib
 {
-    class ZenParser;
-    class zCBspTree
+    namespace ZenLoad
     {
-    public:
-        enum EVersion
+        class ZenParser;
+        class zCBspTree
         {
-            Gothic_26f = 67698688,
-            Gothic_18k = 34144256
-        };
+        public:
+            enum EVersion
+            {
+                Gothic_26f = 67698688,
+                Gothic_18k = 34144256
+            };
 
-        enum EBspChunk
-        {
-            CHUNK_BSP = 0xC000,
-            CHUNK_BSP_POLYLIST = 0xC010,
-            CHUNK_BSP_TREE = 0xC040,
-            CHUNK_BSP_LEAF_LIGHT = 0xC045,
-            CHUNK_BSP_OUTDOOR_SECTORS = 0xC050,
-            CHUNK_BSP_END = 0xC0FF,
-        };
+            enum EBspChunk
+            {
+                CHUNK_BSP = 0xC000,
+                CHUNK_BSP_POLYLIST = 0xC010,
+                CHUNK_BSP_TREE = 0xC040,
+                CHUNK_BSP_LEAF_LIGHT = 0xC045,
+                CHUNK_BSP_OUTDOOR_SECTORS = 0xC050,
+                CHUNK_BSP_END = 0xC0FF,
+            };
 
-        /**
+            /**
         * Reads this object from an internal zen
         */
-        static zCBspTreeData readObjectData(ZenParser& parser, zCMesh* mesh)
-        {
-            zCBspTreeData info;
-
-            // Information about the whole file we are reading here
-            BinaryFileInfo fileInfo;
-            uint32_t version = 0;
-            size_t binFileEnd;  // Ending location of the binary file
-
-            // Read information about the current file. Mainly size is important here.
-            parser.readStructure(fileInfo);
-
-            // Calculate ending location and thus, the filesize
-            binFileEnd = parser.getSeek() + fileInfo.size;
-
-            // Read the BSP-Tree first
-            size_t meshPosition = parser.getSeek();
-            zCMesh::skip(parser);
-            //mesh->readObjectData(parser);
-
-            // Information about a single chunk
-            BinaryChunkInfo chunkInfo;
-
-            bool done = false;
-            while (!done && parser.getSeek() < binFileEnd)
+            static zCBspTreeData readObjectData(ZenParser& parser, zCMesh* mesh)
             {
-                // Read chunk header and calculate position of next chunk
-                parser.readStructure(chunkInfo);
+                zCBspTreeData info;
 
-                size_t chunkEnd = parser.getSeek() + chunkInfo.length;
+                // Information about the whole file we are reading here
+                BinaryFileInfo fileInfo;
+                uint32_t version = 0;
+                size_t binFileEnd;  // Ending location of the binary file
 
-                switch (chunkInfo.id)
+                // Read information about the current file. Mainly size is important here.
+                parser.readStructure(fileInfo);
+
+                // Calculate ending location and thus, the filesize
+                binFileEnd = parser.getSeek() + fileInfo.size;
+
+                // Read the BSP-Tree first
+                size_t meshPosition = parser.getSeek();
+                zCMesh::skip(parser);
+                //mesh->readObjectData(parser);
+
+                // Information about a single chunk
+                BinaryChunkInfo chunkInfo;
+
+                bool done = false;
+                while (!done && parser.getSeek() < binFileEnd)
                 {
-                    case EBspChunk::CHUNK_BSP:
-                        version = parser.readBinaryWord();
-                        info.mode = static_cast<zCBspTreeData::TreeMode>(parser.readBinaryDWord());
+                    // Read chunk header and calculate position of next chunk
+                    parser.readStructure(chunkInfo);
+
+                    size_t chunkEnd = parser.getSeek() + chunkInfo.length;
+
+                    switch (chunkInfo.id)
+                    {
+                        case EBspChunk::CHUNK_BSP:
+                            version = parser.readBinaryWord();
+                            info.mode = static_cast<zCBspTreeData::TreeMode>(parser.readBinaryDWord());
+                            break;
+
+                        case CHUNK_BSP_POLYLIST:
+                        {
+                            uint32_t numPolys = parser.readBinaryDWord();
+                            info.treePolyIndices.resize(numPolys);
+
+                            LogInfo() << "numPolys: " << numPolys;
+
+                            // Convert these to size_t
+                            for (volatile uint32_t i = 0; i < numPolys; i++)
+                                info.treePolyIndices[i] = static_cast<size_t>(parser.readBinaryDWord());
+                        }
                         break;
 
-                    case CHUNK_BSP_POLYLIST:
-                    {
-                        uint32_t numPolys = parser.readBinaryDWord();
-                        info.treePolyIndices.resize(numPolys);
-
-                        LogInfo() << "numPolys: " << numPolys;
-
-                        // Convert these to size_t
-                        for (volatile uint32_t i = 0; i < numPolys; i++)
-                            info.treePolyIndices[i] = static_cast<size_t>(parser.readBinaryDWord());
-                    }
-                    break;
-
-                    case CHUNK_BSP_TREE:
-                    {
-                        uint32_t numNodes = parser.readBinaryDWord();
-                        uint32_t numLeafs = parser.readBinaryDWord();
-                        //info.nodes.resize(numNodes + numLeafs);
-                        //info.leafIndices.reserve(numLeafs);
-
-                        LogInfo() << "Num nodes: " << numNodes;
-
-                        if (!numNodes)
+                        case CHUNK_BSP_TREE:
                         {
-                            parser.setSeek(chunkEnd);  // Skip chunk
-                            break;
-                        }
+                            uint32_t numNodes = parser.readBinaryDWord();
+                            uint32_t numLeafs = parser.readBinaryDWord();
+                            //info.nodes.resize(numNodes + numLeafs);
+                            //info.leafIndices.reserve(numLeafs);
 
-                        info.nodes.reserve(numNodes + numLeafs);
-                        info.nodes.emplace_back();
-                        info.nodes[0].parent = zCBspNode::INVALID_NODE;
+                            LogInfo() << "Num nodes: " << numNodes;
 
-                        std::function<void(bool)> loadRec = [&](bool isNode) {
-                            size_t idx = info.nodes.size() - 1;
-                            //LogInfo() << " - Reading node " << idx;
-
-                            zCBspNode& n = info.nodes[idx];
-
-                            parser.readStructure(n.bbox3dMin);
-                            parser.readStructure(n.bbox3dMax);
-
-                            n.bbox3dMin *= 0.01f;  // Convert to meters
-                            n.bbox3dMax *= 0.01f;
-
-                            // Read indices to the polys this contains
-                            n.treePolyIndex = static_cast<size_t>(parser.readBinaryDWord());
-                            n.numPolys = static_cast<size_t>(parser.readBinaryDWord());
-
-                            n.front = zCBspNode::INVALID_NODE;
-                            n.back = zCBspNode::INVALID_NODE;
-                            n.parent = zCBspNode::INVALID_NODE;
-
-                            // Only need to load data if this isn't a leaf
-                            if (isNode)
+                            if (!numNodes)
                             {
-                                /**
+                                parser.setSeek(chunkEnd);  // Skip chunk
+                                break;
+                            }
+
+                            info.nodes.reserve(numNodes + numLeafs);
+                            info.nodes.emplace_back();
+                            info.nodes[0].parent = zCBspNode::INVALID_NODE;
+
+                            std::function<void(bool)> loadRec = [&](bool isNode)
+                            {
+                                size_t idx = info.nodes.size() - 1;
+                                //LogInfo() << " - Reading node " << idx;
+
+                                zCBspNode& n = info.nodes[idx];
+
+                                parser.readStructure(n.bbox3dMin);
+                                parser.readStructure(n.bbox3dMax);
+
+                                n.bbox3dMin *= 0.01f;  // Convert to meters
+                                n.bbox3dMax *= 0.01f;
+
+                                // Read indices to the polys this contains
+                                n.treePolyIndex = static_cast<size_t>(parser.readBinaryDWord());
+                                n.numPolys = static_cast<size_t>(parser.readBinaryDWord());
+
+                                n.front = zCBspNode::INVALID_NODE;
+                                n.back = zCBspNode::INVALID_NODE;
+                                n.parent = zCBspNode::INVALID_NODE;
+
+                                // Only need to load data if this isn't a leaf
+                                if (isNode)
+                                {
+                                    /**
                                  * Flags:
                                  * 1: front
                                  * 2: back
                                  * 4: front is leaf
                                  * 8: back is leaf
                                  */
-                                const int FLAG_FRONT = 1;
-                                const int FLAG_BACK = 2;
-                                const int FLAG_FRONT_IS_LEAF = 4;
-                                const int FLAG_BACK_IS_LEAF = 8;
+                                    const int FLAG_FRONT = 1;
+                                    const int FLAG_BACK = 2;
+                                    const int FLAG_FRONT_IS_LEAF = 4;
+                                    const int FLAG_BACK_IS_LEAF = 8;
 
-                                // flags tell if this node got children and whether they are leafs
-                                uint8_t flags = parser.readBinaryByte();
+                                    // flags tell if this node got children and whether they are leafs
+                                    uint8_t flags = parser.readBinaryByte();
 
-                                parser.readStructure(n.plane.w);
-                                parser.readStructure(n.plane.x);
-                                parser.readStructure(n.plane.y);
-                                parser.readStructure(n.plane.z);
+                                    parser.readStructure(n.plane.w);
+                                    parser.readStructure(n.plane.x);
+                                    parser.readStructure(n.plane.y);
+                                    parser.readStructure(n.plane.z);
 
-                                n.plane.w *= 0.01f;  // Convert to meters
+                                    n.plane.w *= 0.01f;  // Convert to meters
 
-                                // G1 has an extra byte here
-                                if (fileInfo.version == Gothic_18k)
-                                    parser.readBinaryByte();  // Lod-flag
+                                    // G1 has an extra byte here
+                                    if (fileInfo.version == Gothic_18k)
+                                        parser.readBinaryByte();  // Lod-flag
 
-                                // Read front node
-                                if ((flags & FLAG_FRONT) != 0)
-                                {
-                                    // Assign index and add actual node
-                                    n.front = info.nodes.size();
-                                    info.nodes.emplace_back();
+                                    // Read front node
+                                    if ((flags & FLAG_FRONT) != 0)
+                                    {
+                                        // Assign index and add actual node
+                                        n.front = info.nodes.size();
+                                        info.nodes.emplace_back();
 
-                                    zCBspNode& front = info.nodes[n.front];
+                                        zCBspNode& front = info.nodes[n.front];
 
-                                    // Set new nodes parent
-                                    front.parent = idx;
+                                        // Set new nodes parent
+                                        front.parent = idx;
 
-                                    // If this is a leaf, add it to the leaf-list
-                                    if ((flags & FLAG_FRONT_IS_LEAF) != 0)
-                                        info.leafIndices.push_back(n.front);
+                                        // If this is a leaf, add it to the leaf-list
+                                        if ((flags & FLAG_FRONT_IS_LEAF) != 0)
+                                            info.leafIndices.push_back(n.front);
 
-                                    // Continue to load the tree
-                                    loadRec((flags & FLAG_FRONT_IS_LEAF) == 0);
+                                        // Continue to load the tree
+                                        loadRec((flags & FLAG_FRONT_IS_LEAF) == 0);
+                                    }
+
+                                    // Read back node
+                                    if ((flags & FLAG_BACK) != 0)
+                                    {
+                                        // Assign index and add actual node
+                                        n.back = info.nodes.size();
+                                        info.nodes.emplace_back();
+
+                                        zCBspNode& back = info.nodes[n.back];
+
+                                        // Set new nodes parent
+                                        back.parent = idx;
+
+                                        // If this is a leaf, add it to the leaf-list
+                                        if ((flags & FLAG_BACK_IS_LEAF) != 0)
+                                            info.leafIndices.push_back(n.back);
+
+                                        // Continue to load the tree
+                                        loadRec((flags & FLAG_BACK_IS_LEAF) == 0);
+                                    }
                                 }
-
-                                // Read back node
-                                if ((flags & FLAG_BACK) != 0)
+                                else
                                 {
-                                    // Assign index and add actual node
-                                    n.back = info.nodes.size();
-                                    info.nodes.emplace_back();
-
-                                    zCBspNode& back = info.nodes[n.back];
-
-                                    // Set new nodes parent
-                                    back.parent = idx;
-
-                                    // If this is a leaf, add it to the leaf-list
-                                    if ((flags & FLAG_BACK_IS_LEAF) != 0)
-                                        info.leafIndices.push_back(n.back);
-
-                                    // Continue to load the tree
-                                    loadRec((flags & FLAG_BACK_IS_LEAF) == 0);
+                                    //LogInfo() << idx << " Leaf!";
                                 }
-                            }
-                            else
-                            {
-                                //LogInfo() << idx << " Leaf!";
-                            }
-                        };
+                            };
 
-                        loadRec(true);
+                            loadRec(true);
+                        }
+                        break;
+
+                        case CHUNK_BSP_LEAF_LIGHT:
+                            parser.setSeek(chunkEnd);  // Skip chunk
+                            break;
+
+                        case CHUNK_BSP_OUTDOOR_SECTORS:
+                            parser.setSeek(chunkEnd);  // Skip chunk
+                            break;
+
+                        case CHUNK_BSP_END:
+                            done = true;
+                            break;
+
+                        default:
+                            parser.setSeek(chunkEnd);  // Skip chunk
                     }
-                    break;
-
-                    case CHUNK_BSP_LEAF_LIGHT:
-                        parser.setSeek(chunkEnd);  // Skip chunk
-                        break;
-
-                    case CHUNK_BSP_OUTDOOR_SECTORS:
-                        parser.setSeek(chunkEnd);  // Skip chunk
-                        break;
-
-                    case CHUNK_BSP_END:
-                        done = true;
-                        break;
-
-                    default:
-                        parser.setSeek(chunkEnd);  // Skip chunk
                 }
+                (void)version;
+
+                // Now get the list of non-lod polygons to load the worldmesh without them
+                std::vector<size_t> nonLodPolys = getNonLodPolygons(info);
+
+                std::sort(nonLodPolys.begin(), nonLodPolys.end());
+                nonLodPolys.erase(std::unique(nonLodPolys.begin(), nonLodPolys.end()), nonLodPolys.end());
+
+                LogInfo() << "Found " << nonLodPolys.size() << " non lod polys";
+
+                // Reset to mesh position
+                size_t seek = parser.getSeek();
+                parser.setSeek(meshPosition);
+                mesh->readObjectData(parser, nonLodPolys, parser.getZenHeader().user == std::string("XZEN"));
+
+                parser.setSeek(binFileEnd);
+
+                return info;
             }
-            (void)version;
 
-            // Now get the list of non-lod polygons to load the worldmesh without them
-            std::vector<size_t> nonLodPolys = getNonLodPolygons(info);
-
-            std::sort(nonLodPolys.begin(), nonLodPolys.end());
-            nonLodPolys.erase(std::unique(nonLodPolys.begin(), nonLodPolys.end()), nonLodPolys.end());
-
-            LogInfo() << "Found " << nonLodPolys.size() << " non lod polys";
-
-            // Reset to mesh position
-            size_t seek = parser.getSeek();
-            parser.setSeek(meshPosition);
-            mesh->readObjectData(parser, nonLodPolys, parser.getZenHeader().user == std::string("XZEN"));
-
-            parser.setSeek(binFileEnd);
-
-            return info;
-        }
-
-        /**
+            /**
          * Returns a list of polygon-indices which are not LOD-polyons
          * @param d Loaded BSP-Tree data
          * @return List of indices to polygons, which are not LOD-Polygons. These are the
          *         actual indices of the polygons inside the mesh.
          */
-        static std::vector<size_t> getNonLodPolygons(const zCBspTreeData& d)
-        {
-            std::vector<size_t> r;
-
-            for (size_t nidx : d.leafIndices)
+            static std::vector<size_t> getNonLodPolygons(const zCBspTreeData& d)
             {
-                const zCBspNode& n = d.nodes[nidx];
+                std::vector<size_t> r;
 
-                for (size_t i = n.treePolyIndex; i < n.treePolyIndex + n.numPolys; i++)
-                    r.push_back(d.treePolyIndices[i]);
+                for (size_t nidx : d.leafIndices)
+                {
+                    const zCBspNode& n = d.nodes[nidx];
+
+                    for (size_t i = n.treePolyIndex; i < n.treePolyIndex + n.numPolys; i++)
+                        r.push_back(d.treePolyIndices[i]);
+                }
+
+                return r;
             }
 
-            return r;
-        }
-
-    private:
-    };
-}  // namespace ZenLoad
+        private:
+        };
+    }  // namespace ZenLoad
+}  // namespace ZenLib

--- a/zenload/zCCSLib.cpp
+++ b/zenload/zCCSLib.cpp
@@ -7,135 +7,138 @@
 #include <utils/logger.h>
 #include <vdfs/fileIndex.h>
 
-using namespace ZenLoad;
-
-zCCSLib::zCCSLib(const std::string& fileName, const VDFS::FileIndex& fileIndex)
+namespace ZenLib
 {
-    std::vector<uint8_t> data;
-    fileIndex.getFileData(fileName, data);
+    using namespace ZenLoad;
 
-    if (data.empty())
-        return;  // TODO: Throw an exception or something
-
-    try
+    zCCSLib::zCCSLib(const std::string& fileName, const VDFS::FileIndex& fileIndex)
     {
-        // Create parser from memory
-        // FIXME: There is an internal copy of the data here. Optimize!
-        ZenLoad::ZenParser parser(data.data(), data.size());
+        std::vector<uint8_t> data;
+        fileIndex.getFileData(fileName, data);
 
-        readObjectData(parser);
-    }
-    catch (std::exception& e)
-    {
-        LogError() << e.what();
-        return;
-    }
-}
+        if (data.empty())
+            return;  // TODO: Throw an exception or something
 
-zCCSLib::zCCSLib(const std::string& file)
-{
-    try
-    {
-        // Create parser from memory
-        // FIXME: There is an internal copy of the data here. Optimize!
-        ZenLoad::ZenParser parser(file);
-
-        readObjectData(parser);
-    }
-    catch (std::exception& e)
-    {
-        LogError() << e.what();
-        return;
-    }
-}
-
-void zCCSLib::readObjectData(ZenParser& parser)
-{
-    zCCSLibData& info = m_Data;
-
-    parser.readHeader();
-
-    ZenParser::ChunkHeader libHeader;
-    parser.readChunkStart(libHeader);
-
-    assert(libHeader.classname == "zCCSLib");
-
-    uint32_t numItems;
-    parser.getImpl()->readEntry("NumOfItems", &numItems, sizeof(numItems), ParserImpl::ZVT_INT);
-
-    LogInfo() << "Reading " << numItems << " blocks";
-
-    for (uint32_t i = 0; i < numItems; i++)
-    {
-        ZenParser::ChunkHeader blockHeader;
-        parser.readChunkStart(blockHeader);
-
-        zCCSBlockData blk;
-        uint32_t numBlocks;
-        float subBlock0;
-        ReadObjectProperties(parser, blk.properties,
-                             Prop("blockName", blk.blockName),
-                             Prop("numOfBlocks", numBlocks),
-                             Prop("subBlock0", subBlock0));
-
-        // Haven't seen different values for these
-        assert(numBlocks == 1);
-        assert(subBlock0 == 0.0f);
-
-        // Read the single atomic block
+        try
         {
-            ZenParser::ChunkHeader atomicHeader;
+            // Create parser from memory
+            // FIXME: There is an internal copy of the data here. Optimize!
+            ZenLoad::ZenParser parser(data.data(), data.size());
 
-            parser.readChunkStart(atomicHeader);
+            readObjectData(parser);
+        }
+        catch (std::exception& e)
+        {
+            LogError() << e.what();
+            return;
+        }
+    }
 
-            // Read event-message of atomic block
+    zCCSLib::zCCSLib(const std::string& file)
+    {
+        try
+        {
+            // Create parser from memory
+            // FIXME: There is an internal copy of the data here. Optimize!
+            ZenLoad::ZenParser parser(file);
+
+            readObjectData(parser);
+        }
+        catch (std::exception& e)
+        {
+            LogError() << e.what();
+            return;
+        }
+    }
+
+    void zCCSLib::readObjectData(ZenParser& parser)
+    {
+        zCCSLibData& info = m_Data;
+
+        parser.readHeader();
+
+        ZenParser::ChunkHeader libHeader;
+        parser.readChunkStart(libHeader);
+
+        assert(libHeader.classname == "zCCSLib");
+
+        uint32_t numItems;
+        parser.getImpl()->readEntry("NumOfItems", &numItems, sizeof(numItems), ParserImpl::ZVT_INT);
+
+        LogInfo() << "Reading " << numItems << " blocks";
+
+        for (uint32_t i = 0; i < numItems; i++)
+        {
+            ZenParser::ChunkHeader blockHeader;
+            parser.readChunkStart(blockHeader);
+
+            zCCSBlockData blk;
+            uint32_t numBlocks;
+            float subBlock0;
+            ReadObjectProperties(parser, blk.properties,
+                                 Prop("blockName", blk.blockName),
+                                 Prop("numOfBlocks", numBlocks),
+                                 Prop("subBlock0", subBlock0));
+
+            // Haven't seen different values for these
+            assert(numBlocks == 1);
+            assert(subBlock0 == 0.0f);
+
+            // Read the single atomic block
             {
-                ZenParser::ChunkHeader messageHeader;
-                parser.readChunkStart(messageHeader);
+                ZenParser::ChunkHeader atomicHeader;
 
-                /*parser.getImpl()->readEntry("subtype", &blk.atomicBlockData.command.subType, 1, ZenLoad::ParserImpl::ZVT_ENUM);
+                parser.readChunkStart(atomicHeader);
+
+                // Read event-message of atomic block
+                {
+                    ZenParser::ChunkHeader messageHeader;
+                    parser.readChunkStart(messageHeader);
+
+                    /*parser.getImpl()->readEntry("subtype", &blk.atomicBlockData.command.subType, 1, ZenLoad::ParserImpl::ZVT_ENUM);
 				parser.getImpl()->readEntry("text", &blk.atomicBlockData.command.text, 0, ZenLoad::ParserImpl::ZVT_STRING);
 				parser.getImpl()->readEntry("name", &blk.atomicBlockData.command.name, 0, ZenLoad::ParserImpl::ZVT_STRING);*/
 
-                ReadObjectProperties(parser, blk.atomicBlockData.properties,
-                                     Prop("subType", blk.atomicBlockData.command.subType),
-                                     Prop("text", blk.atomicBlockData.command.text),
-                                     Prop("name", blk.atomicBlockData.command.name));
+                    ReadObjectProperties(parser, blk.atomicBlockData.properties,
+                                         Prop("subType", blk.atomicBlockData.command.subType),
+                                         Prop("text", blk.atomicBlockData.command.text),
+                                         Prop("name", blk.atomicBlockData.command.name));
 
-                //LogInfo() << "Read message: " << blk.atomicBlockData.command.name;
+                    //LogInfo() << "Read message: " << blk.atomicBlockData.command.name;
+
+                    parser.readChunkEnd();
+                    //parser.skipChunk();
+                }
 
                 parser.readChunkEnd();
                 //parser.skipChunk();
             }
+            //parser.skipChunk();
 
             parser.readChunkEnd();
-            //parser.skipChunk();
+
+            info.blocks.push_back(blk.atomicBlockData);
+
+            auto nameUppered = blk.blockName;
+            std::transform(nameUppered.begin(), nameUppered.end(), nameUppered.begin(), ::toupper);
+            //LogInfo() << "message = " << blk.blockName;
+            m_MessagesByName[nameUppered] = info.blocks.size() - 1;
         }
-        //parser.skipChunk();
-
-        parser.readChunkEnd();
-
-        info.blocks.push_back(blk.atomicBlockData);
-
-        auto nameUppered = blk.blockName;
-        std::transform(nameUppered.begin(), nameUppered.end(), nameUppered.begin(), ::toupper);
-        //LogInfo() << "message = " << blk.blockName;
-        m_MessagesByName[nameUppered] = info.blocks.size() - 1;
     }
-}
 
-const oCMsgConversationData& zCCSLib::getMessageByName(const std::string& name)
-{
-    auto nameUppered = name;
-    std::transform(nameUppered.begin(), nameUppered.end(), nameUppered.begin(), ::toupper);
-    assert(m_MessagesByName.find(nameUppered) != m_MessagesByName.end());
-    size_t idx = m_MessagesByName[nameUppered];
-    return m_Data.blocks[idx].command;
-}
+    const oCMsgConversationData& zCCSLib::getMessageByName(const std::string& name)
+    {
+        auto nameUppered = name;
+        std::transform(nameUppered.begin(), nameUppered.end(), nameUppered.begin(), ::toupper);
+        assert(m_MessagesByName.find(nameUppered) != m_MessagesByName.end());
+        size_t idx = m_MessagesByName[nameUppered];
+        return m_Data.blocks[idx].command;
+    }
 
-bool zCCSLib::messageExists(const std::string& name) const
-{
-    auto nameUppered = name;
-    std::transform(nameUppered.begin(), nameUppered.end(), nameUppered.begin(), ::toupper);
-    return m_MessagesByName.find(nameUppered) != m_MessagesByName.end();
-}
+    bool zCCSLib::messageExists(const std::string& name) const
+    {
+        auto nameUppered = name;
+        std::transform(nameUppered.begin(), nameUppered.end(), nameUppered.begin(), ::toupper);
+        return m_MessagesByName.find(nameUppered) != m_MessagesByName.end();
+    }
+}  // namespace ZenLib

--- a/zenload/zCCSLib.h
+++ b/zenload/zCCSLib.h
@@ -2,49 +2,52 @@
 #include <map>
 #include "zTypes.h"
 
-namespace VDFS
+namespace ZenLib
 {
-    class FileIndex;
-}
-
-namespace ZenLoad
-{
-    class ZenParser;
-    class zCCSLib
+    namespace VDFS
     {
-    public:
-        /**
+        class FileIndex;
+    }
+
+    namespace ZenLoad
+    {
+        class ZenParser;
+        class zCCSLib
+        {
+        public:
+            /**
 		 * @brief Loads the file from the given VDF-Archive
 		 */
-        zCCSLib(const std::string& fileName, const VDFS::FileIndex& fileIndex);
-        zCCSLib(const std::string& file);
+            zCCSLib(const std::string& fileName, const VDFS::FileIndex& fileIndex);
+            zCCSLib(const std::string& file);
 
-        /**
+            /**
         * Reads this object from an internal zen
         */
-        void readObjectData(ZenParser& parser);
+            void readObjectData(ZenParser& parser);
 
-        /**
+            /**
          * @return the message of the given name
          */
-        const oCMsgConversationData& getMessageByName(const std::string& name);
+            const oCMsgConversationData& getMessageByName(const std::string& name);
 
-        /**
+            /**
          * @return true if the message was found
          */
-        bool messageExists(const std::string& name) const;
+            bool messageExists(const std::string& name) const;
 
-        const zCCSLibData& getData() { return m_Data; }
+            const zCCSLibData& getData() { return m_Data; }
 
-    private:
-        /**
+        private:
+            /**
          * Loaded data straight from the file
          */
-        zCCSLibData m_Data;
+            zCCSLibData m_Data;
 
-        /**
+            /**
          * Message indices by their names
          */
-        std::map<std::string, size_t> m_MessagesByName;
-    };
-}  // namespace ZenLoad
+            std::map<std::string, size_t> m_MessagesByName;
+        };
+    }  // namespace ZenLoad
+}  // namespace ZenLib

--- a/zenload/zCFont.cpp
+++ b/zenload/zCFont.cpp
@@ -8,40 +8,42 @@
 #include <utils/logger.h>
 #include <vdfs/fileIndex.h>
 
-using namespace ZenLoad;
-
-zCFont::zCFont(const std::string& fileName, const VDFS::FileIndex& fileIndex)
+namespace ZenLib
 {
-    std::string fntFile = fileName;
-    std::transform(fntFile.begin(), fntFile.end(), fntFile.begin(), ::tolower);
+    using namespace ZenLoad;
 
-    if (fntFile.find(".tga") != std::string::npos)
-        fntFile = fntFile.substr(0, fntFile.size() - 4) + ".FNT";
-    else if (fntFile.find(".fnt") == std::string::npos)
-        fntFile += ".FNT";
-
-    std::vector<uint8_t> data;
-    fileIndex.getFileData(fileName, data);
-
-    if (data.empty())
-        return;  // TODO: Throw an exception or something
-
-    parseFNTData(data);
-}
-
-zCFont::~zCFont()
-{
-}
-
-bool zCFont::parseFNTData(const std::vector<uint8_t>& fntData)
-{
-    try
+    zCFont::zCFont(const std::string& fileName, const VDFS::FileIndex& fileIndex)
     {
-        // Create parser from memory
-        // FIXME: There is an internal copy of the data here. Optimize!
-        ZenLoad::ZenParser parser(fntData.data(), fntData.size());
+        std::string fntFile = fileName;
+        std::transform(fntFile.begin(), fntFile.end(), fntFile.begin(), ::tolower);
 
-        /**
+        if (fntFile.find(".tga") != std::string::npos)
+            fntFile = fntFile.substr(0, fntFile.size() - 4) + ".FNT";
+        else if (fntFile.find(".fnt") == std::string::npos)
+            fntFile += ".FNT";
+
+        std::vector<uint8_t> data;
+        fileIndex.getFileData(fileName, data);
+
+        if (data.empty())
+            return;  // TODO: Throw an exception or something
+
+        parseFNTData(data);
+    }
+
+    zCFont::~zCFont()
+    {
+    }
+
+    bool zCFont::parseFNTData(const std::vector<uint8_t>& fntData)
+    {
+        try
+        {
+            // Create parser from memory
+            // FIXME: There is an internal copy of the data here. Optimize!
+            ZenLoad::ZenParser parser(fntData.data(), fntData.size());
+
+            /**
          * FNT-format is pretty simple:
          * [string]: version\n
          * [string]: name\n
@@ -52,41 +54,42 @@ bool zCFont::parseFNTData(const std::vector<uint8_t>& fntData)
          * {float2]:  fontUV2[FONT_NUM_MAX_LETTERS]
          */
 
-        std::string version = parser.readLine();
+            std::string version = parser.readLine();
 
-        // Only version 1 is used by gothic
-        if (version != "1")
+            // Only version 1 is used by gothic
+            if (version != "1")
+            {
+                LogError() << "Unknown font-version: " << version;
+                return false;
+            }
+
+            std::string name = parser.readLine(false);
+
+            uint32_t height = parser.readBinaryDWord();
+            uint32_t magic = parser.readBinaryDWord();
+
+            if (magic != 256)
+            {
+                LogError() << "Invalid font-file! Magic: " << magic;
+                return false;
+            }
+
+            // Checks are through, directly write to font-info now
+
+            parser.readBinaryRaw(m_Info.glyphWidth, sizeof(m_Info.glyphWidth));
+            parser.readBinaryRaw(m_Info.fontUV1, sizeof(m_Info.fontUV1));
+            parser.readBinaryRaw(m_Info.fontUV2, sizeof(m_Info.fontUV2));
+
+            // Plug the other information in
+            m_Info.fontName = name;
+            m_Info.fontHeight = height;
+        }
+        catch (std::exception& e)
         {
-            LogError() << "Unknown font-version: " << version;
+            LogError() << e.what();
             return false;
         }
 
-        std::string name = parser.readLine(false);
-
-        uint32_t height = parser.readBinaryDWord();
-        uint32_t magic = parser.readBinaryDWord();
-
-        if (magic != 256)
-        {
-            LogError() << "Invalid font-file! Magic: " << magic;
-            return false;
-        }
-
-        // Checks are through, directly write to font-info now
-
-        parser.readBinaryRaw(m_Info.glyphWidth, sizeof(m_Info.glyphWidth));
-        parser.readBinaryRaw(m_Info.fontUV1, sizeof(m_Info.fontUV1));
-        parser.readBinaryRaw(m_Info.fontUV2, sizeof(m_Info.fontUV2));
-
-        // Plug the other information in
-        m_Info.fontName = name;
-        m_Info.fontHeight = height;
+        return true;
     }
-    catch (std::exception& e)
-    {
-        LogError() << e.what();
-        return false;
-    }
-
-    return true;
-}
+}  // namespace ZenLib

--- a/zenload/zCFont.h
+++ b/zenload/zCFont.h
@@ -6,62 +6,65 @@
 #include <map>
 #include "zTypes.h"
 
-namespace VDFS
+namespace ZenLib
 {
-    class FileIndex;
-}
-
-namespace ZenLoad
-{
-    class ZenParser;
-    class zCFont
+    namespace VDFS
     {
-    public:
-        /**
+        class FileIndex;
+    }
+
+    namespace ZenLoad
+    {
+        class ZenParser;
+        class zCFont
+        {
+        public:
+            /**
          * Max number of letters that a font can have (file format limitation)
          */
-        static const int FONT_NUM_MAX_LETTERS = 256;
+            static const int FONT_NUM_MAX_LETTERS = 256;
 
-        /**
+            /**
          * Everything found in the FNT-file
          */
-        struct FontInfo
-        {
-            FontInfo()
+            struct FontInfo
             {
-                fontHeight = 0;
-                memset(glyphWidth, 0, sizeof(glyphWidth));
-            }
+                FontInfo()
+                {
+                    fontHeight = 0;
+                    memset(glyphWidth, 0, sizeof(glyphWidth));
+                }
 
-            std::string fontName;                         // Name of the font-file?
-            uint32_t fontHeight;                          // Height of the glyphs
-            uint8_t glyphWidth[FONT_NUM_MAX_LETTERS];     // Widths of the single glyphs
-            ZMath::float2 fontUV1[FONT_NUM_MAX_LETTERS];  // Top-left corner
-            ZMath::float2 fontUV2[FONT_NUM_MAX_LETTERS];  // Bottom-right corner
-        };
+                std::string fontName;                         // Name of the font-file?
+                uint32_t fontHeight;                          // Height of the glyphs
+                uint8_t glyphWidth[FONT_NUM_MAX_LETTERS];     // Widths of the single glyphs
+                ZMath::float2 fontUV1[FONT_NUM_MAX_LETTERS];  // Top-left corner
+                ZMath::float2 fontUV2[FONT_NUM_MAX_LETTERS];  // Bottom-right corner
+            };
 
-        zCFont(const std::string& fileName, const VDFS::FileIndex& fileIndex);
-        virtual ~zCFont();
+            zCFont(const std::string& fileName, const VDFS::FileIndex& fileIndex);
+            virtual ~zCFont();
 
-        /**
+            /**
          * @return Whether this font was correctly loaded
          */
-        bool isValid() { return m_Info.fontHeight != 0; }
+            bool isValid() { return m_Info.fontHeight != 0; }
 
-        /**
+            /**
          * @return Information loaded from the font-file
          */
-        const FontInfo& getFontInfo() { return m_Info; }
+            const FontInfo& getFontInfo() { return m_Info; }
 
-    protected:
-        /**
+        protected:
+            /**
          * Parses a .FNT-File given as a binary blob
          * @param fntData .FNT-File given as a binary blob
          * @return Success
          */
-        bool parseFNTData(const std::vector<uint8_t>& fntData);
+            bool parseFNTData(const std::vector<uint8_t>& fntData);
 
-        // Everything found in the FNT-file
-        FontInfo m_Info;
-    };
-}  // namespace ZenLoad
+            // Everything found in the FNT-file
+            FontInfo m_Info;
+        };
+    }  // namespace ZenLoad
+}  // namespace ZenLib

--- a/zenload/zCMaterial.cpp
+++ b/zenload/zCMaterial.cpp
@@ -1,3 +1,6 @@
 #include "zCMaterial.h"
 
-using namespace ZenLoad;
+namespace ZenLib
+{
+    using namespace ZenLoad;
+}

--- a/zenload/zCMaterial.h
+++ b/zenload/zCMaterial.h
@@ -4,107 +4,110 @@
 #include "zenParser.h"
 #include "zenParserPropRead.h"
 
-namespace ZenLoad
+namespace ZenLib
 {
-    enum class MaterialGroup : int
+    namespace ZenLoad
     {
-        UNDEF = 0,
-        METAL,
-        STONE,
-        WOOD,
-        EARTH,
-        WATER,
-        SNOW,
-        NUM_MAT_GROUPS
-    };
+        enum class MaterialGroup : int
+        {
+            UNDEF = 0,
+            METAL,
+            STONE,
+            WOOD,
+            EARTH,
+            WATER,
+            SNOW,
+            NUM_MAT_GROUPS
+        };
 
-    static const std::string MaterialGroupNames[(int)MaterialGroup::NUM_MAT_GROUPS] = {
-        "UNDEF",
-        "METAL",
-        "STONE",
-        "WOOD",
-        "EARTH",
-        "WATER",
-        "SNOW",
-    };
+        static const std::string MaterialGroupNames[(int)MaterialGroup::NUM_MAT_GROUPS] = {
+            "UNDEF",
+            "METAL",
+            "STONE",
+            "WOOD",
+            "EARTH",
+            "WATER",
+            "SNOW",
+        };
 
-    class zCMaterial
-    {
-    public:
-        /**
+        class zCMaterial
+        {
+        public:
+            /**
          * Converts the given material-group enum value to the regarding string
          */
-        static std::string getMatGroupString(MaterialGroup group)
-        {
-            if ((int)group >= (int)MaterialGroup::NUM_MAT_GROUPS)
+            static std::string getMatGroupString(MaterialGroup group)
             {
-                return MaterialGroupNames[(int)MaterialGroup::UNDEF];
+                if ((int)group >= (int)MaterialGroup::NUM_MAT_GROUPS)
+                {
+                    return MaterialGroupNames[(int)MaterialGroup::UNDEF];
+                }
+
+                return MaterialGroupNames[(int)group];
             }
 
-            return MaterialGroupNames[(int)group];
-        }
-
-        /**
+            /**
          * Reads this object from an internal zen
          */
-        static zCMaterialData readObjectData(ZenParser& parser, uint16_t version = 0)
-        {
-            // Read everything the material has to offer
-            zCMaterialData materialInfo;
-
-            materialInfo.objectClass = "zCMaterial";
-
-            if (version != 39939)  // Gothic 1
+            static zCMaterialData readObjectData(ZenParser& parser, uint16_t version = 0)
             {
-                ReadObjectProperties(parser, materialInfo.properties,
-                                     Prop("MaterialName", materialInfo.matName),
-                                     Prop("MaterialGroup", materialInfo.matGroup),
-                                     Prop("Color", materialInfo.color),
-                                     Prop("SmoothAngle", materialInfo.smoothAngle),
-                                     Prop("Texture", materialInfo.texture),
-                                     Prop("TextureScale", materialInfo.texScale),
-                                     Prop("TextureAniFPS", materialInfo.texAniFPS),
-                                     Prop("TextureAniMapMode", materialInfo.texAniMapMode),
-                                     Prop("TextureAniMapDir", materialInfo.texAniMapDir),
-                                     Prop("NoCollisionDetection", materialInfo.noCollDet),
-                                     Prop("NoLightmap", materialInfo.noLighmap),
-                                     Prop("LoadDontCollapse", materialInfo.loadDontCollapse),
-                                     Prop("DetailObject", materialInfo.detailObject),
-                                     Prop("DefaultMapping", materialInfo.defaultMapping));
+                // Read everything the material has to offer
+                zCMaterialData materialInfo;
+
+                materialInfo.objectClass = "zCMaterial";
+
+                if (version != 39939)  // Gothic 1
+                {
+                    ReadObjectProperties(parser, materialInfo.properties,
+                                         Prop("MaterialName", materialInfo.matName),
+                                         Prop("MaterialGroup", materialInfo.matGroup),
+                                         Prop("Color", materialInfo.color),
+                                         Prop("SmoothAngle", materialInfo.smoothAngle),
+                                         Prop("Texture", materialInfo.texture),
+                                         Prop("TextureScale", materialInfo.texScale),
+                                         Prop("TextureAniFPS", materialInfo.texAniFPS),
+                                         Prop("TextureAniMapMode", materialInfo.texAniMapMode),
+                                         Prop("TextureAniMapDir", materialInfo.texAniMapDir),
+                                         Prop("NoCollisionDetection", materialInfo.noCollDet),
+                                         Prop("NoLightmap", materialInfo.noLighmap),
+                                         Prop("LoadDontCollapse", materialInfo.loadDontCollapse),
+                                         Prop("DetailObject", materialInfo.detailObject),
+                                         Prop("DefaultMapping", materialInfo.defaultMapping));
+                }
+                else
+                {
+                    ReadObjectProperties(parser, materialInfo.properties,
+                                         Prop("MaterialName", materialInfo.matName),
+                                         Prop("MaterialGroup", materialInfo.matGroup),
+                                         Prop("Color", materialInfo.color),
+                                         Prop("SmoothAngle", materialInfo.smoothAngle),
+                                         Prop("Texture", materialInfo.texture),
+                                         Prop("TextureScale", materialInfo.texScale),
+                                         Prop("TextureAniFPS", materialInfo.texAniFPS),
+                                         Prop("TextureAniMapMode", materialInfo.texAniMapMode),
+                                         Prop("TextureAniMapDir", materialInfo.texAniMapDir),
+                                         Prop("NoCollisionDetection", materialInfo.noCollDet),
+                                         Prop("NoLightmap", materialInfo.noLighmap),
+                                         Prop("LoadDontCollapse", materialInfo.loadDontCollapse),
+                                         Prop("DetailObject", materialInfo.detailObject),
+                                         Prop("DetailTextureScale", materialInfo.detailTextureScale),
+                                         Prop("ForceOccluder", materialInfo.forceOccluder),
+                                         Prop("EnvironmentMapping", materialInfo.environmentMapping),
+                                         Prop("EnvironmentalMappingStrength", materialInfo.environmentalMappingStrength),
+                                         Prop("WaveMode", materialInfo.waveMode),
+                                         Prop("WaveSpeed", materialInfo.waveSpeed),
+                                         Prop("WaveMaxAmplitude", materialInfo.waveMaxAmplitude),
+                                         Prop("WaveGridSize", materialInfo.waveGridSize),
+                                         Prop("IgnoreSun", materialInfo.ignoreSun),
+                                         Prop("AlphaFunc", materialInfo.alphaFunc),
+                                         Prop("DefaultMapping", materialInfo.defaultMapping));
+                }
+
+                return materialInfo;
             }
-            else
-            {
-                ReadObjectProperties(parser, materialInfo.properties,
-                                     Prop("MaterialName", materialInfo.matName),
-                                     Prop("MaterialGroup", materialInfo.matGroup),
-                                     Prop("Color", materialInfo.color),
-                                     Prop("SmoothAngle", materialInfo.smoothAngle),
-                                     Prop("Texture", materialInfo.texture),
-                                     Prop("TextureScale", materialInfo.texScale),
-                                     Prop("TextureAniFPS", materialInfo.texAniFPS),
-                                     Prop("TextureAniMapMode", materialInfo.texAniMapMode),
-                                     Prop("TextureAniMapDir", materialInfo.texAniMapDir),
-                                     Prop("NoCollisionDetection", materialInfo.noCollDet),
-                                     Prop("NoLightmap", materialInfo.noLighmap),
-                                     Prop("LoadDontCollapse", materialInfo.loadDontCollapse),
-                                     Prop("DetailObject", materialInfo.detailObject),
-                                     Prop("DetailTextureScale", materialInfo.detailTextureScale),
-                                     Prop("ForceOccluder", materialInfo.forceOccluder),
-                                     Prop("EnvironmentMapping", materialInfo.environmentMapping),
-                                     Prop("EnvironmentalMappingStrength", materialInfo.environmentalMappingStrength),
-                                     Prop("WaveMode", materialInfo.waveMode),
-                                     Prop("WaveSpeed", materialInfo.waveSpeed),
-                                     Prop("WaveMaxAmplitude", materialInfo.waveMaxAmplitude),
-                                     Prop("WaveGridSize", materialInfo.waveGridSize),
-                                     Prop("IgnoreSun", materialInfo.ignoreSun),
-                                     Prop("AlphaFunc", materialInfo.alphaFunc),
-                                     Prop("DefaultMapping", materialInfo.defaultMapping));
-            }
 
-            return materialInfo;
-        }
+        private:
+        };
 
-    private:
-    };
-
-}  // namespace ZenLoad
+    }  // namespace ZenLoad
+}  // namespace ZenLib

--- a/zenload/zCMesh.cpp
+++ b/zenload/zCMesh.cpp
@@ -8,400 +8,375 @@
 #include "vdfs/fileIndex.h"
 #include <utils/alignment.h>
 
-using namespace ZenLoad;
-
-// Types of chunks we will find in a zCMesh-Section
-static const unsigned short MSID_MESH = 0xB000;
-static const unsigned short MSID_BBOX3D = 0xB010;
-static const unsigned short MSID_MATLIST = 0xB020;
-static const unsigned short MSID_LIGHTMAPLIST = 0xB025;
-static const unsigned short MSID_LIGHTMAPLIST_SHARED = 0xB026;
-static const unsigned short MSID_VERTLIST = 0xB030;
-static const unsigned short MSID_FEATLIST = 0xB040;
-static const unsigned short MSID_POLYLIST = 0xB050;
-static const unsigned short MSID_MESH_END = 0xB060;
-
-enum EVersion
+namespace ZenLib
 {
-    G1_1_08k = 9,
-    G2_2_6fix = 265
-};
+    using namespace ZenLoad;
 
-/**
+    // Types of chunks we will find in a zCMesh-Section
+    static const unsigned short MSID_MESH = 0xB000;
+    static const unsigned short MSID_BBOX3D = 0xB010;
+    static const unsigned short MSID_MATLIST = 0xB020;
+    static const unsigned short MSID_LIGHTMAPLIST = 0xB025;
+    static const unsigned short MSID_LIGHTMAPLIST_SHARED = 0xB026;
+    static const unsigned short MSID_VERTLIST = 0xB030;
+    static const unsigned short MSID_FEATLIST = 0xB040;
+    static const unsigned short MSID_POLYLIST = 0xB050;
+    static const unsigned short MSID_MESH_END = 0xB060;
+
+    enum EVersion
+    {
+        G1_1_08k = 9,
+        G2_2_6fix = 265
+    };
+
+    /**
 * @brief Loads the mesh from the given VDF-Archive
 */
-zCMesh::zCMesh(const std::string& fileName, VDFS::FileIndex& fileIndex)
-{
-    std::vector<uint8_t> data;
-    fileIndex.getFileData(fileName, data);
-
-    if (data.empty())
+    zCMesh::zCMesh(const std::string& fileName, VDFS::FileIndex& fileIndex)
     {
-        return;  // TODO: Throw an exception or something
+        std::vector<uint8_t> data;
+        fileIndex.getFileData(fileName, data);
+
+        if (data.empty())
+        {
+            return;  // TODO: Throw an exception or something
+        }
+
+        try
+        {
+            // Create parser from memory
+            // FIXME: There is an internal copy of the data here. Optimize!
+            ZenLoad::ZenParser parser(data.data(), data.size());
+
+            // .MSH-Files are just saved zCMeshes
+            readObjectData(parser);
+        }
+        catch (std::exception& e)
+        {
+            LogError() << e.what();
+            return;
+        }
     }
 
-    try
-    {
-        // Create parser from memory
-        // FIXME: There is an internal copy of the data here. Optimize!
-        ZenLoad::ZenParser parser(data.data(), data.size());
-
-        // .MSH-Files are just saved zCMeshes
-        readObjectData(parser);
-    }
-    catch (std::exception& e)
-    {
-        LogError() << e.what();
-        return;
-    }
-}
-
-/**
+    /**
  * Helper structs for version independend loading of polygon data
  */
-template <typename FT>
-struct polyData1
-{
-    int16_t materialIndex;  // -1 if none
-    int16_t lightmapIndex;  // -1 if none
-    zTPlane polyPlane;
-    FT flags;
-    uint8_t polyNumVertices;
-};
+    template <typename FT>
+    struct polyData1
+    {
+        int16_t materialIndex;  // -1 if none
+        int16_t lightmapIndex;  // -1 if none
+        zTPlane polyPlane;
+        FT flags;
+        uint8_t polyNumVertices;
+    };
 
 #pragma pack(push, 1)
-template <typename FT>
-struct polyData1Packed
-{
-    int16_t materialIndex;  // -1 if none
-    int16_t lightmapIndex;  // -1 if none
-    zTPlane polyPlane;
-    FT flags;
-    uint8_t polyNumVertices;
-};
+    template <typename FT>
+    struct polyData1Packed
+    {
+        int16_t materialIndex;  // -1 if none
+        int16_t lightmapIndex;  // -1 if none
+        zTPlane polyPlane;
+        FT flags;
+        uint8_t polyNumVertices;
+    };
 #pragma pack(pop)
 
-template <typename IT, typename FT>
-struct polyData2 : public polyData1<FT>
-{
-    /**
+    template <typename IT, typename FT>
+    struct polyData2 : public polyData1<FT>
+    {
+        /**
      * @brief ugly helper-constructor to get from the specific G1/G2-format to a generic one
      */
-    template <typename _IT, typename _FT>
-    void from(const polyData2<_IT, _FT>& src)
-    {
-        for (size_t i = 0; i < src.polyNumVertices; i++)
+        template <typename _IT, typename _FT>
+        void from(const polyData2<_IT, _FT>& src)
         {
-            indices[i].VertexIndex = static_cast<IT>(src.indices[i].VertexIndex);
-            indices[i].FeatIndex = src.indices[i].FeatIndex;
+            for (size_t i = 0; i < src.polyNumVertices; i++)
+            {
+                indices[i].VertexIndex = static_cast<IT>(src.indices[i].VertexIndex);
+                indices[i].FeatIndex = src.indices[i].FeatIndex;
+            }
+
+            polyData1<FT>::materialIndex = src.materialIndex;
+            polyData1<FT>::lightmapIndex = src.lightmapIndex;
+            polyData1<FT>::polyPlane = src.polyPlane;
+            polyData1<FT>::polyNumVertices = src.polyNumVertices;
+            polyData1<FT>::flags = src.flags.generify();
         }
 
-        polyData1<FT>::materialIndex = src.materialIndex;
-        polyData1<FT>::lightmapIndex = src.lightmapIndex;
-        polyData1<FT>::polyPlane = src.polyPlane;
-        polyData1<FT>::polyNumVertices = src.polyNumVertices;
-        polyData1<FT>::flags = src.flags.generify();
-    }
+        polyData2() {}
 
-    polyData2() {}
-
-    struct Index
-    {
-        IT VertexIndex;
-        uint32_t FeatIndex;
-    };
+        struct Index
+        {
+            IT VertexIndex;
+            uint32_t FeatIndex;
+        };
 
 #pragma pack(push, 1)
-    struct IndexPacked
-    {
-        IT VertexIndex;
-        uint32_t FeatIndex;
-    };
+        struct IndexPacked
+        {
+            IT VertexIndex;
+            uint32_t FeatIndex;
+        };
 #pragma pack(pop)
 
-    void read(const uint8_t* _data)
-    {
-        const void*& data = (const void*&)_data;
-        Utils::unalignedRead(polyData1<FT>::materialIndex, data);
-        Utils::unalignedRead(polyData1<FT>::lightmapIndex, data);
-        Utils::unalignedRead(polyData1<FT>::polyPlane, data);
-        Utils::unalignedRead(polyData1<FT>::flags, data);
-        Utils::unalignedRead(polyData1<FT>::polyNumVertices, data);
-
-        for (int i = 0; i < polyData1<FT>::polyNumVertices; i++)
+        void read(const uint8_t* _data)
         {
-            Utils::unalignedRead(indices[i].VertexIndex, data);
-            Utils::unalignedRead(indices[i].FeatIndex, data);
-        }
-    }
+            const void*& data = (const void*&)_data;
+            Utils::unalignedRead(polyData1<FT>::materialIndex, data);
+            Utils::unalignedRead(polyData1<FT>::lightmapIndex, data);
+            Utils::unalignedRead(polyData1<FT>::polyPlane, data);
+            Utils::unalignedRead(polyData1<FT>::flags, data);
+            Utils::unalignedRead(polyData1<FT>::polyNumVertices, data);
 
-    Index indices[255];
-};
-/**
+            for (int i = 0; i < polyData1<FT>::polyNumVertices; i++)
+            {
+                Utils::unalignedRead(indices[i].VertexIndex, data);
+                Utils::unalignedRead(indices[i].FeatIndex, data);
+            }
+        }
+
+        Index indices[255];
+    };
+    /**
 * @brief Reads the mesh-object from the given binary stream
 */
-void zCMesh::readObjectData(ZenParser& parser, const std::vector<size_t>& skipPolys, bool forceG132bitIndices)
-{
-    uint16_t version;
-
-    // Information about a single chunk
-    BinaryChunkInfo chunkInfo;
-
-    // Read chunks until we left the virtual binary file or got to the end-chunk
-    // Each chunk starts with a header (BinaryChunkInfo) which gives information
-    // about what to do and how long the chunk is
-    bool doneReadingChunks = false;
-    while (!doneReadingChunks)
+    void zCMesh::readObjectData(ZenParser& parser, const std::vector<size_t>& skipPolys, bool forceG132bitIndices)
     {
-        // Read chunk header and calculate position of next chunk
-        parser.readStructure(chunkInfo);
+        uint16_t version;
 
-        size_t chunkEnd = parser.getSeek() + chunkInfo.length;
+        // Information about a single chunk
+        BinaryChunkInfo chunkInfo;
 
-        switch (chunkInfo.id)
+        // Read chunks until we left the virtual binary file or got to the end-chunk
+        // Each chunk starts with a header (BinaryChunkInfo) which gives information
+        // about what to do and how long the chunk is
+        bool doneReadingChunks = false;
+        while (!doneReadingChunks)
         {
-            case MSID_MESH:
+            // Read chunk header and calculate position of next chunk
+            parser.readStructure(chunkInfo);
+
+            size_t chunkEnd = parser.getSeek() + chunkInfo.length;
+
+            switch (chunkInfo.id)
             {
-                // uint32 - version
-                // zDate - Structure
-                // \n terminated string for the name
-                version = parser.readBinaryWord();
-                zDate date;
-                parser.readStructure(date);
-                std::string name = parser.readLine(false);
-                (void)date;
-
-                LogInfo() << "Reading mesh '" << name << "' (Version: " << version << ")";
-
-                parser.setSeek(chunkEnd);  // Skip chunk
-            }
-            break;
-
-            case MSID_BBOX3D:
-            {
-                ZMath::float4 min, max;
-                parser.readStructure(min);
-                parser.readStructure(max);
-
-                m_BBMin = ZMath::float3(min.x, min.y, min.z);
-                m_BBMax = ZMath::float3(max.x, max.y, max.z);
-
-                parser.setSeek(chunkEnd);  // Skip chunk
-            }
-            break;
-
-            case MSID_MATLIST:
-            {
-                // ZenArchive - Header
-                // uint32_t - Num materials
-                // For each material:
-                //  - String - Name
-                //  - zCMaterial-Chunk
-
-                //ZenParser p2(&parser.getData()[parser.getSeek()], parser.getData().size() - parser.getSeek());
-                //p2.readHeader();
-
-                ZenLoad::ParserImpl* oldImpl = parser.getImpl();
-                ZenLoad::ZenParser::ZenHeader oldHeader = parser.getZenHeader();
-
-                // These are binary, init the 'new' header
-                parser.readHeader();
-
-                // Read number of materials
-                uint32_t numMaterials = parser.readBinaryDWord();
-                m_Materials.reserve(numMaterials);
-
-                // Read every stored material
-                for (uint32_t i = 0; i < numMaterials; i++)
+                case MSID_MESH:
                 {
-                    parser.readLine(false);  // Read unused material name (Stored a second time later)
+                    // uint32 - version
+                    // zDate - Structure
+                    // \n terminated string for the name
+                    version = parser.readBinaryWord();
+                    zDate date;
+                    parser.readStructure(date);
+                    std::string name = parser.readLine(false);
+                    (void)date;
 
-                    // Skip chunk headers - we know these are zCMaterial
-                    uint32_t chunksize = parser.readBinaryDWord();
-                    uint16_t version = parser.readBinaryWord();
-                    uint32_t objectIndex = parser.readBinaryDWord();
+                    LogInfo() << "Reading mesh '" << name << "' (Version: " << version << ")";
 
-                    parser.skipSpaces();
-
-                    // Skip chunk-header
-                    std::string name = parser.readLine();
-                    std::string classname = parser.readLine();
-
-                    // Save into vector
-                    m_Materials.emplace_back(zCMaterial::readObjectData(parser, version));
+                    parser.setSeek(chunkEnd);  // Skip chunk
                 }
-
-                // Note: There is a bool stored here in the G2-Formats, which says whether to use alphatesting or not
-                // 		 We just skip this for now
-
-                // Restore old header and impl
-                delete parser.getImpl();
-                parser.setImpl(oldImpl);
-                parser.setZenHeader(oldHeader);
-
-                parser.setSeek(chunkEnd);  // Skip chunk
-            }
-            break;
-
-            case MSID_LIGHTMAPLIST:
-                parser.setSeek(chunkEnd);  // Skip chunk
                 break;
 
-            case MSID_LIGHTMAPLIST_SHARED:
-                parser.setSeek(chunkEnd);  // Skip chunk
+                case MSID_BBOX3D:
+                {
+                    ZMath::float4 min, max;
+                    parser.readStructure(min);
+                    parser.readStructure(max);
+
+                    m_BBMin = ZMath::float3(min.x, min.y, min.z);
+                    m_BBMax = ZMath::float3(max.x, max.y, max.z);
+
+                    parser.setSeek(chunkEnd);  // Skip chunk
+                }
                 break;
 
-            case MSID_VERTLIST:
-            {
-                // uint32 - number of vertices
-                // numVx float3s of vertexpositions
-
-                // Read how many vertices we have in this chunk
-                uint32_t numVertices = parser.readBinaryDWord();
-                m_Vertices.clear();
-
-                // Read vertex data and emplace into m_Vertices
-                m_Vertices.resize(numVertices);
-                parser.readBinaryRaw(m_Vertices.data(), numVertices * sizeof(float) * 3);
-
-                LogInfo() << "Found " << numVertices << " vertices";
-                // Flip x-coord to make up for right handedness
-                //for(auto& v : m_Vertices)
-                //	v.x = -v.x;
-            }
-            break;
-
-            case MSID_FEATLIST:
-            {
-                // uint32 - number of features
-                // zTMSH_FeatureChunk*num - features
-
-                // Read how many feats we have
-                uint32_t numFeats = parser.readBinaryDWord();
-
-                // Read features
-                m_Features.resize(numFeats);
-                parser.readBinaryRaw(m_Features.data(), numFeats * sizeof(zTMSH_FeatureChunk));
-            }
-            break;
-
-            case MSID_POLYLIST:
-            {
-                // Current entry of the skip list. This is increased as we go.
-                size_t skipListEntry = 0;
-
-                // Read number of polys
-                auto const numPolys = parser.readBinaryDWord();
-
-                // Read block of data
-                //std::vector<uint8_t> dataBlock;
-                //dataBlock.resize(chunkInfo.length);
-                //parser.readBinaryRaw(dataBlock.data(), chunkInfo.length);
-
-                // Fake a read here, to get around an additional copy of the data
-                const uint8_t* blockPtr = &parser.getData()[parser.getSeek()];
-                parser.setSeek(parser.getSeek() + chunkInfo.length);
-
-                size_t blockSize = version == EVersion::G2_2_6fix
-                                       ? sizeof(polyData1Packed<PolyFlags2_6fix>)
-                                       : sizeof(polyData1Packed<PolyFlags1_08k>);
-
-                size_t indicesSize = version == EVersion::G2_2_6fix
-                                         ? sizeof(polyData2<uint32_t, PolyFlags2_6fix>::IndexPacked)
-                                         : sizeof(polyData2<uint16_t, PolyFlags1_08k>::IndexPacked);
-
-                if (forceG132bitIndices)
+                case MSID_MATLIST:
                 {
-                    indicesSize = sizeof(polyData2<uint32_t, PolyFlags1_08k>::IndexPacked);
-                }
+                    // ZenArchive - Header
+                    // uint32_t - Num materials
+                    // For each material:
+                    //  - String - Name
+                    //  - zCMaterial-Chunk
 
-                // Preallocate some memory for the triangles
-                // Note: There will be some more triangles, since not all polys have 3 vertices. Times 2 could be a little bit too hugh, though.
-                m_Triangles.reserve(numPolys * 2);
+                    //ZenParser p2(&parser.getData()[parser.getSeek()], parser.getData().size() - parser.getSeek());
+                    //p2.readHeader();
 
-                // Iterate throuh every poly
-                for (auto i = size_t{0}; i < numPolys; i++)
-                {
-                    // Convert to a generic version
-                    polyData2<uint32_t, PolyFlags> p;
-                    if (version == EVersion::G2_2_6fix)
+                    ZenLoad::ParserImpl* oldImpl = parser.getImpl();
+                    ZenLoad::ZenParser::ZenHeader oldHeader = parser.getZenHeader();
+
+                    // These are binary, init the 'new' header
+                    parser.readHeader();
+
+                    // Read number of materials
+                    uint32_t numMaterials = parser.readBinaryDWord();
+                    m_Materials.reserve(numMaterials);
+
+                    // Read every stored material
+                    for (uint32_t i = 0; i < numMaterials; i++)
                     {
-                        polyData2<uint32_t, PolyFlags2_6fix> d;
-                        d.read(blockPtr);
+                        parser.readLine(false);  // Read unused material name (Stored a second time later)
 
-                        p.from(d);
+                        // Skip chunk headers - we know these are zCMaterial
+                        uint32_t chunksize = parser.readBinaryDWord();
+                        uint16_t version = parser.readBinaryWord();
+                        uint32_t objectIndex = parser.readBinaryDWord();
+
+                        parser.skipSpaces();
+
+                        // Skip chunk-header
+                        std::string name = parser.readLine();
+                        std::string classname = parser.readLine();
+
+                        // Save into vector
+                        m_Materials.emplace_back(zCMaterial::readObjectData(parser, version));
                     }
-                    else
+
+                    // Note: There is a bool stored here in the G2-Formats, which says whether to use alphatesting or not
+                    // 		 We just skip this for now
+
+                    // Restore old header and impl
+                    delete parser.getImpl();
+                    parser.setImpl(oldImpl);
+                    parser.setZenHeader(oldHeader);
+
+                    parser.setSeek(chunkEnd);  // Skip chunk
+                }
+                break;
+
+                case MSID_LIGHTMAPLIST:
+                    parser.setSeek(chunkEnd);  // Skip chunk
+                    break;
+
+                case MSID_LIGHTMAPLIST_SHARED:
+                    parser.setSeek(chunkEnd);  // Skip chunk
+                    break;
+
+                case MSID_VERTLIST:
+                {
+                    // uint32 - number of vertices
+                    // numVx float3s of vertexpositions
+
+                    // Read how many vertices we have in this chunk
+                    uint32_t numVertices = parser.readBinaryDWord();
+                    m_Vertices.clear();
+
+                    // Read vertex data and emplace into m_Vertices
+                    m_Vertices.resize(numVertices);
+                    parser.readBinaryRaw(m_Vertices.data(), numVertices * sizeof(float) * 3);
+
+                    LogInfo() << "Found " << numVertices << " vertices";
+                    // Flip x-coord to make up for right handedness
+                    //for(auto& v : m_Vertices)
+                    //	v.x = -v.x;
+                }
+                break;
+
+                case MSID_FEATLIST:
+                {
+                    // uint32 - number of features
+                    // zTMSH_FeatureChunk*num - features
+
+                    // Read how many feats we have
+                    uint32_t numFeats = parser.readBinaryDWord();
+
+                    // Read features
+                    m_Features.resize(numFeats);
+                    parser.readBinaryRaw(m_Features.data(), numFeats * sizeof(zTMSH_FeatureChunk));
+                }
+                break;
+
+                case MSID_POLYLIST:
+                {
+                    // Current entry of the skip list. This is increased as we go.
+                    size_t skipListEntry = 0;
+
+                    // Read number of polys
+                    auto const numPolys = parser.readBinaryDWord();
+
+                    // Read block of data
+                    //std::vector<uint8_t> dataBlock;
+                    //dataBlock.resize(chunkInfo.length);
+                    //parser.readBinaryRaw(dataBlock.data(), chunkInfo.length);
+
+                    // Fake a read here, to get around an additional copy of the data
+                    const uint8_t* blockPtr = &parser.getData()[parser.getSeek()];
+                    parser.setSeek(parser.getSeek() + chunkInfo.length);
+
+                    size_t blockSize = version == EVersion::G2_2_6fix
+                                           ? sizeof(polyData1Packed<PolyFlags2_6fix>)
+                                           : sizeof(polyData1Packed<PolyFlags1_08k>);
+
+                    size_t indicesSize = version == EVersion::G2_2_6fix
+                                             ? sizeof(polyData2<uint32_t, PolyFlags2_6fix>::IndexPacked)
+                                             : sizeof(polyData2<uint16_t, PolyFlags1_08k>::IndexPacked);
+
+                    if (forceG132bitIndices)
                     {
-                        if (forceG132bitIndices)
+                        indicesSize = sizeof(polyData2<uint32_t, PolyFlags1_08k>::IndexPacked);
+                    }
+
+                    // Preallocate some memory for the triangles
+                    // Note: There will be some more triangles, since not all polys have 3 vertices. Times 2 could be a little bit too hugh, though.
+                    m_Triangles.reserve(numPolys * 2);
+
+                    // Iterate throuh every poly
+                    for (auto i = size_t{0}; i < numPolys; i++)
+                    {
+                        // Convert to a generic version
+                        polyData2<uint32_t, PolyFlags> p;
+                        if (version == EVersion::G2_2_6fix)
                         {
-                            polyData2<uint32_t, PolyFlags1_08k> d;
+                            polyData2<uint32_t, PolyFlags2_6fix> d;
                             d.read(blockPtr);
 
                             p.from(d);
                         }
                         else
                         {
-                            polyData2<uint16_t, PolyFlags1_08k> d;
-                            d.read(blockPtr);
-
-                            p.from(d);
-                        }
-                    }
-
-                    if (skipPolys.empty() || (skipPolys[skipListEntry] == i))
-                    {
-                        // TODO: Store these somewhere else
-                        // TODO: lodFlag isn't set to something useful in Gothic 1. Also the portal-flags aren't set? Investigate!
-                        if (!p.flags.ghostOccluder && !p.flags.portalPoly && !p.flags.ghostOccluder &&
-                            !p.flags.portalIndoorOutdoor)
-                        {
-                            if (p.polyNumVertices != 0)
+                            if (forceG132bitIndices)
                             {
-                                if (p.polyNumVertices == 3)
+                                polyData2<uint32_t, PolyFlags1_08k> d;
+                                d.read(blockPtr);
+
+                                p.from(d);
+                            }
+                            else
+                            {
+                                polyData2<uint16_t, PolyFlags1_08k> d;
+                                d.read(blockPtr);
+
+                                p.from(d);
+                            }
+                        }
+
+                        if (skipPolys.empty() || (skipPolys[skipListEntry] == i))
+                        {
+                            // TODO: Store these somewhere else
+                            // TODO: lodFlag isn't set to something useful in Gothic 1. Also the portal-flags aren't set? Investigate!
+                            if (!p.flags.ghostOccluder && !p.flags.portalPoly && !p.flags.ghostOccluder &&
+                                !p.flags.portalIndoorOutdoor)
+                            {
+                                if (p.polyNumVertices != 0)
                                 {
-                                    // Write indices directly to a vector
-                                    WorldVertex vx[3];
-                                    for (int v = 0; v < 3; v++)
+                                    if (p.polyNumVertices == 3)
                                     {
-                                        m_Indices.emplace_back(p.indices[v].VertexIndex);
-                                        m_FeatureIndices.emplace_back(p.indices[v].FeatIndex);
+                                        // Write indices directly to a vector
+                                        WorldVertex vx[3];
+                                        for (int v = 0; v < 3; v++)
+                                        {
+                                            m_Indices.emplace_back(p.indices[v].VertexIndex);
+                                            m_FeatureIndices.emplace_back(p.indices[v].FeatIndex);
 
-                                        // Gather vertex information
-                                        vx[v].Position = m_Vertices[p.indices[v].VertexIndex];
-                                        vx[v].Color = m_Features[p.indices[v].FeatIndex].lightStat;
+                                            // Gather vertex information
+                                            vx[v].Position = m_Vertices[p.indices[v].VertexIndex];
+                                            vx[v].Color = m_Features[p.indices[v].FeatIndex].lightStat;
 
-                                        vx[v].TexCoord = ZMath::float2(m_Features[p.indices[v].FeatIndex].uv[0],
-                                                                       m_Features[p.indices[v].FeatIndex].uv[1]);
-                                        vx[v].Normal = m_Features[p.indices[v].FeatIndex].vertNormal;
-                                    }
-
-                                    // Save material index for the written triangle
-                                    m_TriangleMaterialIndices.push_back(p.materialIndex);
-
-                                    // Save lightmap-index
-                                    m_TriangleLightmapIndices.push_back(p.lightmapIndex);
-
-                                    WorldTriangle triangle;
-                                    triangle.flags = p.flags;
-                                    memcpy(triangle.vertices, vx, sizeof(vx));
-
-                                    // Save triangle
-                                    m_Triangles.push_back(triangle);
-                                }
-                                else
-                                {
-                                    // Triangulate a triangle-fan
-                                    //for(unsigned int i = p.polyNumVertices - 2; i >= 1; i--)
-                                    for (int i = 1; i < p.polyNumVertices - 1; i++)
-                                    {
-                                        m_Indices.emplace_back(p.indices[0].VertexIndex);
-                                        m_Indices.emplace_back(p.indices[i].VertexIndex);
-                                        m_Indices.emplace_back(p.indices[i + 1].VertexIndex);
-
-                                        m_FeatureIndices.emplace_back(p.indices[0].FeatIndex);
-                                        m_FeatureIndices.emplace_back(p.indices[i].FeatIndex);
-                                        m_FeatureIndices.emplace_back(p.indices[i + 1].FeatIndex);
+                                            vx[v].TexCoord = ZMath::float2(m_Features[p.indices[v].FeatIndex].uv[0],
+                                                                           m_Features[p.indices[v].FeatIndex].uv[1]);
+                                            vx[v].Normal = m_Features[p.indices[v].FeatIndex].vertNormal;
+                                        }
 
                                         // Save material index for the written triangle
                                         m_TriangleMaterialIndices.push_back(p.materialIndex);
@@ -411,80 +386,140 @@ void zCMesh::readObjectData(ZenParser& parser, const std::vector<size_t>& skipPo
 
                                         WorldTriangle triangle;
                                         triangle.flags = p.flags;
-                                        uint32_t idx[] = {p.indices[0].VertexIndex, p.indices[i].VertexIndex,
-                                                          p.indices[i + 1].VertexIndex};
+                                        memcpy(triangle.vertices, vx, sizeof(vx));
 
-                                        // Gather vertex information
-                                        for (int v = 0; v < 3; v++)
-                                        {
-                                            triangle.vertices[v].Position = m_Vertices[idx[v]];
-                                            triangle.vertices[v].Color = m_Features[idx[v]].lightStat;
-                                            triangle.vertices[v].TexCoord = ZMath::float2(m_Features[idx[v]].uv[0],
-                                                                                          m_Features[idx[v]].uv[1]);
-                                            triangle.vertices[v].Normal = m_Features[idx[v]].vertNormal;
-                                        }
-
-                                        // Start filling in the flags
+                                        // Save triangle
                                         m_Triangles.push_back(triangle);
+                                    }
+                                    else
+                                    {
+                                        // Triangulate a triangle-fan
+                                        //for(unsigned int i = p.polyNumVertices - 2; i >= 1; i--)
+                                        for (int i = 1; i < p.polyNumVertices - 1; i++)
+                                        {
+                                            m_Indices.emplace_back(p.indices[0].VertexIndex);
+                                            m_Indices.emplace_back(p.indices[i].VertexIndex);
+                                            m_Indices.emplace_back(p.indices[i + 1].VertexIndex);
+
+                                            m_FeatureIndices.emplace_back(p.indices[0].FeatIndex);
+                                            m_FeatureIndices.emplace_back(p.indices[i].FeatIndex);
+                                            m_FeatureIndices.emplace_back(p.indices[i + 1].FeatIndex);
+
+                                            // Save material index for the written triangle
+                                            m_TriangleMaterialIndices.push_back(p.materialIndex);
+
+                                            // Save lightmap-index
+                                            m_TriangleLightmapIndices.push_back(p.lightmapIndex);
+
+                                            WorldTriangle triangle;
+                                            triangle.flags = p.flags;
+                                            uint32_t idx[] = {p.indices[0].VertexIndex, p.indices[i].VertexIndex,
+                                                              p.indices[i + 1].VertexIndex};
+
+                                            // Gather vertex information
+                                            for (int v = 0; v < 3; v++)
+                                            {
+                                                triangle.vertices[v].Position = m_Vertices[idx[v]];
+                                                triangle.vertices[v].Color = m_Features[idx[v]].lightStat;
+                                                triangle.vertices[v].TexCoord = ZMath::float2(m_Features[idx[v]].uv[0],
+                                                                                              m_Features[idx[v]].uv[1]);
+                                                triangle.vertices[v].Normal = m_Features[idx[v]].vertNormal;
+                                            }
+
+                                            // Start filling in the flags
+                                            m_Triangles.push_back(triangle);
+                                        }
                                     }
                                 }
                             }
+
+                            skipListEntry++;
+                        }
+                        else
+                        {
                         }
 
-                        skipListEntry++;
-                    }
-                    else
-                    {
+                        // Goto next polygon using this weird shit
+                        blockPtr += blockSize + indicesSize * p.polyNumVertices;
                     }
 
-                    // Goto next polygon using this weird shit
-                    blockPtr += blockSize + indicesSize * p.polyNumVertices;
+                    parser.setSeek(chunkEnd);  // Skip chunk, there could be more data here which is never read
                 }
-
-                parser.setSeek(chunkEnd);  // Skip chunk, there could be more data here which is never read
-            }
-            break;
-
-            case MSID_MESH_END:
-                doneReadingChunks = true;
                 break;
 
-            default:
-                parser.setSeek(chunkEnd);  // Skip chunk
+                case MSID_MESH_END:
+                    doneReadingChunks = true;
+                    break;
+
+                default:
+                    parser.setSeek(chunkEnd);  // Skip chunk
+            }
         }
     }
-}
 
-/**
+    /**
 * @brief Creates packed submesh-data
 */
-void zCMesh::packMesh(PackedMesh& mesh, float scale, bool removeDoubles)
-{
-    std::vector<WorldVertex>& newVertices = mesh.vertices;
-    std::vector<uint32_t> newIndices;
-    newIndices.reserve(m_Indices.size());
-
-    // Map of vertex-indices and their used feature-indices to a vertex in "newVertices"
-    std::map<std::tuple<uint32_t, uint32_t, int16_t>, size_t> vfToNewVx;
-
-    // Map of the new indices and the old indices to the index-vector
-    //std::unordered_map<uint32_t, uint32_t> newToOldIdxIdx;
-
-    if (removeDoubles)
+    void zCMesh::packMesh(PackedMesh& mesh, float scale, bool removeDoubles)
     {
-        // Get vertices
-        for (size_t i = 0, end = m_Indices.size(); i < end; i++)
-        {
-            uint32_t featidx = m_FeatureIndices[i];
-            uint32_t vertidx = m_Indices[i];
-            int16_t lightmap = m_TriangleLightmapIndices[i / 3];
+        std::vector<WorldVertex>& newVertices = mesh.vertices;
+        std::vector<uint32_t> newIndices;
+        newIndices.reserve(m_Indices.size());
 
-            // Check if we already got this pair of vertex/feature
-            auto it = vfToNewVx.find(std::make_tuple(vertidx, featidx, lightmap));
-            if (it == vfToNewVx.end())
+        // Map of vertex-indices and their used feature-indices to a vertex in "newVertices"
+        std::map<std::tuple<uint32_t, uint32_t, int16_t>, size_t> vfToNewVx;
+
+        // Map of the new indices and the old indices to the index-vector
+        //std::unordered_map<uint32_t, uint32_t> newToOldIdxIdx;
+
+        if (removeDoubles)
+        {
+            // Get vertices
+            for (size_t i = 0, end = m_Indices.size(); i < end; i++)
             {
-                // Add new entry
-                vfToNewVx[std::make_tuple(vertidx, featidx, lightmap)] = newVertices.size();
+                uint32_t featidx = m_FeatureIndices[i];
+                uint32_t vertidx = m_Indices[i];
+                int16_t lightmap = m_TriangleLightmapIndices[i / 3];
+
+                // Check if we already got this pair of vertex/feature
+                auto it = vfToNewVx.find(std::make_tuple(vertidx, featidx, lightmap));
+                if (it == vfToNewVx.end())
+                {
+                    // Add new entry
+                    vfToNewVx[std::make_tuple(vertidx, featidx, lightmap)] = newVertices.size();
+                    WorldVertex vx;
+
+                    // Extract vertex information
+                    vx.Position = m_Vertices[vertidx] * scale;
+                    vx.Color = m_Features[featidx].lightStat;
+                    vx.TexCoord = ZMath::float2(m_Features[featidx].uv[0], m_Features[featidx].uv[1]);
+                    vx.Normal = m_Features[featidx].vertNormal;
+
+                    // Add index to this very vertex
+                    newIndices.push_back(newVertices.size());
+
+                    newVertices.push_back(vx);
+                }
+                else
+                {
+                    // Simply put an index to the existing new vertex
+                    newIndices.push_back((*it).second);
+                }
+
+                // Store what this new index was before
+                //newToOldIdxIdx[newIndices.back()] = i;
+            }
+        }
+        else
+        {
+            // Just add them as triangles
+            newVertices.reserve(m_Indices.size());
+            for (size_t i = 0, end = m_Indices.size(); i < end; i++)
+            {
+                uint32_t featidx = m_FeatureIndices[i];
+                uint32_t vertidx = m_Indices[i];
+                int16_t lightmap = m_TriangleLightmapIndices[i / 3];
+
                 WorldVertex vx;
 
                 // Extract vertex information
@@ -493,124 +528,92 @@ void zCMesh::packMesh(PackedMesh& mesh, float scale, bool removeDoubles)
                 vx.TexCoord = ZMath::float2(m_Features[featidx].uv[0], m_Features[featidx].uv[1]);
                 vx.Normal = m_Features[featidx].vertNormal;
 
-                // Add index to this very vertex
-                newIndices.push_back(newVertices.size());
-
                 newVertices.push_back(vx);
+                newIndices.push_back(newVertices.size() - 1);
             }
-            else
+        }
+
+        // Filter textures
+        std::unordered_map<std::string, uint32_t> materialsByTexture;
+        std::unordered_map<uint32_t, uint32_t> newMaterialSlotsByMatIndex;
+        for (size_t i = 0, end = m_Materials.size(); i < end; i++)
+        {
+            materialsByTexture[m_Materials[i].texture] = i;
+        }
+
+        // Assign materials to packed mesh
+        uint32_t mc = 0;
+        for (auto& m : materialsByTexture)
+        {
+            newMaterialSlotsByMatIndex[m.second] = mc++;
+            mesh.subMeshes.emplace_back();
+            mesh.subMeshes.back().material = m_Materials[m.second];
+        }
+
+        mesh.subMeshes.resize(materialsByTexture.size());
+        // Add triangles
+        for (size_t i = 0, end = newIndices.size(); i < end; i += 3)
+        {
+            // Get material info of this triangle
+            uint32_t matIdx = m_TriangleMaterialIndices[i / 3];
+
+            // Find texture of this material
+            const auto& matByTex = materialsByTexture.find(m_Materials[matIdx].texture);
+            if (matByTex != materialsByTexture.end())
             {
-                // Simply put an index to the existing new vertex
-                newIndices.push_back((*it).second);
+                const auto& matSlotByIndex = newMaterialSlotsByMatIndex.find(matByTex->second);
+                if (matSlotByIndex != newMaterialSlotsByMatIndex.end())
+                {
+                    // Copy lightmap index
+                    mesh.subMeshes[matSlotByIndex->second].triangleLightmapIndices.push_back(m_TriangleLightmapIndices[i / 3]);
+
+                    // Add this triangle to its submesh
+                    for (size_t j = 0; j < 3; j++)
+                        mesh.subMeshes[matSlotByIndex->second].indices.push_back(newIndices[i + j]);
+                }
             }
-
-            // Store what this new index was before
-            //newToOldIdxIdx[newIndices.back()] = i;
         }
-    }
-    else
-    {
-        // Just add them as triangles
-        newVertices.reserve(m_Indices.size());
-        for (size_t i = 0, end = m_Indices.size(); i < end; i++)
+
+        // Store triangles with more information attached as well
+        mesh.triangles.reserve(m_Triangles.size());
+        for (size_t i = 0; i < m_Triangles.size(); i++)
         {
-            uint32_t featidx = m_FeatureIndices[i];
-            uint32_t vertidx = m_Indices[i];
-            int16_t lightmap = m_TriangleLightmapIndices[i / 3];
+            // Add submesh index to this triangle
+            m_Triangles[i].submeshIndex = newMaterialSlotsByMatIndex[materialsByTexture[m_Materials[m_TriangleMaterialIndices[i]].texture]];
+            mesh.triangles.push_back(m_Triangles[i]);
 
-            WorldVertex vx;
-
-            // Extract vertex information
-            vx.Position = m_Vertices[vertidx] * scale;
-            vx.Color = m_Features[featidx].lightStat;
-            vx.TexCoord = ZMath::float2(m_Features[featidx].uv[0], m_Features[featidx].uv[1]);
-            vx.Normal = m_Features[featidx].vertNormal;
-
-            newVertices.push_back(vx);
-            newIndices.push_back(newVertices.size() - 1);
+            for (int v = 0; v < 3; v++)
+                mesh.triangles.back().vertices[v].Position = mesh.triangles.back().vertices[v].Position * scale;
         }
+
+        mesh.bbox[0] = m_BBMin * scale;
+        mesh.bbox[1] = m_BBMax * scale;
     }
 
-    // Filter textures
-    std::unordered_map<std::string, uint32_t> materialsByTexture;
-    std::unordered_map<uint32_t, uint32_t> newMaterialSlotsByMatIndex;
-    for (size_t i = 0, end = m_Materials.size(); i < end; i++)
+    void zCMesh::skip(ZenParser& parser)
     {
-        materialsByTexture[m_Materials[i].texture] = i;
-    }
+        // Information about a single chunk
+        BinaryChunkInfo chunkInfo;
 
-    // Assign materials to packed mesh
-    uint32_t mc = 0;
-    for (auto& m : materialsByTexture)
-    {
-        newMaterialSlotsByMatIndex[m.second] = mc++;
-        mesh.subMeshes.emplace_back();
-        mesh.subMeshes.back().material = m_Materials[m.second];
-    }
-
-    mesh.subMeshes.resize(materialsByTexture.size());
-    // Add triangles
-    for (size_t i = 0, end = newIndices.size(); i < end; i += 3)
-    {
-        // Get material info of this triangle
-        uint32_t matIdx = m_TriangleMaterialIndices[i / 3];
-
-        // Find texture of this material
-        const auto& matByTex = materialsByTexture.find(m_Materials[matIdx].texture);
-        if (matByTex != materialsByTexture.end())
+        // Read chunks until we left the virtual binary file or got to the end-chunk
+        // Each chunk starts with a header (BinaryChunkInfo) which gives information
+        // about what to do and how long the chunk is
+        while (true)
         {
-            const auto& matSlotByIndex = newMaterialSlotsByMatIndex.find(matByTex->second);
-            if (matSlotByIndex != newMaterialSlotsByMatIndex.end())
+            // Read chunk header and calculate position of next chunk
+            parser.readStructure(chunkInfo);
+
+            size_t chunkEnd = parser.getSeek() + chunkInfo.length;
+
+            // Just skip all of it
+            switch (chunkInfo.id)
             {
-                // Copy lightmap index
-                mesh.subMeshes[matSlotByIndex->second].triangleLightmapIndices.push_back(m_TriangleLightmapIndices[i / 3]);
+                case MSID_MESH_END:
+                    return;
 
-                // Add this triangle to its submesh
-                for (size_t j = 0; j < 3; j++)
-                    mesh.subMeshes[matSlotByIndex->second].indices.push_back(newIndices[i + j]);
+                default:
+                    parser.setSeek(chunkEnd);  // Skip chunk
             }
         }
     }
-
-    // Store triangles with more information attached as well
-    mesh.triangles.reserve(m_Triangles.size());
-    for (size_t i = 0; i < m_Triangles.size(); i++)
-    {
-        // Add submesh index to this triangle
-        m_Triangles[i].submeshIndex = newMaterialSlotsByMatIndex[materialsByTexture[m_Materials[m_TriangleMaterialIndices[i]].texture]];
-        mesh.triangles.push_back(m_Triangles[i]);
-
-        for (int v = 0; v < 3; v++)
-            mesh.triangles.back().vertices[v].Position = mesh.triangles.back().vertices[v].Position * scale;
-    }
-
-    mesh.bbox[0] = m_BBMin * scale;
-    mesh.bbox[1] = m_BBMax * scale;
-}
-
-void zCMesh::skip(ZenParser& parser)
-{
-    // Information about a single chunk
-    BinaryChunkInfo chunkInfo;
-
-    // Read chunks until we left the virtual binary file or got to the end-chunk
-    // Each chunk starts with a header (BinaryChunkInfo) which gives information
-    // about what to do and how long the chunk is
-    while (true)
-    {
-        // Read chunk header and calculate position of next chunk
-        parser.readStructure(chunkInfo);
-
-        size_t chunkEnd = parser.getSeek() + chunkInfo.length;
-
-        // Just skip all of it
-        switch (chunkInfo.id)
-        {
-            case MSID_MESH_END:
-                return;
-
-            default:
-                parser.setSeek(chunkEnd);  // Skip chunk
-        }
-    }
-}
+}  // namespace ZenLib

--- a/zenload/zCMesh.h
+++ b/zenload/zCMesh.h
@@ -4,134 +4,137 @@
 #include "zenParser.h"
 #include "utils/mathlib.h"
 
-namespace VDFS
+namespace ZenLib
 {
-    class FileIndex;
-}
-
-namespace ZenLoad
-{
-    class ZenParser;
-    class zCMesh
+    namespace VDFS
     {
-    public:
-        zCMesh() {}
+        class FileIndex;
+    }
 
-        /**
+    namespace ZenLoad
+    {
+        class ZenParser;
+        class zCMesh
+        {
+        public:
+            zCMesh() {}
+
+            /**
 		 * @brief Loads the mesh from the given VDF-Archive
 		 */
-        zCMesh(const std::string& fileName, VDFS::FileIndex& fileIndex);
+            zCMesh(const std::string& fileName, VDFS::FileIndex& fileIndex);
 
-        /**
+            /**
 		 * @brief Reads the mesh-object from the given binary stream
 		 * @param fromZen Whether this mesh is supposed to be read from a zenfile. In this case, information about the binary chunk is also read.
 		 * @param skipPolys These polygons will be skipped while loading. These need to be ordered! (Used to load world witout LOD in G1)
 		 * @param force32bitIndices Loads all indices as 32-bit, even though the ZEN may come from Gothic 1
 		 */
-        void readObjectData(ZenParser& parser, const std::vector<size_t>& skipPolys = std::vector<size_t>(),
-                            bool forceG132bitIndices = false);
+            void readObjectData(ZenParser& parser, const std::vector<size_t>& skipPolys = std::vector<size_t>(),
+                                bool forceG132bitIndices = false);
 
-        /**
+            /**
 		 * Simply skips all data found here
 		 * @param parser
 		 */
-        static void skip(ZenParser& parser);
+            static void skip(ZenParser& parser);
 
-        /**
+            /**
 		@ brief returns the vector of vertex-positions
 		*/
-        const std::vector<ZMath::float3>& getVertices() const { return m_Vertices; }
+            const std::vector<ZMath::float3>& getVertices() const { return m_Vertices; }
 
-        /**
+            /**
 		@ brief returns the vector of features
 		*/
-        const std::vector<zTMSH_FeatureChunk>& getFeatures() const { return m_Features; }
+            const std::vector<zTMSH_FeatureChunk>& getFeatures() const { return m_Features; }
 
-        /**
+            /**
 		 * @brief returns the vector of triangle-indices
 		 */
-        const std::vector<uint32_t>& getIndices() const { return m_Indices; }
+            const std::vector<uint32_t>& getIndices() const { return m_Indices; }
 
-        /**
+            /**
 		 * @brief returns the vector of triangle-indices
 		 */
-        const std::vector<uint32_t>& getFeatureIndices() const { return m_FeatureIndices; }
+            const std::vector<uint32_t>& getFeatureIndices() const { return m_FeatureIndices; }
 
-        /**
+            /**
 		 * @brief returns the vector of triangle-material-indices
 		 */
-        const std::vector<int16_t>& getTriangleMaterialIndices() const { return m_TriangleMaterialIndices; }
+            const std::vector<int16_t>& getTriangleMaterialIndices() const { return m_TriangleMaterialIndices; }
 
-        /**
+            /**
 		* @brief returns the vector of triangle-material-indices
 		*/
-        const std::vector<int16_t>& getTriangleLightmapIndices() const { return m_TriangleLightmapIndices; }
+            const std::vector<int16_t>& getTriangleLightmapIndices() const { return m_TriangleLightmapIndices; }
 
-        /**
+            /**
 		 * @brief returns the vector of the materials used by this mesh
 		 */
-        const std::vector<zCMaterialData>& getMaterials() const { return m_Materials; }
+            const std::vector<zCMaterialData>& getMaterials() const { return m_Materials; }
 
-        /**
+            /**
 		 * @brief getter for the boudingboxes
 		 */
-        void getBoundingBox(ZMath::float3& min, ZMath::float3& max)
-        {
-            min = m_BBMin;
-            max = m_BBMax;
-        }
+            void getBoundingBox(ZMath::float3& min, ZMath::float3& max)
+            {
+                min = m_BBMin;
+                max = m_BBMax;
+            }
 
-        /**
+            /**
 		 * @brief Creates packed submesh-data
 		 */
-        void packMesh(PackedMesh& mesh, float scale = 1.0f, bool removeDoubles = true);
+            void packMesh(PackedMesh& mesh, float scale = 1.0f, bool removeDoubles = true);
 
-    private:
-        /**
+        private:
+            /**
 		 * @brief vector of vertex-positions for this mesh
 		 */
-        std::vector<ZMath::float3> m_Vertices;
+            std::vector<ZMath::float3> m_Vertices;
 
-        /** 
+            /** 
 		 * @brief Featues for the vertices with the corresponding index
 		 */
-        std::vector<zTMSH_FeatureChunk> m_Features;
+            std::vector<zTMSH_FeatureChunk> m_Features;
 
-        /**
+            /**
 		 * @brief indices for the triangles of the mesh
 		 */
-        std::vector<uint32_t> m_Indices;
+            std::vector<uint32_t> m_Indices;
 
-        /**
+            /**
 		* @brief indices for the triangles of the mesh
 		*/
-        std::vector<uint32_t> m_FeatureIndices;
+            std::vector<uint32_t> m_FeatureIndices;
 
-        /**
+            /**
 		 * @brief Textures for the triangles. Divide index-position by 3 to get the 
 		 * corresponding material-info 
 		 */
-        std::vector<int16_t> m_TriangleMaterialIndices;
+            std::vector<int16_t> m_TriangleMaterialIndices;
 
-        /**
+            /**
 		 * @brief Index of the lightmap used by the triangles in order. -1 of no lightmap registered.
 		 */
-        std::vector<int16_t> m_TriangleLightmapIndices;
+            std::vector<int16_t> m_TriangleLightmapIndices;
 
-        /**
+            /**
 		 * @brief All materials used by this mesh
 		 */
-        std::vector<zCMaterialData> m_Materials;
+            std::vector<zCMaterialData> m_Materials;
 
-        /**
+            /**
 		 * @brief Triangles of the current mesh, containing flags
 		 */
-        std::vector<WorldTriangle> m_Triangles;
+            std::vector<WorldTriangle> m_Triangles;
 
-        /**
+            /**
 		 * @brief Bounding-box of this mesh
 		 */
-        ZMath::float3 m_BBMin;
-        ZMath::float3 m_BBMax;
-    };
-}  // namespace ZenLoad
+            ZMath::float3 m_BBMin;
+            ZMath::float3 m_BBMax;
+        };
+    }  // namespace ZenLoad
+}  // namespace ZenLib

--- a/zenload/zCMeshSoftSkin.cpp
+++ b/zenload/zCMeshSoftSkin.cpp
@@ -9,252 +9,255 @@
 #include "utils/logger.h"
 #include "vdfs/fileIndex.h"
 
-using namespace ZenLoad;
-
-static const uint16_t MSID_MESHSOFTSKIN = 0xE100;
-static const uint16_t MSID_MESHSOFTSKIN_END = 0xE110;
-
-void oBBox3d::load(ZenParser& parser)
+namespace ZenLib
 {
-    parser.readBinaryRaw(&center, sizeof(center));
+    using namespace ZenLoad;
 
-    parser.readBinaryRaw(&axis, sizeof(axis));
-    parser.readBinaryRaw(&extends, sizeof(extends));
+    static const uint16_t MSID_MESHSOFTSKIN = 0xE100;
+    static const uint16_t MSID_MESHSOFTSKIN_END = 0xE110;
 
-    uint16_t numChildren = parser.readBinaryWord();
-
-    for (uint16_t i = 0; i < numChildren; i++)
+    void oBBox3d::load(ZenParser& parser)
     {
-        children.emplace_back();
-        children.back().load(parser);
+        parser.readBinaryRaw(&center, sizeof(center));
+
+        parser.readBinaryRaw(&axis, sizeof(axis));
+        parser.readBinaryRaw(&extends, sizeof(extends));
+
+        uint16_t numChildren = parser.readBinaryWord();
+
+        for (uint16_t i = 0; i < numChildren; i++)
+        {
+            children.emplace_back();
+            children.back().load(parser);
+        }
     }
-}
 
-void oBBox3d::getAABB(ZMath::float3& min, ZMath::float3& max) const
-{
-    const float sign[8][3] = {
-        -1, -1, -1,
-        -1, -1, +1,
-        -1, +1, -1,
-        -1, +1, +1,
-        +1, -1, -1,
-        +1, -1, +1,
-        +1, +1, -1,
-        +1, +1, +1};
-
-    min = {FLT_MAX, FLT_MAX, FLT_MAX};
-    max = {-FLT_MAX, -FLT_MAX, -FLT_MAX};
-
-    for (int i = 0; i < 8; i++)
+    void oBBox3d::getAABB(ZMath::float3& min, ZMath::float3& max) const
     {
-        ZMath::float3 point = center;
-        const ZMath::float3 axis0 = axis[0] * extends.x * sign[i][0];
-        const ZMath::float3 axis1 = axis[1] * extends.y * sign[i][1];
-        const ZMath::float3 axis2 = axis[2] * extends.z * sign[i][2];
+        const float sign[8][3] = {
+            -1, -1, -1,
+            -1, -1, +1,
+            -1, +1, -1,
+            -1, +1, +1,
+            +1, -1, -1,
+            +1, -1, +1,
+            +1, +1, -1,
+            +1, +1, +1};
 
-        point.x += axis0.x + axis1.x + axis2.x;
-        point.y += axis0.y + axis1.y + axis2.y;
-        point.z += axis0.z + axis1.z + axis2.z;
+        min = {FLT_MAX, FLT_MAX, FLT_MAX};
+        max = {-FLT_MAX, -FLT_MAX, -FLT_MAX};
 
-        min.x = std::min(min.x, point.x);
-        min.y = std::min(min.y, point.y);
-        min.z = std::min(min.z, point.z);
+        for (int i = 0; i < 8; i++)
+        {
+            ZMath::float3 point = center;
+            const ZMath::float3 axis0 = axis[0] * extends.x * sign[i][0];
+            const ZMath::float3 axis1 = axis[1] * extends.y * sign[i][1];
+            const ZMath::float3 axis2 = axis[2] * extends.z * sign[i][2];
 
-        max.x = std::max(max.x, point.x);
-        max.y = std::max(max.y, point.y);
-        max.z = std::max(max.z, point.z);
+            point.x += axis0.x + axis1.x + axis2.x;
+            point.y += axis0.y + axis1.y + axis2.y;
+            point.z += axis0.z + axis1.z + axis2.z;
+
+            min.x = std::min(min.x, point.x);
+            min.y = std::min(min.y, point.y);
+            min.z = std::min(min.z, point.z);
+
+            max.x = std::max(max.x, point.x);
+            max.y = std::max(max.y, point.y);
+            max.z = std::max(max.z, point.z);
+        }
     }
-}
 
-/**
+    /**
 * @brief Reads the mesh-object from the given binary stream
 */
-void zCMeshSoftSkin::readObjectData(ZenParser& parser)
-{
-    // Information about the whole file we are reading here
-    BinaryFileInfo fileInfo;
-
-    // Information about a single chunk
-    BinaryChunkInfo chunkInfo;
-
-    // Read chunks until we left the virtual binary file or got to the end-chunk
-    // Each chunk starts with a header (BinaryChunkInfo) which gives information
-    // about what to do and how long the chunk is
-    bool doneReadingChunks = false;
-    while (!doneReadingChunks)
+    void zCMeshSoftSkin::readObjectData(ZenParser& parser)
     {
-        // Read chunk header and calculate position of next chunk
-        parser.readStructure(chunkInfo);
+        // Information about the whole file we are reading here
+        BinaryFileInfo fileInfo;
 
-        size_t chunkEnd = parser.getSeek() + chunkInfo.length;
+        // Information about a single chunk
+        BinaryChunkInfo chunkInfo;
 
-        switch (chunkInfo.id)
+        // Read chunks until we left the virtual binary file or got to the end-chunk
+        // Each chunk starts with a header (BinaryChunkInfo) which gives information
+        // about what to do and how long the chunk is
+        bool doneReadingChunks = false;
+        while (!doneReadingChunks)
         {
-            case MSID_MESHSOFTSKIN:
+            // Read chunk header and calculate position of next chunk
+            parser.readStructure(chunkInfo);
+
+            size_t chunkEnd = parser.getSeek() + chunkInfo.length;
+
+            switch (chunkInfo.id)
             {
-                uint32_t version = parser.readBinaryDWord();
-
-                m_Mesh.readObjectData(parser);
-
-                uint32_t vertexWeightStreamSize = parser.readBinaryDWord();
-
-                m_VertexWeightStream.resize(vertexWeightStreamSize);
-                parser.readBinaryRaw(m_VertexWeightStream.data(), vertexWeightStreamSize);
-
-                uint32_t numNodeWedgeNormals = parser.readBinaryDWord();
-                std::vector<zTNodeWedgeNormal> nodeWedgeNormals(numNodeWedgeNormals);
-
-                if (numNodeWedgeNormals > 0)
-                    parser.readBinaryRaw(nodeWedgeNormals.data(), numNodeWedgeNormals * sizeof(zTNodeWedgeNormal));
-
-                uint16_t numNodes = parser.readBinaryWord();
-                std::vector<int32_t> nodeList(numNodes);
-                parser.readBinaryRaw(nodeList.data(), numNodes * sizeof(int32_t));
-
-                for (uint16_t i = 0; i < numNodes; i++)
+                case MSID_MESHSOFTSKIN:
                 {
-                    m_BBoxesByNodes.emplace_back();
-                    m_BBoxesByNodes.back().load(parser);
+                    uint32_t version = parser.readBinaryDWord();
+
+                    m_Mesh.readObjectData(parser);
+
+                    uint32_t vertexWeightStreamSize = parser.readBinaryDWord();
+
+                    m_VertexWeightStream.resize(vertexWeightStreamSize);
+                    parser.readBinaryRaw(m_VertexWeightStream.data(), vertexWeightStreamSize);
+
+                    uint32_t numNodeWedgeNormals = parser.readBinaryDWord();
+                    std::vector<zTNodeWedgeNormal> nodeWedgeNormals(numNodeWedgeNormals);
+
+                    if (numNodeWedgeNormals > 0)
+                        parser.readBinaryRaw(nodeWedgeNormals.data(), numNodeWedgeNormals * sizeof(zTNodeWedgeNormal));
+
+                    uint16_t numNodes = parser.readBinaryWord();
+                    std::vector<int32_t> nodeList(numNodes);
+                    parser.readBinaryRaw(nodeList.data(), numNodes * sizeof(int32_t));
+
+                    for (uint16_t i = 0; i < numNodes; i++)
+                    {
+                        m_BBoxesByNodes.emplace_back();
+                        m_BBoxesByNodes.back().load(parser);
+                    }
+
+                    updateBboxTotal();
+                    // Chunksize seems wrong, can't skip here!
+                    //parser.setSeek(chunkEnd); // Skip chunk
                 }
-
-                updateBboxTotal();
-                // Chunksize seems wrong, can't skip here!
-                //parser.setSeek(chunkEnd); // Skip chunk
-            }
-            break;
-
-            case MSID_MESHSOFTSKIN_END:
-                doneReadingChunks = true;
                 break;
 
-            default:
-                parser.setSeek(chunkEnd);  // Skip chunk
-        }
-    }
-}
+                case MSID_MESHSOFTSKIN_END:
+                    doneReadingChunks = true;
+                    break;
 
-/**
-* @brief Creates packed submesh-data
-*/
-void zCMeshSoftSkin::packMesh(PackedSkeletalMesh& mesh, float scale) const
-{
-    std::vector<uint32_t> submeshIndexStarts;
-    std::vector<uint32_t> indices;
-    std::vector<SkeletalVertex> vertices(m_Mesh.getVertices().size());
-
-    // Extract weights and local positions
-    const uint8_t* stream = m_VertexWeightStream.data();
-    //LogInfo() << "Stream size: " << m_VertexWeightStream.size();
-
-    for (size_t i = 0, end = m_Mesh.getVertices().size(); i < end; i++)
-    {
-        // Layout:
-        //	uint32_t: numWeights
-        //	numWeights* zTWeightEntry: weights
-
-        uint32_t numWeights;
-        Utils::getUnaligned(&numWeights, stream);
-        stream += sizeof(uint32_t);
-
-        for (size_t j = 0; j < numWeights; j++)
-        {
-            // Note: Using zTWeightEntry here causes a SIGBUS on ARM because of packing!
-            float weight;
-            Utils::getUnaligned(&weight, stream);
-            stream += sizeof(float);
-
-            ZMath::float3 localVertexPosition;
-            Utils::getUnaligned(&localVertexPosition.x, stream);
-            stream += sizeof(float);
-            Utils::getUnaligned(&localVertexPosition.y, stream);
-            stream += sizeof(float);
-            Utils::getUnaligned(&localVertexPosition.z, stream);
-            stream += sizeof(float);
-
-            unsigned char nodeIndex;
-            Utils::getUnaligned(&nodeIndex, stream);
-            stream += sizeof(uint8_t);
-
-            // Move data to our structure
-            vertices[i].BoneIndices[j] = nodeIndex;
-            vertices[i].LocalPositions[j] = localVertexPosition * scale;
-            vertices[i].Weights[j] = weight;
-        }
-    }
-
-    for (size_t s = 0; s < m_Mesh.getNumSubmeshes(); s++)
-    {
-        const zCProgMeshProto::SubMesh& sm = m_Mesh.getSubmesh(s);
-
-        unsigned int meshVxStart = mesh.vertices.size();
-
-        // Get data
-        for (size_t i = 0; i < sm.m_WedgeList.size(); i++)
-        {
-            const zWedge& wedge = sm.m_WedgeList[i];
-
-            SkeletalVertex v = vertices[wedge.m_VertexIndex];
-
-            v.Normal = wedge.m_Normal;
-            v.TexCoord = wedge.m_Texcoord;
-            v.Color = 0xFFFFFFFF;  // TODO: Apply color from material!
-            mesh.vertices.push_back(v);
-        }
-
-        // Mark when the submesh starts
-        submeshIndexStarts.push_back(indices.size());
-
-        // And get the indices
-        for (size_t i = 0; i < sm.m_TriangleList.size(); i++)
-        {
-            //for(int j=2;j>=0;j--)
-            for (int j = 0; j < 3; j++)
-            {
-                indices.push_back((sm.m_TriangleList[i].m_Wedges[j])  // Take wedge-index of submesh
-                                  + meshVxStart);                     // And add the starting location of the vertices for this submesh
+                default:
+                    parser.setSeek(chunkEnd);  // Skip chunk
             }
         }
     }
 
-    // Create objects for all submeshes
-    for (size_t i = 0; i < m_Mesh.getNumSubmeshes(); i++)
+    /**
+* @brief Creates packed submesh-data
+*/
+    void zCMeshSoftSkin::packMesh(PackedSkeletalMesh& mesh, float scale) const
     {
-        mesh.subMeshes.emplace_back();
-        mesh.subMeshes.back().material = m_Mesh.getSubmesh(i).m_Material;
+        std::vector<uint32_t> submeshIndexStarts;
+        std::vector<uint32_t> indices;
+        std::vector<SkeletalVertex> vertices(m_Mesh.getVertices().size());
 
-        // Get indices
-        for (size_t j = submeshIndexStarts[i]; j < submeshIndexStarts[i] + m_Mesh.getSubmesh(i).m_TriangleList.size() * 3; j++)
+        // Extract weights and local positions
+        const uint8_t* stream = m_VertexWeightStream.data();
+        //LogInfo() << "Stream size: " << m_VertexWeightStream.size();
+
+        for (size_t i = 0, end = m_Mesh.getVertices().size(); i < end; i++)
         {
-            mesh.subMeshes.back().indices.push_back(indices[j]);
+            // Layout:
+            //	uint32_t: numWeights
+            //	numWeights* zTWeightEntry: weights
+
+            uint32_t numWeights;
+            Utils::getUnaligned(&numWeights, stream);
+            stream += sizeof(uint32_t);
+
+            for (size_t j = 0; j < numWeights; j++)
+            {
+                // Note: Using zTWeightEntry here causes a SIGBUS on ARM because of packing!
+                float weight;
+                Utils::getUnaligned(&weight, stream);
+                stream += sizeof(float);
+
+                ZMath::float3 localVertexPosition;
+                Utils::getUnaligned(&localVertexPosition.x, stream);
+                stream += sizeof(float);
+                Utils::getUnaligned(&localVertexPosition.y, stream);
+                stream += sizeof(float);
+                Utils::getUnaligned(&localVertexPosition.z, stream);
+                stream += sizeof(float);
+
+                unsigned char nodeIndex;
+                Utils::getUnaligned(&nodeIndex, stream);
+                stream += sizeof(uint8_t);
+
+                // Move data to our structure
+                vertices[i].BoneIndices[j] = nodeIndex;
+                vertices[i].LocalPositions[j] = localVertexPosition * scale;
+                vertices[i].Weights[j] = weight;
+            }
+        }
+
+        for (size_t s = 0; s < m_Mesh.getNumSubmeshes(); s++)
+        {
+            const zCProgMeshProto::SubMesh& sm = m_Mesh.getSubmesh(s);
+
+            unsigned int meshVxStart = mesh.vertices.size();
+
+            // Get data
+            for (size_t i = 0; i < sm.m_WedgeList.size(); i++)
+            {
+                const zWedge& wedge = sm.m_WedgeList[i];
+
+                SkeletalVertex v = vertices[wedge.m_VertexIndex];
+
+                v.Normal = wedge.m_Normal;
+                v.TexCoord = wedge.m_Texcoord;
+                v.Color = 0xFFFFFFFF;  // TODO: Apply color from material!
+                mesh.vertices.push_back(v);
+            }
+
+            // Mark when the submesh starts
+            submeshIndexStarts.push_back(indices.size());
+
+            // And get the indices
+            for (size_t i = 0; i < sm.m_TriangleList.size(); i++)
+            {
+                //for(int j=2;j>=0;j--)
+                for (int j = 0; j < 3; j++)
+                {
+                    indices.push_back((sm.m_TriangleList[i].m_Wedges[j])  // Take wedge-index of submesh
+                                      + meshVxStart);                     // And add the starting location of the vertices for this submesh
+                }
+            }
+        }
+
+        // Create objects for all submeshes
+        for (size_t i = 0; i < m_Mesh.getNumSubmeshes(); i++)
+        {
+            mesh.subMeshes.emplace_back();
+            mesh.subMeshes.back().material = m_Mesh.getSubmesh(i).m_Material;
+
+            // Get indices
+            for (size_t j = submeshIndexStarts[i]; j < submeshIndexStarts[i] + m_Mesh.getSubmesh(i).m_TriangleList.size() * 3; j++)
+            {
+                mesh.subMeshes.back().indices.push_back(indices[j]);
+            }
+        }
+
+        mesh.bbox[0] = m_BBoxTotal[0] * scale;
+        mesh.bbox[1] = m_BBoxTotal[1] * scale;
+    }
+
+    void zCMeshSoftSkin::updateBboxTotal()
+    {
+        m_BBoxTotal[0] = {FLT_MAX, FLT_MAX, FLT_MAX};
+        m_BBoxTotal[1] = {-FLT_MAX, -FLT_MAX, -FLT_MAX};
+
+        for (const oBBox3d& bb : m_BBoxesByNodes)
+        {
+            ZMath::float3 min, max;
+            bb.getAABB(min, max);
+
+            m_BBoxTotal[0].x = std::min(m_BBoxTotal[0].x, min.x);
+            m_BBoxTotal[0].y = std::min(m_BBoxTotal[0].y, min.y);
+            m_BBoxTotal[0].z = std::min(m_BBoxTotal[0].z, min.z);
+
+            m_BBoxTotal[1].x = std::max(m_BBoxTotal[1].x, max.x);
+            m_BBoxTotal[1].y = std::max(m_BBoxTotal[1].y, max.y);
+            m_BBoxTotal[1].z = std::max(m_BBoxTotal[1].z, max.z);
         }
     }
 
-    mesh.bbox[0] = m_BBoxTotal[0] * scale;
-    mesh.bbox[1] = m_BBoxTotal[1] * scale;
-}
-
-void zCMeshSoftSkin::updateBboxTotal()
-{
-    m_BBoxTotal[0] = {FLT_MAX, FLT_MAX, FLT_MAX};
-    m_BBoxTotal[1] = {-FLT_MAX, -FLT_MAX, -FLT_MAX};
-
-    for (const oBBox3d& bb : m_BBoxesByNodes)
+    void zCMeshSoftSkin::getAABBTotal(ZMath::float3& min, ZMath::float3& max) const
     {
-        ZMath::float3 min, max;
-        bb.getAABB(min, max);
-
-        m_BBoxTotal[0].x = std::min(m_BBoxTotal[0].x, min.x);
-        m_BBoxTotal[0].y = std::min(m_BBoxTotal[0].y, min.y);
-        m_BBoxTotal[0].z = std::min(m_BBoxTotal[0].z, min.z);
-
-        m_BBoxTotal[1].x = std::max(m_BBoxTotal[1].x, max.x);
-        m_BBoxTotal[1].y = std::max(m_BBoxTotal[1].y, max.y);
-        m_BBoxTotal[1].z = std::max(m_BBoxTotal[1].z, max.z);
+        min = m_BBoxTotal[0];
+        max = m_BBoxTotal[1];
     }
-}
-
-void zCMeshSoftSkin::getAABBTotal(ZMath::float3& min, ZMath::float3& max) const
-{
-    min = m_BBoxTotal[0];
-    max = m_BBoxTotal[1];
-}
+}  // namespace ZenLib

--- a/zenload/zCMeshSoftSkin.h
+++ b/zenload/zCMeshSoftSkin.h
@@ -4,68 +4,71 @@
 #include "zTypes.h"
 #include "utils/mathlib.h"
 
-namespace VDFS
+namespace ZenLib
 {
-    class FileIndex;
-}
-
-namespace ZenLoad
-{
-    struct oBBox3d
+    namespace VDFS
     {
-        ZMath::float3 center;
-        ZMath::float3 axis[3];
-        ZMath::float3 extends;
+        class FileIndex;
+    }
 
-        std::vector<oBBox3d> children;
-
-        void getAABB(ZMath::float3& min, ZMath::float3& max) const;
-        void load(ZenParser& parser);
-    };
-
-    class ZenParser;
-    class zCMeshSoftSkin
+    namespace ZenLoad
     {
-    public:
-        zCMeshSoftSkin() {}
+        struct oBBox3d
+        {
+            ZMath::float3 center;
+            ZMath::float3 axis[3];
+            ZMath::float3 extends;
 
-        /**
+            std::vector<oBBox3d> children;
+
+            void getAABB(ZMath::float3& min, ZMath::float3& max) const;
+            void load(ZenParser& parser);
+        };
+
+        class ZenParser;
+        class zCMeshSoftSkin
+        {
+        public:
+            zCMeshSoftSkin() {}
+
+            /**
 		 * @brief Reads the mesh-object from the given binary stream
 		 * @param fromZen Whether this mesh is supposed to be read from a zenfile. In this case, information about the binary chunk is also read.
 		 */
-        void readObjectData(ZenParser& parser);
+            void readObjectData(ZenParser& parser);
 
-        /**
+            /**
 		 * @return Internal zCProgMeshProto of this soft skin. The soft-skin only displaces the vertices found in the ProgMesh.
 		 */
-        const zCProgMeshProto& getMesh() const { return m_Mesh; }
+            const zCProgMeshProto& getMesh() const { return m_Mesh; }
 
-        /**
+            /**
 		 * @brief Creates packed submesh-data
 		 */
-        void packMesh(PackedSkeletalMesh& mesh, float scale = 1.0f) const;
+            void packMesh(PackedSkeletalMesh& mesh, float scale = 1.0f) const;
 
-        /**
+            /**
 		 * @param min Output of min-part of the AABB surrounding this mesh
 		 * @param max Output of max-part of the AABB surrounding this mesh
 		 */
-        void getAABBTotal(ZMath::float3& min, ZMath::float3& max) const;
+            void getAABBTotal(ZMath::float3& min, ZMath::float3& max) const;
 
-    private:
-        void updateBboxTotal();
+        private:
+            void updateBboxTotal();
 
-        /**
+            /**
 		 * @brief Internal zCProgMeshProto of this soft skin. The soft-skin only displaces the vertices found in the ProgMesh.
 		 */
-        zCProgMeshProto m_Mesh;
+            zCProgMeshProto m_Mesh;
 
-        /**
+            /**
 		 * @brief Stream containing the vertex-weights. Layout:
 		 *		  uint32_t: numWeights
 		 *		  numWeights* zTWeightEntry: weights
 		 */
-        std::vector<uint8_t> m_VertexWeightStream;
-        std::vector<oBBox3d> m_BBoxesByNodes;
-        ZMath::float3 m_BBoxTotal[2];
-    };
-}  // namespace ZenLoad
+            std::vector<uint8_t> m_VertexWeightStream;
+            std::vector<oBBox3d> m_BBoxesByNodes;
+            ZMath::float3 m_BBoxTotal[2];
+        };
+    }  // namespace ZenLoad
+}  // namespace ZenLib

--- a/zenload/zCModelAni.h
+++ b/zenload/zCModelAni.h
@@ -5,83 +5,23 @@
 #include "zTypes.h"
 #include "utils/mathlib.h"
 
-namespace VDFS
+namespace ZenLib
 {
-    class FileIndex;
-}
-
-namespace ZenLoad
-{
-    class ZenParser;
-
-    enum
+    namespace VDFS
     {
-        ANIEVENT_MAXSTRING = 4
-    };
+        class FileIndex;
+    }
 
-    struct zCModelAniHeader
+    namespace ZenLoad
     {
-        uint16_t version;
+        class ZenParser;
 
-        std::string aniName;
-
-        uint32_t layer;
-        uint32_t numFrames;
-        uint32_t numNodes;
-        float fpsRate;
-        float fpsRateSource;
-        float samplePosRangeMin;
-        float samplePosScaler;
-
-        ZMath::float3 aniBBox[2];
-
-        std::string nextAniName;
-
-        uint32_t nodeChecksum;
-    };
-
-    struct zCModelAniSample
-    {
-        ZMath::float4 rotation;  // Quaternion
-        ZMath::float3 position;
-    };
-}  // namespace ZenLoad
-
-// FIXME: COMPATIBILITY FOR MASTER - REMOVE LATER!
-
-#include <vector>
-#include "zTypes.h"
-#include "utils/mathlib.h"
-
-namespace VDFS
-{
-    class FileIndex;
-}
-
-namespace ZenLoad
-{
-    class ZenParser;
-    class zCModelAni
-    {
-    public:
-        struct zCModelAniEvent
+        enum
         {
-            enum
-            {
-                ANIEVENT_MAXSTRING = 4
-            };
-
-            zTMdl_AniEventType aniEventType;
-            uint32_t frameNr;
-            std::string tagString;
-            std::string string[ANIEVENT_MAXSTRING];
-            float values[ANIEVENT_MAXSTRING];
-            float prob;
-
-            void load(ZenParser& parser);
+            ANIEVENT_MAXSTRING = 4
         };
 
-        struct ModelAniHeader
+        struct zCModelAniHeader
         {
             uint16_t version;
 
@@ -102,57 +42,122 @@ namespace ZenLoad
             uint32_t nodeChecksum;
         };
 
-        struct AniSample
+        struct zCModelAniSample
         {
             ZMath::float4 rotation;  // Quaternion
             ZMath::float3 position;
         };
+    }  // namespace ZenLoad
 
-        zCModelAni() {}
+    // FIXME: COMPATIBILITY FOR MASTER - REMOVE LATER!
 
-        /**
+#include <vector>
+
+#include "zTypes.h"
+
+#include "utils/mathlib.h"
+
+    namespace VDFS
+    {
+        class FileIndex;
+    }
+
+    namespace ZenLoad
+    {
+        class ZenParser;
+        class zCModelAni
+        {
+        public:
+            struct zCModelAniEvent
+            {
+                enum
+                {
+                    ANIEVENT_MAXSTRING = 4
+                };
+
+                zTMdl_AniEventType aniEventType;
+                uint32_t frameNr;
+                std::string tagString;
+                std::string string[ANIEVENT_MAXSTRING];
+                float values[ANIEVENT_MAXSTRING];
+                float prob;
+
+                void load(ZenParser& parser);
+            };
+
+            struct ModelAniHeader
+            {
+                uint16_t version;
+
+                std::string aniName;
+
+                uint32_t layer;
+                uint32_t numFrames;
+                uint32_t numNodes;
+                float fpsRate;
+                float fpsRateSource;
+                float samplePosRangeMin;
+                float samplePosScaler;
+
+                ZMath::float3 aniBBox[2];
+
+                std::string nextAniName;
+
+                uint32_t nodeChecksum;
+            };
+
+            struct AniSample
+            {
+                ZMath::float4 rotation;  // Quaternion
+                ZMath::float3 position;
+            };
+
+            zCModelAni() {}
+
+            /**
         * @brief Loads the mesh from the given VDF-Archive
         */
-        zCModelAni(const std::string& fileName, const VDFS::FileIndex& fileIndex, float scale = 1.0f);
+            zCModelAni(const std::string& fileName, const VDFS::FileIndex& fileIndex, float scale = 1.0f);
 
-        /**
+            /**
          * @brief Reads the mesh-object from the given binary stream
          * @param fromZen Whether this mesh is supposed to be read from a zenfile. In this case, information about the binary chunk is also read.
          */
-        void readObjectData(ZenParser& parser);
+            void readObjectData(ZenParser& parser);
 
-        /**
+            /**
          * @return generic information about this animation
          */
-        const ModelAniHeader& getModelAniHeader() const { return m_ModelAniHeader; }
+            const ModelAniHeader& getModelAniHeader() const { return m_ModelAniHeader; }
 
-        /**
+            /**
          * @return Animation-data. Access: sampleIdx * numNodes + node
          */
-        const std::vector<AniSample>& getAniSamples() const { return m_AniSamples; }
+            const std::vector<AniSample>& getAniSamples() const { return m_AniSamples; }
 
-        /**
+            /**
          * @return Indices of the samples to the actual nodes
          */
-        const std::vector<uint32_t>& getNodeIndexList() const { return m_NodeIndexList; }
+            const std::vector<uint32_t>& getNodeIndexList() const { return m_NodeIndexList; }
 
-        /**
+            /**
          * @return Whether the animation was correctly loaded
          */
-        bool isValid() { return m_ModelAniHeader.version != 0; }
+            bool isValid() { return m_ModelAniHeader.version != 0; }
 
-    private:
-        /**
+        private:
+            /**
          * @brief File information
          */
-        ModelAniHeader m_ModelAniHeader;
+            ModelAniHeader m_ModelAniHeader;
 
-        /**
+            /**
          * @brief Ani-Events
          */
-        std::vector<zCModelAniEvent> m_AniEvents;
+            std::vector<zCModelAniEvent> m_AniEvents;
 
-        std::vector<uint32_t> m_NodeIndexList;
-        std::vector<AniSample> m_AniSamples;
-    };
-}  // namespace ZenLoad
+            std::vector<uint32_t> m_NodeIndexList;
+            std::vector<AniSample> m_AniSamples;
+        };
+    }  // namespace ZenLoad
+}  // namespace ZenLib

--- a/zenload/zCModelMeshLib.cpp
+++ b/zenload/zCModelMeshLib.cpp
@@ -9,293 +9,296 @@
 #include "utils/logger.h"
 #include "vdfs/fileIndex.h"
 
-using namespace ZenLoad;
+namespace ZenLib
+{
+    using namespace ZenLoad;
 
-// Types of chunks we will find in a zCModelMeshLib-Section
+    // Types of chunks we will find in a zCModelMeshLib-Section
 
-const uint32_t MDM_VERSION = 67699974;  // TODO: Calculate this!
+    const uint32_t MDM_VERSION = 67699974;  // TODO: Calculate this!
 
-const uint16_t MLID_MODELMESH = 0xD000;
-const uint16_t MLID_MDM_SOURCE = 0xD010;
-const uint16_t MLID_MDM_NODEMESHES = 0xD020;
-const uint16_t MLID_MDM_SOFSKINLIST = 0xD030;
-const uint16_t MLID_MDM_END = 0xD040;
+    const uint16_t MLID_MODELMESH = 0xD000;
+    const uint16_t MLID_MDM_SOURCE = 0xD010;
+    const uint16_t MLID_MDM_NODEMESHES = 0xD020;
+    const uint16_t MLID_MDM_SOFSKINLIST = 0xD030;
+    const uint16_t MLID_MDM_END = 0xD040;
 
-const uint32_t zMDH_VERS = 3;
+    const uint32_t zMDH_VERS = 3;
 
-const uint16_t MLID_MODELHIERARCHY = 0xD100;
-const uint16_t MLID_MDH_SOURCE = 0xD110;
-const uint16_t MLID_MDH_END = 0xD120;
+    const uint16_t MLID_MODELHIERARCHY = 0xD100;
+    const uint16_t MLID_MDH_SOURCE = 0xD110;
+    const uint16_t MLID_MDH_END = 0xD120;
 
-/**
+    /**
 * @brief Loads the lib from the given VDF-Archive
 */
-zCModelMeshLib::zCModelMeshLib(const std::string& fileName, const VDFS::FileIndex& fileIndex, float scale)
-{
-    memset(m_BBox, 0, sizeof(m_BBox));
-    memset(m_BBoxCollision, 0, sizeof(m_BBoxCollision));
-
-    std::vector<uint8_t> data;
-    fileIndex.getFileData(fileName, data);
-
-    if (data.empty())
+    zCModelMeshLib::zCModelMeshLib(const std::string& fileName, const VDFS::FileIndex& fileIndex, float scale)
     {
-        return;  // TODO: Throw an exception or something
+        memset(m_BBox, 0, sizeof(m_BBox));
+        memset(m_BBoxCollision, 0, sizeof(m_BBoxCollision));
+
+        std::vector<uint8_t> data;
+        fileIndex.getFileData(fileName, data);
+
+        if (data.empty())
+        {
+            return;  // TODO: Throw an exception or something
+        }
+
+        try
+        {
+            // Create parser from memory
+            // FIXME: There is an internal copy of the data here. Optimize!
+            ZenLoad::ZenParser parser(data.data(), data.size());
+
+            if (fileName.find(".MDM") != std::string::npos)
+                loadMDM(parser);
+            else if (fileName.find(".MDH") != std::string::npos)
+                loadMDH(parser, scale);
+            else if (fileName.find(".MDL") != std::string::npos)
+                loadMDL(parser, scale);
+        }
+        catch (std::exception& e)
+        {
+            LogError() << e.what();
+            return;
+        }
     }
 
-    try
-    {
-        // Create parser from memory
-        // FIXME: There is an internal copy of the data here. Optimize!
-        ZenLoad::ZenParser parser(data.data(), data.size());
-
-        if (fileName.find(".MDM") != std::string::npos)
-            loadMDM(parser);
-        else if (fileName.find(".MDH") != std::string::npos)
-            loadMDH(parser, scale);
-        else if (fileName.find(".MDL") != std::string::npos)
-            loadMDL(parser, scale);
-    }
-    catch (std::exception& e)
-    {
-        LogError() << e.what();
-        return;
-    }
-}
-
-/**
+    /**
 * @brief Reads the mesh-object from the given binary stream
 */
-void zCModelMeshLib::loadMDM(ZenParser& parser)
-{
-    // Information about the whole file we are reading here
-    BinaryFileInfo fileInfo;
-
-    // Information about a single chunk
-    BinaryChunkInfo chunkInfo;
-
-    // Read chunks until we left the virtual binary file or got to the end-chunk
-    // Each chunk starts with a header (BinaryChunkInfo) which gives information
-    // about what to do and how long the chunk is
-    bool doneReadingChunks = false;
-    while (!doneReadingChunks)
+    void zCModelMeshLib::loadMDM(ZenParser& parser)
     {
-        // Read chunk header and calculate position of next chunk
-        parser.readStructure(chunkInfo);
+        // Information about the whole file we are reading here
+        BinaryFileInfo fileInfo;
 
-        size_t chunkEnd = parser.getSeek() + chunkInfo.length;
+        // Information about a single chunk
+        BinaryChunkInfo chunkInfo;
 
-        switch (chunkInfo.id)
+        // Read chunks until we left the virtual binary file or got to the end-chunk
+        // Each chunk starts with a header (BinaryChunkInfo) which gives information
+        // about what to do and how long the chunk is
+        bool doneReadingChunks = false;
+        while (!doneReadingChunks)
         {
-            case MLID_MODELMESH:
+            // Read chunk header and calculate position of next chunk
+            parser.readStructure(chunkInfo);
+
+            size_t chunkEnd = parser.getSeek() + chunkInfo.length;
+
+            switch (chunkInfo.id)
             {
-                uint32_t version = parser.readBinaryDWord();
-
-                parser.setSeek(chunkEnd);  // Skip chunk
-            }
-            break;
-
-            case MLID_MDM_SOURCE:
-            {
-                // TODO: Implement MDM-Conversion
-                parser.setSeek(chunkEnd);  // Skip chunk
-            }
-            break;
-
-            case MLID_MDM_NODEMESHES:
-            {
-                uint16_t numNodes = parser.readBinaryWord();
-
-                //std::vector<zCModelNodeInst> nodeList(numNodes);
-                m_NodeAttachments.resize(numNodes);
-
-                for (uint16_t i = 0; i < numNodes; i++)
-                    m_NodeAttachments[i].first = parser.readLine(true);
-
-                for (uint16_t i = 0; i < numNodes; i++)
-                    m_NodeAttachments[i].second.readObjectData(parser);
-            }
-            break;
-
-            case MLID_MDM_SOFSKINLIST:
-            {
-                uint32_t checksum = parser.readBinaryDWord();
-                uint16_t numSoftSkins = parser.readBinaryWord();
-
-                for (uint16_t i = 0; i < numSoftSkins; i++)
+                case MLID_MODELMESH:
                 {
-                    m_Meshes.emplace_back();
-                    m_Meshes.back().readObjectData(parser);
-                }
-            }
-            break;
+                    uint32_t version = parser.readBinaryDWord();
 
-            case MLID_MDM_END:
-                doneReadingChunks = true;
+                    parser.setSeek(chunkEnd);  // Skip chunk
+                }
                 break;
-            default:
-                parser.setSeek(chunkEnd);  // Skip chunk
+
+                case MLID_MDM_SOURCE:
+                {
+                    // TODO: Implement MDM-Conversion
+                    parser.setSeek(chunkEnd);  // Skip chunk
+                }
+                break;
+
+                case MLID_MDM_NODEMESHES:
+                {
+                    uint16_t numNodes = parser.readBinaryWord();
+
+                    //std::vector<zCModelNodeInst> nodeList(numNodes);
+                    m_NodeAttachments.resize(numNodes);
+
+                    for (uint16_t i = 0; i < numNodes; i++)
+                        m_NodeAttachments[i].first = parser.readLine(true);
+
+                    for (uint16_t i = 0; i < numNodes; i++)
+                        m_NodeAttachments[i].second.readObjectData(parser);
+                }
+                break;
+
+                case MLID_MDM_SOFSKINLIST:
+                {
+                    uint32_t checksum = parser.readBinaryDWord();
+                    uint16_t numSoftSkins = parser.readBinaryWord();
+
+                    for (uint16_t i = 0; i < numSoftSkins; i++)
+                    {
+                        m_Meshes.emplace_back();
+                        m_Meshes.back().readObjectData(parser);
+                    }
+                }
+                break;
+
+                case MLID_MDM_END:
+                    doneReadingChunks = true;
+                    break;
+                default:
+                    parser.setSeek(chunkEnd);  // Skip chunk
+            }
         }
     }
-}
 
-/**
+    /**
 * @brief Reads the model hierachy from a file (MDH-File)
 */
-void zCModelMeshLib::loadMDH(ZenParser& parser, float scale)
-{
-    // Information about the whole file we are reading here
-    BinaryFileInfo fileInfo;
-
-    // Information about a single chunk
-    BinaryChunkInfo chunkInfo;
-
-    // Read chunks until we left the virtual binary file or got to the end-chunk
-    // Each chunk starts with a header (BinaryChunkInfo) which gives information
-    // about what to do and how long the chunk is
-    bool doneReadingChunks = false;
-    while (!doneReadingChunks)
+    void zCModelMeshLib::loadMDH(ZenParser& parser, float scale)
     {
-        // Read chunk header and calculate position of next chunk
-        parser.readStructure(chunkInfo);
+        // Information about the whole file we are reading here
+        BinaryFileInfo fileInfo;
 
-        size_t chunkEnd = parser.getSeek() + chunkInfo.length;
+        // Information about a single chunk
+        BinaryChunkInfo chunkInfo;
 
-        switch (chunkInfo.id)
+        // Read chunks until we left the virtual binary file or got to the end-chunk
+        // Each chunk starts with a header (BinaryChunkInfo) which gives information
+        // about what to do and how long the chunk is
+        bool doneReadingChunks = false;
+        while (!doneReadingChunks)
         {
-            case MLID_MODELHIERARCHY:
+            // Read chunk header and calculate position of next chunk
+            parser.readStructure(chunkInfo);
+
+            size_t chunkEnd = parser.getSeek() + chunkInfo.length;
+
+            switch (chunkInfo.id)
             {
-                uint32_t version = parser.readBinaryDWord();
-                //if(version != MDM_VERSION)
-                //	LogWarn() << "MDM Version mismatch!";
-
-                uint16_t numNodes = parser.readBinaryWord();
-                m_Nodes.resize(numNodes);
-
-                for (int i = 0; i < numNodes; i++)
+                case MLID_MODELHIERARCHY:
                 {
-                    m_Nodes[i].name = parser.readLine(false);
-                    m_Nodes[i].parentIndex = parser.readBinaryWord();
+                    uint32_t version = parser.readBinaryDWord();
+                    //if(version != MDM_VERSION)
+                    //	LogWarn() << "MDM Version mismatch!";
 
-                    if (m_Nodes[i].parentIndex != 0xFFFF)
+                    uint16_t numNodes = parser.readBinaryWord();
+                    m_Nodes.resize(numNodes);
+
+                    for (int i = 0; i < numNodes; i++)
                     {
-                        if (m_Nodes[i].parentIndex >= numNodes)
-                            LogWarn() << "MSH-Parse fail: parentIndex >= numNodes";
+                        m_Nodes[i].name = parser.readLine(false);
+                        m_Nodes[i].parentIndex = parser.readBinaryWord();
 
-                        ModelNode* parent = &m_Nodes[m_Nodes[i].parentIndex];
-                        parent->childIndices.push_back(i);
+                        if (m_Nodes[i].parentIndex != 0xFFFF)
+                        {
+                            if (m_Nodes[i].parentIndex >= numNodes)
+                                LogWarn() << "MSH-Parse fail: parentIndex >= numNodes";
+
+                            ModelNode* parent = &m_Nodes[m_Nodes[i].parentIndex];
+                            parent->childIndices.push_back(i);
+                        }
+                        else
+                        {
+                            m_Nodes[i].parentIndex = 0xFFFF;
+
+                            // Found root node
+                            m_RootNodes.push_back(i);
+                        }
+
+                        parser.readBinaryRaw(&m_Nodes[i].transformLocal, sizeof(ZMath::Matrix));
+                        m_Nodes[i].transformLocal.Transpose();
+
+                        ZMath::float3 t = m_Nodes[i].transformLocal.Translation();
+                        m_Nodes[i].transformLocal.Translation(ZMath::float3(t.x * scale, t.y * scale, t.z * scale));
                     }
-                    else
-                    {
-                        m_Nodes[i].parentIndex = 0xFFFF;
 
-                        // Found root node
-                        m_RootNodes.push_back(i);
-                    }
+                    parser.readBinaryRaw(m_BBox, sizeof(m_BBox));
+                    parser.readBinaryRaw(m_BBoxCollision, sizeof(m_BBoxCollision));
 
-                    parser.readBinaryRaw(&m_Nodes[i].transformLocal, sizeof(ZMath::Matrix));
-                    m_Nodes[i].transformLocal.Transpose();
+                    m_BBox[0] *= scale;
+                    m_BBox[1] *= scale;
+                    m_BBoxCollision[0] *= scale;
+                    m_BBoxCollision[1] *= scale;
 
-                    ZMath::float3 t = m_Nodes[i].transformLocal.Translation();
-                    m_Nodes[i].transformLocal.Translation(ZMath::float3(t.x * scale, t.y * scale, t.z * scale));
+                    parser.readBinaryRaw(&m_RootNodeTranslation, sizeof(m_RootNodeTranslation));
+
+                    m_RootNodeTranslation *= scale;
+
+                    m_NodeChecksum = parser.readBinaryDWord();
+
+                    parser.setSeek(chunkEnd);  // Skip chunk
                 }
-
-                parser.readBinaryRaw(m_BBox, sizeof(m_BBox));
-                parser.readBinaryRaw(m_BBoxCollision, sizeof(m_BBoxCollision));
-
-                m_BBox[0] *= scale;
-                m_BBox[1] *= scale;
-                m_BBoxCollision[0] *= scale;
-                m_BBoxCollision[1] *= scale;
-
-                parser.readBinaryRaw(&m_RootNodeTranslation, sizeof(m_RootNodeTranslation));
-
-                m_RootNodeTranslation *= scale;
-
-                m_NodeChecksum = parser.readBinaryDWord();
-
-                parser.setSeek(chunkEnd);  // Skip chunk
-            }
-            break;
-
-            case MLID_MDH_SOURCE:
-            {
-                // TODO: Implement MDM-Conversion
-                parser.setSeek(chunkEnd);  // Skip chunk
-            }
-            break;
-
-            case MLID_MDH_END:
-                doneReadingChunks = true;
                 break;
-            default:
-                parser.setSeek(chunkEnd);  // Skip chunk
+
+                case MLID_MDH_SOURCE:
+                {
+                    // TODO: Implement MDM-Conversion
+                    parser.setSeek(chunkEnd);  // Skip chunk
+                }
+                break;
+
+                case MLID_MDH_END:
+                    doneReadingChunks = true;
+                    break;
+                default:
+                    parser.setSeek(chunkEnd);  // Skip chunk
+            }
         }
     }
-}
 
-/**
+    /**
 * @brief reads this lib as MDL
 */
-void zCModelMeshLib::loadMDL(ZenParser& parser, float scale)
-{
-    loadMDH(parser, scale);
-    loadMDM(parser);
-}
+    void zCModelMeshLib::loadMDL(ZenParser& parser, float scale)
+    {
+        loadMDH(parser, scale);
+        loadMDM(parser);
+    }
 
-/**
+    /**
 * @brief Creates packed submesh-data
 */
-void zCModelMeshLib::packMesh(PackedSkeletalMesh& mesh, float scale) const
-{
-    for (const auto& m : m_Meshes)
+    void zCModelMeshLib::packMesh(PackedSkeletalMesh& mesh, float scale) const
     {
-        m.packMesh(mesh, scale);
-    }
+        for (const auto& m : m_Meshes)
+        {
+            m.packMesh(mesh, scale);
+        }
 
-    mesh.bbox[0] = {FLT_MAX, FLT_MAX, FLT_MAX};
-    mesh.bbox[1] = {-FLT_MAX, -FLT_MAX, -FLT_MAX};
+        mesh.bbox[0] = {FLT_MAX, FLT_MAX, FLT_MAX};
+        mesh.bbox[1] = {-FLT_MAX, -FLT_MAX, -FLT_MAX};
 
-    // Choose the biggest BBox possible (From model hierarchy or soft-meshes)
-    for (const auto& m : m_Meshes)
-    {
-        ZMath::float3 min, max;
-        m.getAABBTotal(min, max);
+        // Choose the biggest BBox possible (From model hierarchy or soft-meshes)
+        for (const auto& m : m_Meshes)
+        {
+            ZMath::float3 min, max;
+            m.getAABBTotal(min, max);
 
-        min *= scale;
-        max *= scale;
+            min *= scale;
+            max *= scale;
 
-        mesh.bbox[0].x = std::min(mesh.bbox[0].x, min.x);
-        mesh.bbox[0].y = std::min(mesh.bbox[0].y, min.y);
-        mesh.bbox[0].z = std::min(mesh.bbox[0].z, min.z);
+            mesh.bbox[0].x = std::min(mesh.bbox[0].x, min.x);
+            mesh.bbox[0].y = std::min(mesh.bbox[0].y, min.y);
+            mesh.bbox[0].z = std::min(mesh.bbox[0].z, min.z);
 
-        mesh.bbox[1].x = std::max(mesh.bbox[1].x, max.x);
-        mesh.bbox[1].y = std::max(mesh.bbox[1].y, max.y);
-        mesh.bbox[1].z = std::max(mesh.bbox[1].z, max.z);
-    }
+            mesh.bbox[1].x = std::max(mesh.bbox[1].x, max.x);
+            mesh.bbox[1].y = std::max(mesh.bbox[1].y, max.y);
+            mesh.bbox[1].z = std::max(mesh.bbox[1].z, max.z);
+        }
 
-    mesh.bbox[0].x = std::min(mesh.bbox[0].x, m_BBox[0].x);
-    mesh.bbox[0].y = std::min(mesh.bbox[0].y, m_BBox[0].y);
-    mesh.bbox[0].z = std::min(mesh.bbox[0].z, m_BBox[0].z);
+        mesh.bbox[0].x = std::min(mesh.bbox[0].x, m_BBox[0].x);
+        mesh.bbox[0].y = std::min(mesh.bbox[0].y, m_BBox[0].y);
+        mesh.bbox[0].z = std::min(mesh.bbox[0].z, m_BBox[0].z);
 
-    mesh.bbox[1].x = std::max(mesh.bbox[1].x, m_BBox[1].x);
-    mesh.bbox[1].y = std::max(mesh.bbox[1].y, m_BBox[1].y);
-    mesh.bbox[1].z = std::max(mesh.bbox[1].z, m_BBox[1].z);
+        mesh.bbox[1].x = std::max(mesh.bbox[1].x, m_BBox[1].x);
+        mesh.bbox[1].y = std::max(mesh.bbox[1].y, m_BBox[1].y);
+        mesh.bbox[1].z = std::max(mesh.bbox[1].z, m_BBox[1].z);
 
-    // TODO: Implement node-attachments!
-    /*for(const auto& m : m_NodeAttachments)
+        // TODO: Implement node-attachments!
+        /*for(const auto& m : m_NodeAttachments)
 	{
 		m.packMesh(mesh, scale);
 	}*/
-}
-
-size_t zCModelMeshLib::findNodeIndex(const std::string& nodeName) const
-{
-    for (size_t i = 0; i < m_Nodes.size(); i++)
-    {
-        if (m_Nodes[i].name == nodeName)
-            return i;
     }
 
-    return static_cast<size_t>(-1);
-}
+    size_t zCModelMeshLib::findNodeIndex(const std::string& nodeName) const
+    {
+        for (size_t i = 0; i < m_Nodes.size(); i++)
+        {
+            if (m_Nodes[i].name == nodeName)
+                return i;
+        }
+
+        return static_cast<size_t>(-1);
+    }
+}  // namespace ZenLib

--- a/zenload/zCModelMeshLib.h
+++ b/zenload/zCModelMeshLib.h
@@ -4,131 +4,134 @@
 #include "zTypes.h"
 #include "utils/mathlib.h"
 
-namespace VDFS
+namespace ZenLib
 {
-    class FileIndex;
-}
-
-namespace ZenLoad
-{
-    struct ModelNode
+    namespace VDFS
     {
-        /**
+        class FileIndex;
+    }
+
+    namespace ZenLoad
+    {
+        struct ModelNode
+        {
+            /**
 		 * @return Whether the parent is valid or not (Invalid on root-nodes)
 		 */
-        bool parentValid() const { return parentIndex != 0xFFFF; }
+            bool parentValid() const { return parentIndex != 0xFFFF; }
 
-        uint16_t parentIndex;
-        std::string name;
-        ZMath::Matrix transformLocal;
-        ZMath::Matrix transformBindPoseDebug;  // "Global"
+            uint16_t parentIndex;
+            std::string name;
+            ZMath::Matrix transformLocal;
+            ZMath::Matrix transformBindPoseDebug;  // "Global"
 
-        std::vector<uint16_t> childIndices;
-    };
+            std::vector<uint16_t> childIndices;
+        };
 
-    class ZenParser;
-    class zCModelMeshLib
-    {
-    public:
-        zCModelMeshLib()
+        class ZenParser;
+        class zCModelMeshLib
         {
-            memset(m_BBox, 0, sizeof(m_BBox));
-            memset(m_BBoxCollision, 0, sizeof(m_BBoxCollision));
-            memset(&m_RootNodeTranslation, 0, sizeof(m_RootNodeTranslation));
-        }
+        public:
+            zCModelMeshLib()
+            {
+                memset(m_BBox, 0, sizeof(m_BBox));
+                memset(m_BBoxCollision, 0, sizeof(m_BBoxCollision));
+                memset(&m_RootNodeTranslation, 0, sizeof(m_RootNodeTranslation));
+            }
 
-        /**
+            /**
 		 * @brief Loads the mesh from the given VDF-Archive
 		 */
-        zCModelMeshLib(const std::string& fileName, const VDFS::FileIndex& fileIndex, float scale = 1.0f);
+            zCModelMeshLib(const std::string& fileName, const VDFS::FileIndex& fileIndex, float scale = 1.0f);
 
-        /**
+            /**
 		 * @brief Reads the mesh-object from the given binary stream
 		 * @param fromZen Whether this mesh is supposed to be read from a zenfile. In this case, information about the binary chunk is also read.
 		 */
-        void loadMDM(ZenParser& parser);
+            void loadMDM(ZenParser& parser);
 
-        /**
+            /**
 		* @brief Reads the model hierachy from a file (MDH-File)
 		*/
-        void loadMDH(ZenParser& parser, float scale = 1.0f);
+            void loadMDH(ZenParser& parser, float scale = 1.0f);
 
-        /**
+            /**
 		* @brief reads this lib as MDL
 		*/
-        void loadMDL(ZenParser& parser, float scale = 1.0f);
+            void loadMDL(ZenParser& parser, float scale = 1.0f);
 
-        /**
+            /**
 		 * @brief Creates packed submesh-data
 		 */
-        void packMesh(PackedSkeletalMesh& mesh, float scale = 1.0f) const;
+            void packMesh(PackedSkeletalMesh& mesh, float scale = 1.0f) const;
 
-        /**
+            /**
 		 * @return List of meshes registered in this library
 		 */
-        const std::vector<zCMeshSoftSkin>& getMeshes() const { return m_Meshes; }
+            const std::vector<zCMeshSoftSkin>& getMeshes() const { return m_Meshes; }
 
-        /**
+            /**
 		 * @return List of nodes in the hierachy
 		 */
-        const std::vector<ModelNode>& getNodes() const { return m_Nodes; }
+            const std::vector<ModelNode>& getNodes() const { return m_Nodes; }
 
-        /**
+            /**
 		 * @return List of attached meshes
 		 */
-        const std::vector<std::pair<std::string, zCProgMeshProto>>& getAttachments() const { return m_NodeAttachments; }
+            const std::vector<std::pair<std::string, zCProgMeshProto>>& getAttachments() const { return m_NodeAttachments; }
 
-        /**
+            /**
 		 * @return Checksum for this node hierachy 
 		 */
-        uint32_t getNodeChecksum() const { return m_NodeChecksum; }
+            uint32_t getNodeChecksum() const { return m_NodeChecksum; }
 
-        /**
+            /**
 		 * @return The index of the node with the given name
 		 */
-        size_t findNodeIndex(const std::string& nodeName) const;
+            size_t findNodeIndex(const std::string& nodeName) const;
 
-        /**
+            /**
 		 * @return Whether this was loaded correctly
 		 */
-        bool isValid()
-        {
-            return !m_Meshes.empty() || !m_NodeAttachments.empty() || !m_Nodes.empty();
-        }
+            bool isValid()
+            {
+                return !m_Meshes.empty() || !m_NodeAttachments.empty() || !m_Nodes.empty();
+            }
 
-        /**
+            /**
 		 * @return BBox min/max
 		 */
-        ZMath::float3 getBBoxMin() const { return m_BBox[0]; }
-        ZMath::float3 getBBoxMax() const { return m_BBox[1]; }
-        ZMath::float3 getBBoxCollisionMin() const { return m_BBoxCollision[0]; }
-        ZMath::float3 getBBoxCollisionMax() const { return m_BBoxCollision[1]; }
-        ZMath::float3 getRootNodeTranslation() const { return m_RootNodeTranslation; }
+            ZMath::float3 getBBoxMin() const { return m_BBox[0]; }
+            ZMath::float3 getBBoxMax() const { return m_BBox[1]; }
+            ZMath::float3 getBBoxCollisionMin() const { return m_BBoxCollision[0]; }
+            ZMath::float3 getBBoxCollisionMax() const { return m_BBoxCollision[1]; }
+            ZMath::float3 getRootNodeTranslation() const { return m_RootNodeTranslation; }
 
-    private:
-        /**
+        private:
+            /**
 		 * @brief List of meshes registered in this library
 		 */
-        std::vector<zCMeshSoftSkin> m_Meshes;
+            std::vector<zCMeshSoftSkin> m_Meshes;
 
-        /** 
+            /** 
 		 * @brief Node-Attachments
 		 */
-        std::vector<std::pair<std::string, zCProgMeshProto>> m_NodeAttachments;
+            std::vector<std::pair<std::string, zCProgMeshProto>> m_NodeAttachments;
 
-        /**
+            /**
 		 * @brief Model hierachy
 		 */
-        std::vector<ModelNode> m_Nodes;
-        std::vector<uint16_t> m_RootNodes;
+            std::vector<ModelNode> m_Nodes;
+            std::vector<uint16_t> m_RootNodes;
 
-        /**
+            /**
 		 * @brief Checksum for this node hierachy
 		 */
-        uint32_t m_NodeChecksum;
+            uint32_t m_NodeChecksum;
 
-        ZMath::float3 m_BBox[2];
-        ZMath::float3 m_BBoxCollision[2];
-        ZMath::float3 m_RootNodeTranslation;
-    };
-}  // namespace ZenLoad
+            ZMath::float3 m_BBox[2];
+            ZMath::float3 m_BBoxCollision[2];
+            ZMath::float3 m_RootNodeTranslation;
+        };
+    }  // namespace ZenLoad
+}  // namespace ZenLib

--- a/zenload/zCModelPrototype.cpp
+++ b/zenload/zCModelPrototype.cpp
@@ -8,121 +8,123 @@
 #include "utils/logger.h"
 #include "vdfs/fileIndex.h"
 
-using namespace ZenLoad;
-
-enum class EIdxAni : int
+namespace ZenLib
 {
-    def,
-    name,
-    layer,
-    nextAni,
-    blendIn,
-    blendOut,
-    flags,
-    ASC_Name,
-    aniDir,
-    startFrame,
-    endFrame,
-    fps,
-};
+    using namespace ZenLoad;
 
-enum class EIdxMeshAndTree
-{
-    def,
-    name,
-    dontUseMesh
-};
+    enum class EIdxAni : int
+    {
+        def,
+        name,
+        layer,
+        nextAni,
+        blendIn,
+        blendOut,
+        flags,
+        ASC_Name,
+        aniDir,
+        startFrame,
+        endFrame,
+        fps,
+    };
 
-enum class EIdxRegisterMesh
-{
-    def,
-    name
-};
+    enum class EIdxMeshAndTree
+    {
+        def,
+        name,
+        dontUseMesh
+    };
 
-/**
+    enum class EIdxRegisterMesh
+    {
+        def,
+        name
+    };
+
+    /**
  * Splits one of the MDS-Declerations like the example seen inside the function
  * @param _line line to parse
  * @return Vector of all parameters as strings
  */
-std::vector<std::string> splitDecl(const std::string& _line)
-{
-    // Example: registerMesh ("Gob_Body.ASC")
-    // Example: ani			("s_FistRun"					1	"s_FistRun"			0.1	0.1	M.	"Gob_1hRunAmbient_M01.asc"	F	0	30	FPS:10)
-
-    // Collapse
-    std::vector<std::string> out;
-    out.push_back("");
-    bool inArg = true;
-    for (auto& c : _line)
+    std::vector<std::string> splitDecl(const std::string& _line)
     {
-        if (c == ' ' || c == '\t' || c == '(')
+        // Example: registerMesh ("Gob_Body.ASC")
+        // Example: ani			("s_FistRun"					1	"s_FistRun"			0.1	0.1	M.	"Gob_1hRunAmbient_M01.asc"	F	0	30	FPS:10)
+
+        // Collapse
+        std::vector<std::string> out;
+        out.push_back("");
+        bool inArg = true;
+        for (auto& c : _line)
         {
-            if (inArg)  // Only add a new section, when the last one was filled
+            if (c == ' ' || c == '\t' || c == '(')
             {
-                out.push_back("");
-                inArg = false;
+                if (inArg)  // Only add a new section, when the last one was filled
+                {
+                    out.push_back("");
+                    inArg = false;
+                }
+            }
+            else
+            {
+                if (c != '"' && c != ')')  // Don't add quotes and the closing bracket
+                {
+                    out.back() += c;
+                    inArg = true;
+                }
+
+                // Handle empty strings
+                if (c == '"')
+                    inArg = true;
             }
         }
-        else
-        {
-            if (c != '"' && c != ')')  // Don't add quotes and the closing bracket
-            {
-                out.back() += c;
-                inArg = true;
-            }
 
-            // Handle empty strings
-            if (c == '"')
-                inArg = true;
+        return out;
+    }
+
+    zCModelPrototype::zCModelPrototype(const std::string& fileName, const VDFS::FileIndex& fileIndex)
+    {
+        std::vector<uint8_t> data;
+        fileIndex.getFileData(fileName, data);
+
+        if (data.empty())
+            return;  // TODO: Throw an exception or something
+
+        try
+        {
+            // Create parser from memory
+            // FIXME: There is an internal copy of the data here. Optimize!
+            ZenLoad::ZenParser parser(data.data(), data.size());
+
+            readObjectData(parser);
+        }
+        catch (std::exception& e)
+        {
+            LogError() << e.what();
+            return;
         }
     }
-
-    return out;
-}
-
-zCModelPrototype::zCModelPrototype(const std::string& fileName, const VDFS::FileIndex& fileIndex)
-{
-    std::vector<uint8_t> data;
-    fileIndex.getFileData(fileName, data);
-
-    if (data.empty())
-        return;  // TODO: Throw an exception or something
-
-    try
-    {
-        // Create parser from memory
-        // FIXME: There is an internal copy of the data here. Optimize!
-        ZenLoad::ZenParser parser(data.data(), data.size());
-
-        readObjectData(parser);
-    }
-    catch (std::exception& e)
-    {
-        LogError() << e.what();
-        return;
-    }
-}
-
-/**
-* @brief Reads the mesh-object from the given binary stream
-*/
-void zCModelPrototype::readObjectData(ZenParser& parser)
-{
-    // TODO: Implement G2-Variant of this
-
-    enum Section
-    {
-        Model,
-        AniEnum,
-        MeshAndTree,
-        RegisterMesh,
-        StartMesh,
-    };
 
     /**
+* @brief Reads the mesh-object from the given binary stream
+*/
+    void zCModelPrototype::readObjectData(ZenParser& parser)
+    {
+        // TODO: Implement G2-Variant of this
+
+        enum Section
+        {
+            Model,
+            AniEnum,
+            MeshAndTree,
+            RegisterMesh,
+            StartMesh,
+        };
+
+        /**
      * Ani enum
      */
-    /*
+        /*
     auto readAniEnum = [&]() {
 
         while (parser.getSeek() < parser.getFileSize())
@@ -141,10 +143,10 @@ void zCModelPrototype::readObjectData(ZenParser& parser)
     };
     */
 
-    /**
+        /**
      * Register mesh
      */
-    /*
+        /*
     auto readRegisterMesh = [&](const std::string& line) {
         std::vector<std::string> args = splitDecl(line);
 
@@ -152,49 +154,87 @@ void zCModelPrototype::readObjectData(ZenParser& parser)
     };
     */
 
-    /**
+        /**
      * Ani
      */
-    auto readAni = [&](const std::string& line) {
-        std::vector<std::string> args = splitDecl(line);
+        auto readAni = [&](const std::string& line)
+        {
+            std::vector<std::string> args = splitDecl(line);
 
-        LogInfo() << "Args: " << args;
+            LogInfo() << "Args: " << args;
 
-        Animation ani;
-        ani.animationName = args[(int)EIdxAni::name];
-        ani.layer = atoi(args[(int)EIdxAni::layer].c_str());
-        ani.nextAnimation = args[(int)EIdxAni::nextAni];
-        ani.blendIn = atof(args[(int)EIdxAni::blendIn].c_str());
-        ani.blendOut = atof(args[(int)EIdxAni::blendOut].c_str());
+            Animation ani;
+            ani.animationName = args[(int)EIdxAni::name];
+            ani.layer = atoi(args[(int)EIdxAni::layer].c_str());
+            ani.nextAnimation = args[(int)EIdxAni::nextAni];
+            ani.blendIn = atof(args[(int)EIdxAni::blendIn].c_str());
+            ani.blendOut = atof(args[(int)EIdxAni::blendOut].c_str());
 
-        ani.ascName = args[(int)EIdxAni::ASC_Name];
-        ani.aniReversed = args[(int)EIdxAni::aniDir] == "R";
-        ani.startFrame = atoi(args[(int)EIdxAni::startFrame].c_str());
-        ani.endFrame = atoi(args[(int)EIdxAni::endFrame].c_str());
+            ani.ascName = args[(int)EIdxAni::ASC_Name];
+            ani.aniReversed = args[(int)EIdxAni::aniDir] == "R";
+            ani.startFrame = atoi(args[(int)EIdxAni::startFrame].c_str());
+            ani.endFrame = atoi(args[(int)EIdxAni::endFrame].c_str());
 
-        ani.flags = 0;
-        if (args[(int)EIdxAni::flags].find("m") != std::string::npos)
-            ani.flags |= Animation::MoveObject;
+            ani.flags = 0;
+            if (args[(int)EIdxAni::flags].find("m") != std::string::npos)
+                ani.flags |= Animation::MoveObject;
 
-        if (args[(int)EIdxAni::flags].find("r") != std::string::npos)
-            ani.flags |= Animation::RotateObject;
+            if (args[(int)EIdxAni::flags].find("r") != std::string::npos)
+                ani.flags |= Animation::RotateObject;
 
-        if (args[(int)EIdxAni::flags].find("e") != std::string::npos)
-            ani.flags |= Animation::WaitEnd;
+            if (args[(int)EIdxAni::flags].find("e") != std::string::npos)
+                ani.flags |= Animation::WaitEnd;
 
-        if (args[(int)EIdxAni::flags].find("f") != std::string::npos)
-            ani.flags |= Animation::Fly;
+            if (args[(int)EIdxAni::flags].find("f") != std::string::npos)
+                ani.flags |= Animation::Fly;
 
-        if (args[(int)EIdxAni::flags].find("i") != std::string::npos)
-            ani.flags |= Animation::Idle;
+            if (args[(int)EIdxAni::flags].find("i") != std::string::npos)
+                ani.flags |= Animation::Idle;
 
-        m_Animations.push_back(ani);
-    };
+            m_Animations.push_back(ani);
+        };
 
-    /**
+        /**
      * Base node
      */
-    auto readModel = [&]() {
+        auto readModel = [&]()
+        {
+            while (parser.getSeek() < parser.getFileSize())
+            {
+                std::string line = parser.readLine(true);
+                std::transform(line.begin(), line.end(), line.begin(), ::tolower);
+
+                LogInfo() << "MDS-Line: " << line;
+
+                if (line.find("//") != std::string::npos)
+                    continue;  // Skip comments. These MUST be on their own lines, by definition.
+                else if (line.find("anienum") != std::string::npos)
+                    continue;
+                else if (line.find("aniblend") != std::string::npos)
+                    continue;
+                else if (line.find("eventmmstartani") != std::string::npos)
+                    continue;
+                else if (line.find("anialias") != std::string::npos)
+                    continue;
+                else if (line.find("anicomb") != std::string::npos)
+                    continue;
+                else if (line.find("anidisable") != std::string::npos)
+                    continue;
+                else if (line.find("ani") != std::string::npos)
+                    readAni(line);
+                else if (line.find("meshandtree") != std::string::npos)
+                    continue;
+                else if (line.find("registermesh") != std::string::npos)
+                    continue;
+                else if (line.find("startmesh") != std::string::npos)
+                    continue;
+                else if (line.find("{") != std::string::npos)
+                    continue;
+                else if (line.find("}") != std::string::npos)
+                    continue;  //break; // There can be only one } per block
+            }
+        };
+
         while (parser.getSeek() < parser.getFileSize())
         {
             std::string line = parser.readLine(true);
@@ -204,43 +244,8 @@ void zCModelPrototype::readObjectData(ZenParser& parser)
 
             if (line.find("//") != std::string::npos)
                 continue;  // Skip comments. These MUST be on their own lines, by definition.
-            else if (line.find("anienum") != std::string::npos)
-                continue;
-            else if (line.find("aniblend") != std::string::npos)
-                continue;
-            else if (line.find("eventmmstartani") != std::string::npos)
-                continue;
-            else if (line.find("anialias") != std::string::npos)
-                continue;
-            else if (line.find("anicomb") != std::string::npos)
-                continue;
-            else if (line.find("anidisable") != std::string::npos)
-                continue;
-            else if (line.find("ani") != std::string::npos)
-                readAni(line);
-            else if (line.find("meshandtree") != std::string::npos)
-                continue;
-            else if (line.find("registermesh") != std::string::npos)
-                continue;
-            else if (line.find("startmesh") != std::string::npos)
-                continue;
-            else if (line.find("{") != std::string::npos)
-                continue;
-            else if (line.find("}") != std::string::npos)
-                continue;  //break; // There can be only one } per block
+            else if (line.find("model") != std::string::npos)
+                readModel();
         }
-    };
-
-    while (parser.getSeek() < parser.getFileSize())
-    {
-        std::string line = parser.readLine(true);
-        std::transform(line.begin(), line.end(), line.begin(), ::tolower);
-
-        LogInfo() << "MDS-Line: " << line;
-
-        if (line.find("//") != std::string::npos)
-            continue;  // Skip comments. These MUST be on their own lines, by definition.
-        else if (line.find("model") != std::string::npos)
-            readModel();
     }
-}
+}  // namespace ZenLib

--- a/zenload/zCModelPrototype.h
+++ b/zenload/zCModelPrototype.h
@@ -3,61 +3,64 @@
 #include "zTypes.h"
 #include "utils/mathlib.h"
 
-namespace VDFS
+namespace ZenLib
 {
-    class FileIndex;
-}
-
-namespace ZenLoad
-{
-    class ZenParser;
-    class zCModelPrototype
+    namespace VDFS
     {
-    public:
-        struct Animation
-        {
-            std::string animationName;
-            unsigned int layer;
-            std::string nextAnimation;
-            float blendIn, blendOut;
+        class FileIndex;
+    }
 
-            enum Flags
+    namespace ZenLoad
+    {
+        class ZenParser;
+        class zCModelPrototype
+        {
+        public:
+            struct Animation
             {
-                MoveObject = 1,
-                RotateObject = 2,
-                WaitEnd = 4,
-                Fly = 8,
-                Idle = 16
+                std::string animationName;
+                unsigned int layer;
+                std::string nextAnimation;
+                float blendIn, blendOut;
+
+                enum Flags
+                {
+                    MoveObject = 1,
+                    RotateObject = 2,
+                    WaitEnd = 4,
+                    Fly = 8,
+                    Idle = 16
+                };
+
+                unsigned int flags;
+                std::string ascName;
+                bool aniReversed;
+                int startFrame, endFrame;
             };
 
-            unsigned int flags;
-            std::string ascName;
-            bool aniReversed;
-            int startFrame, endFrame;
-        };
+            zCModelPrototype() {}
 
-        zCModelPrototype() {}
-
-        /**
+            /**
 		 * @brief Loads the mesh from the given VDF-Archive
 		 */
-        zCModelPrototype(const std::string& fileName, const VDFS::FileIndex& fileIndex);
+            zCModelPrototype(const std::string& fileName, const VDFS::FileIndex& fileIndex);
 
-        /**
+            /**
          * @brief Reads the mesh-object from the given binary stream
          * @param fromZen Whether this mesh is supposed to be read from a zenfile. In this case, information about the binary chunk is also read.
          */
-        void readObjectData(ZenParser& parser);
+            void readObjectData(ZenParser& parser);
 
-        /**
+            /**
          * @return List of animations registered here
          */
-        std::vector<Animation> getAnimations()
-        {
-            return m_Animations;
-        }
+            std::vector<Animation> getAnimations()
+            {
+                return m_Animations;
+            }
 
-    private:
-        std::vector<Animation> m_Animations;
-    };
-}  // namespace ZenLoad
+        private:
+            std::vector<Animation> m_Animations;
+        };
+    }  // namespace ZenLoad
+}  // namespace ZenLib

--- a/zenload/zCModelScript.h
+++ b/zenload/zCModelScript.h
@@ -3,140 +3,143 @@
 #include <cstdint>
 #include <string>
 
-namespace ZenLoad
+namespace ZenLib
 {
-    enum
+    namespace ZenLoad
     {
-        ANIEVENT_MAX_NUM_VALUES = 4
-    };
+        enum
+        {
+            ANIEVENT_MAX_NUM_VALUES = 4
+        };
 
-    // TODO: these should be general flags?
-    enum EModelScriptAniFlags
-    {
-        /// Animation moves model in world space
-        MSB_MOVE_MODEL = 0x00000001,
-        /// Animation rotates model in world space
-        MSB_ROTATE_MODEL = 0x00000002,
-        /// Animation is queued after the current any on layer instead of started immediately
-        MSB_QUEUE_ANI = 0x00000004,
-        /// Don't stick to ground
-        MSB_FLY = 0x00000008,
-        /// Idle animation
-        MSB_IDLE = 0x00000010,
-    };
+        // TODO: these should be general flags?
+        enum EModelScriptAniFlags
+        {
+            /// Animation moves model in world space
+            MSB_MOVE_MODEL = 0x00000001,
+            /// Animation rotates model in world space
+            MSB_ROTATE_MODEL = 0x00000002,
+            /// Animation is queued after the current any on layer instead of started immediately
+            MSB_QUEUE_ANI = 0x00000004,
+            /// Don't stick to ground
+            MSB_FLY = 0x00000008,
+            /// Idle animation
+            MSB_IDLE = 0x00000010,
+        };
 
-    // TODO: should general enum?
-    enum EModelScriptAniDir
-    {
-        MSB_FORWARD,
-        MSB_BACKWARD
-    };
+        // TODO: should general enum?
+        enum EModelScriptAniDir
+        {
+            MSB_FORWARD,
+            MSB_BACKWARD
+        };
 
-    struct zCModelScriptAni
-    {
-        /// Add + ".MAN" for the animation data
-        std::string m_Name;
-        uint32_t m_Layer = 0;
-        std::string m_Next;
-        float m_BlendIn = 0;
-        float m_BlendOut = 0;
-        uint32_t m_Flags = 0;
-        std::string m_Asc;
-        EModelScriptAniDir m_Dir = MSB_FORWARD;
-        int32_t m_FirstFrame = 0;
-        int32_t m_LastFrame = 0;
-        float m_MaxFps = 0.0f;
-        float m_Speed = 0.0f;
-        float m_ColVolScale = 1.0f;
-    };
+        struct zCModelScriptAni
+        {
+            /// Add + ".MAN" for the animation data
+            std::string m_Name;
+            uint32_t m_Layer = 0;
+            std::string m_Next;
+            float m_BlendIn = 0;
+            float m_BlendOut = 0;
+            uint32_t m_Flags = 0;
+            std::string m_Asc;
+            EModelScriptAniDir m_Dir = MSB_FORWARD;
+            int32_t m_FirstFrame = 0;
+            int32_t m_LastFrame = 0;
+            float m_MaxFps = 0.0f;
+            float m_Speed = 0.0f;
+            float m_ColVolScale = 1.0f;
+        };
 
-    struct zCModelScriptAniAlias
-    {
-        /// Add + ".MAN" for the animation data
-        std::string m_Name;
-        uint32_t m_Layer = 0;
-        std::string m_Next;
-        float m_BlendIn = 0;
-        float m_BlendOut = 0;
-        uint32_t m_Flags = 0;
-        std::string m_Alias;
-        EModelScriptAniDir m_Dir = MSB_FORWARD;
-    };
+        struct zCModelScriptAniAlias
+        {
+            /// Add + ".MAN" for the animation data
+            std::string m_Name;
+            uint32_t m_Layer = 0;
+            std::string m_Next;
+            float m_BlendIn = 0;
+            float m_BlendOut = 0;
+            uint32_t m_Flags = 0;
+            std::string m_Alias;
+            EModelScriptAniDir m_Dir = MSB_FORWARD;
+        };
 
-    struct zCModelScriptAniBlend
-    {
-        std::string m_Name;
-        uint32_t m_Layer = 0;
-        std::string m_Next;
-        float m_BlendIn = 0;
-        float m_BlendOut = 0;
-    };
+        struct zCModelScriptAniBlend
+        {
+            std::string m_Name;
+            uint32_t m_Layer = 0;
+            std::string m_Next;
+            float m_BlendIn = 0;
+            float m_BlendOut = 0;
+        };
 
-    struct zCModelScriptAniSync
-    {
-        std::string m_Name;
-        uint32_t m_Layer = 0;
-        std::string m_Next;
-    };
+        struct zCModelScriptAniSync
+        {
+            std::string m_Name;
+            uint32_t m_Layer = 0;
+            std::string m_Next;
+        };
 
-    struct zCModelScriptAniCombine
-    {
-        std::string m_Name;
-        uint32_t m_Layer = 0;
-        std::string m_Next;
-        float m_BlendIn = 0;
-        float m_BlendOut = 0;
-        uint32_t m_Flags = 0;
-        std::string m_Asc;
-        uint32_t m_LastFrame = 0;
-    };
+        struct zCModelScriptAniCombine
+        {
+            std::string m_Name;
+            uint32_t m_Layer = 0;
+            std::string m_Next;
+            float m_BlendIn = 0;
+            float m_BlendOut = 0;
+            uint32_t m_Flags = 0;
+            std::string m_Asc;
+            uint32_t m_LastFrame = 0;
+        };
 
-    struct zCModelScriptAniDisable
-    {
-        std::string m_Name;
-    };
+        struct zCModelScriptAniDisable
+        {
+            std::string m_Name;
+        };
 
-    struct zCModelScriptEventTag
-    {
-        int32_t m_Frame;
-        std::string m_Tag;
-        std::string m_Argument;
-    };
+        struct zCModelScriptEventTag
+        {
+            int32_t m_Frame;
+            std::string m_Tag;
+            std::string m_Argument;
+        };
 
-    struct zCModelScriptEventMMStartAni
-    {
-        int32_t m_Frame;
-        std::string m_Animation;
-    };
+        struct zCModelScriptEventMMStartAni
+        {
+            int32_t m_Frame;
+            std::string m_Animation;
+        };
 
-    struct zCModelScriptEventSfx
-    {
-        int32_t m_Frame = 0;
-        std::string m_Name;
+        struct zCModelScriptEventSfx
+        {
+            int32_t m_Frame = 0;
+            std::string m_Name;
 
-        /**
+            /**
          * If non-zero, will overwrite the default sound range of the character
          */
-        float m_Range = 0.0f;
+            float m_Range = 0.0f;
 
-        /**
+            /**
          * If true, the sound shall be played in a new "empty slow", which means
          * that it should not overwrite the currently playing sound.
          */
-        bool m_EmptySlot = false;
-    };
+            bool m_EmptySlot = false;
+        };
 
-    struct zCModelScriptEventPfx
-    {
-        int32_t m_Frame;
-        int32_t m_Num;
-        std::string m_Name;
-        std::string m_Pos;
-        bool m_isAttached = false;
-    };
-    struct zCModelScriptEventPfxStop
-    {
-        int32_t m_Frame;
-        int32_t m_Num;
-    };
-}  // namespace ZenLoad
+        struct zCModelScriptEventPfx
+        {
+            int32_t m_Frame;
+            int32_t m_Num;
+            std::string m_Name;
+            std::string m_Pos;
+            bool m_isAttached = false;
+        };
+        struct zCModelScriptEventPfxStop
+        {
+            int32_t m_Frame;
+            int32_t m_Num;
+        };
+    }  // namespace ZenLoad
+}  // namespace ZenLib

--- a/zenload/zCMorphMesh.cpp
+++ b/zenload/zCMorphMesh.cpp
@@ -7,83 +7,86 @@
 #include "utils/logger.h"
 #include "vdfs/fileIndex.h"
 
-using namespace ZenLoad;
-
-static const uint16_t MMID_MMB_HEADER = 0xE020;
-static const uint16_t MMID_MMB_ANILIST = 0xE030;
-
-zCMorphMesh::zCMorphMesh(const std::string& fileName, const VDFS::FileIndex& fileIndex)
+namespace ZenLib
 {
-    std::vector<uint8_t> data;
-    fileIndex.getFileData(fileName, data);
+    using namespace ZenLoad;
 
-    if (data.empty())
-        return;  // TODO: Throw an exception or something
+    static const uint16_t MMID_MMB_HEADER = 0xE020;
+    static const uint16_t MMID_MMB_ANILIST = 0xE030;
 
-    try
+    zCMorphMesh::zCMorphMesh(const std::string& fileName, const VDFS::FileIndex& fileIndex)
     {
-        // Create parser from memory
-        // FIXME: There is an internal copy of the data here. Optimize!
-        ZenLoad::ZenParser parser(data.data(), data.size());
+        std::vector<uint8_t> data;
+        fileIndex.getFileData(fileName, data);
 
-        readObjectData(parser);
-    }
-    catch (std::exception& e)
-    {
-        LogError() << e.what();
-        return;
-    }
-}
+        if (data.empty())
+            return;  // TODO: Throw an exception or something
 
-/**
-* @brief Reads the mesh-object from the given binary stream
-*/
-void zCMorphMesh::readObjectData(ZenParser& parser)
-{
-    // Information about the whole file we are reading here
-    BinaryFileInfo fileInfo;
-
-    // Information about a single chunk
-    BinaryChunkInfo chunkInfo;
-
-    // Read chunks until we left the virtual binary file or got to the end-chunk
-    // Each chunk starts with a header (BinaryChunkInfo) which gives information
-    // about what to do and how long the chunk is
-    bool doneReadingChunks = false;
-    while (!doneReadingChunks)
-    {
-        // Read chunk header and calculate position of next chunk
-        parser.readStructure(chunkInfo);
-
-        size_t chunkEnd = parser.getSeek() + chunkInfo.length;
-
-        switch (chunkInfo.id)
+        try
         {
-            case MMID_MMB_HEADER:
-            {
-                uint32_t version = parser.readBinaryDWord();
+            // Create parser from memory
+            // FIXME: There is an internal copy of the data here. Optimize!
+            ZenLoad::ZenParser parser(data.data(), data.size());
 
-                std::string morphProtoName = parser.readLine(true);
-                //LogInfo() << "MorphProtoName: " << morphProtoName;
-
-                // Read source-mesh
-                m_Mesh.readObjectData(parser);
-
-                // TODO: use these
-                std::vector<ZMath::float3> morphPositions(m_Mesh.getVertices().size());
-                parser.readBinaryRaw(morphPositions.data(), sizeof(ZMath::float3) * m_Mesh.getVertices().size());
-            }
-            break;
-
-            case MMID_MMB_ANILIST:
-                doneReadingChunks = true;
-                parser.setSeek(chunkEnd);
-                break;
-
-                // Morphmeshes don't have a real end-tag. The anilist is the last one, however
-
-            default:
-                parser.setSeek(chunkEnd);  // Skip chunk
+            readObjectData(parser);
+        }
+        catch (std::exception& e)
+        {
+            LogError() << e.what();
+            return;
         }
     }
-}
+
+    /**
+* @brief Reads the mesh-object from the given binary stream
+*/
+    void zCMorphMesh::readObjectData(ZenParser& parser)
+    {
+        // Information about the whole file we are reading here
+        BinaryFileInfo fileInfo;
+
+        // Information about a single chunk
+        BinaryChunkInfo chunkInfo;
+
+        // Read chunks until we left the virtual binary file or got to the end-chunk
+        // Each chunk starts with a header (BinaryChunkInfo) which gives information
+        // about what to do and how long the chunk is
+        bool doneReadingChunks = false;
+        while (!doneReadingChunks)
+        {
+            // Read chunk header and calculate position of next chunk
+            parser.readStructure(chunkInfo);
+
+            size_t chunkEnd = parser.getSeek() + chunkInfo.length;
+
+            switch (chunkInfo.id)
+            {
+                case MMID_MMB_HEADER:
+                {
+                    uint32_t version = parser.readBinaryDWord();
+
+                    std::string morphProtoName = parser.readLine(true);
+                    //LogInfo() << "MorphProtoName: " << morphProtoName;
+
+                    // Read source-mesh
+                    m_Mesh.readObjectData(parser);
+
+                    // TODO: use these
+                    std::vector<ZMath::float3> morphPositions(m_Mesh.getVertices().size());
+                    parser.readBinaryRaw(morphPositions.data(), sizeof(ZMath::float3) * m_Mesh.getVertices().size());
+                }
+                break;
+
+                case MMID_MMB_ANILIST:
+                    doneReadingChunks = true;
+                    parser.setSeek(chunkEnd);
+                    break;
+
+                    // Morphmeshes don't have a real end-tag. The anilist is the last one, however
+
+                default:
+                    parser.setSeek(chunkEnd);  // Skip chunk
+            }
+        }
+    }
+}  // namespace ZenLib

--- a/zenload/zCMorphMesh.h
+++ b/zenload/zCMorphMesh.h
@@ -4,39 +4,42 @@
 #include "zTypes.h"
 #include "utils/mathlib.h"
 
-namespace VDFS
+namespace ZenLib
 {
-    class FileIndex;
-}
-
-namespace ZenLoad
-{
-    class ZenParser;
-    class zCMorphMesh
+    namespace VDFS
     {
-    public:
-        zCMorphMesh() {}
+        class FileIndex;
+    }
 
-        /**
+    namespace ZenLoad
+    {
+        class ZenParser;
+        class zCMorphMesh
+        {
+        public:
+            zCMorphMesh() {}
+
+            /**
 		 * @brief Loads the mesh from the given VDF-Archive
 		 */
-        zCMorphMesh(const std::string& fileName, const VDFS::FileIndex& fileIndex);
+            zCMorphMesh(const std::string& fileName, const VDFS::FileIndex& fileIndex);
 
-        /**
+            /**
          * @brief Reads the mesh-object from the given binary stream
          * @param fromZen Whether this mesh is supposed to be read from a zenfile. In this case, information about the binary chunk is also read.
          */
-        void readObjectData(ZenParser& parser);
+            void readObjectData(ZenParser& parser);
 
-        /**
+            /**
          * @return Internal zCProgMeshProto of this soft skin. The soft-skin only displaces the vertices found in the ProgMesh.
          */
-        const zCProgMeshProto& getMesh() const { return m_Mesh; }
+            const zCProgMeshProto& getMesh() const { return m_Mesh; }
 
-    private:
-        /**
+        private:
+            /**
          * @brief Internal zCProgMeshProto of this soft skin. The soft-skin only displaces the vertices found in the ProgMesh.
          */
-        zCProgMeshProto m_Mesh;
-    };
-}  // namespace ZenLoad
+            zCProgMeshProto m_Mesh;
+        };
+    }  // namespace ZenLoad
+}  // namespace ZenLib

--- a/zenload/zCProgMeshProto.cpp
+++ b/zenload/zCProgMeshProto.cpp
@@ -7,297 +7,300 @@
 #include "utils/logger.h"
 #include "vdfs/fileIndex.h"
 
-using namespace ZenLoad;
-
-static const uint16_t zCPROGMESH_FILE_VERS_G2 = 0x0905;
-static const uint16_t MSID_PROGMESH = 0xB100;
-static const uint16_t MSID_PROGMESH_END = 0xB1FF;
-
-struct MeshDataEntry
+namespace ZenLib
 {
-    uint32_t offset;
-    uint32_t size;
-};
+    using namespace ZenLoad;
 
-struct MeshOffsetsMain
-{
-    MeshDataEntry position;
-    MeshDataEntry normal;
-};
+    static const uint16_t zCPROGMESH_FILE_VERS_G2 = 0x0905;
+    static const uint16_t MSID_PROGMESH = 0xB100;
+    static const uint16_t MSID_PROGMESH_END = 0xB1FF;
 
-struct MeshOffsetsSubMesh
-{
-    MeshDataEntry triangleList;
-    MeshDataEntry wedgeList;
-    MeshDataEntry colorList;
-    MeshDataEntry trianglePlaneIndexList;
-    MeshDataEntry trianglePlaneList;
-    MeshDataEntry wedgeMap;
-    MeshDataEntry vertexUpdates;
-    MeshDataEntry triangleEdgeList;
-    MeshDataEntry edgeList;
-    MeshDataEntry edgeScoreList;
-};
+    struct MeshDataEntry
+    {
+        uint32_t offset;
+        uint32_t size;
+    };
 
-/**
+    struct MeshOffsetsMain
+    {
+        MeshDataEntry position;
+        MeshDataEntry normal;
+    };
+
+    struct MeshOffsetsSubMesh
+    {
+        MeshDataEntry triangleList;
+        MeshDataEntry wedgeList;
+        MeshDataEntry colorList;
+        MeshDataEntry trianglePlaneIndexList;
+        MeshDataEntry trianglePlaneList;
+        MeshDataEntry wedgeMap;
+        MeshDataEntry vertexUpdates;
+        MeshDataEntry triangleEdgeList;
+        MeshDataEntry edgeList;
+        MeshDataEntry edgeScoreList;
+    };
+
+    /**
 * @brief Loads the mesh from the given VDF-Archive
 */
-zCProgMeshProto::zCProgMeshProto(const std::string& fileName, const VDFS::FileIndex& fileIndex)
-{
-    std::vector<uint8_t> data;
-    fileIndex.getFileData(fileName, data);
-
-    if (data.empty())
+    zCProgMeshProto::zCProgMeshProto(const std::string& fileName, const VDFS::FileIndex& fileIndex)
     {
-        return;  // TODO: Throw an exception or something
+        std::vector<uint8_t> data;
+        fileIndex.getFileData(fileName, data);
+
+        if (data.empty())
+        {
+            return;  // TODO: Throw an exception or something
+        }
+
+        try
+        {
+            // Create parser from memory
+            // FIXME: There is an internal copy of the data here. Optimize!
+            ZenLoad::ZenParser parser(data.data(), data.size());
+
+            readObjectData(parser);
+        }
+        catch (std::exception& e)
+        {
+            LogError() << e.what();
+            return;
+        }
     }
 
-    try
-    {
-        // Create parser from memory
-        // FIXME: There is an internal copy of the data here. Optimize!
-        ZenLoad::ZenParser parser(data.data(), data.size());
-
-        readObjectData(parser);
-    }
-    catch (std::exception& e)
-    {
-        LogError() << e.what();
-        return;
-    }
-}
-
-/**
+    /**
 * @brief Reads the mesh-object from the given binary stream
 */
-void zCProgMeshProto::readObjectData(ZenParser& parser)
-{
-    // Information about a single chunk
-    BinaryChunkInfo chunkInfo;
-
-    bool doneReadingChunks = false;
-    while (!doneReadingChunks && parser.getSeek() <= parser.getFileSize())
+    void zCProgMeshProto::readObjectData(ZenParser& parser)
     {
-        // Read chunk header and calculate position of next chunk
-        parser.readStructure(chunkInfo);
+        // Information about a single chunk
+        BinaryChunkInfo chunkInfo;
 
-        size_t chunkEnd = parser.getSeek() + chunkInfo.length;
-        switch (chunkInfo.id)
+        bool doneReadingChunks = false;
+        while (!doneReadingChunks && parser.getSeek() <= parser.getFileSize())
         {
-            case MSID_PROGMESH:
+            // Read chunk header and calculate position of next chunk
+            parser.readStructure(chunkInfo);
+
+            size_t chunkEnd = parser.getSeek() + chunkInfo.length;
+            switch (chunkInfo.id)
             {
-                uint16_t version = parser.readBinaryWord();
-                /*if(version != zCPROGMESH_FILE_VERS_G2)
+                case MSID_PROGMESH:
+                {
+                    uint16_t version = parser.readBinaryWord();
+                    /*if(version != zCPROGMESH_FILE_VERS_G2)
 				{
 					LogWarn() << "Unsupported zCProgMeshProto-Version: " << version;
 				}*/
 
-                // Read data-pool
-                uint32_t dataSize = parser.readBinaryDWord();
-                std::vector<uint8_t> dataPool;
-                dataPool.resize(dataSize);
-                parser.readBinaryRaw(dataPool.data(), dataSize);
+                    // Read data-pool
+                    uint32_t dataSize = parser.readBinaryDWord();
+                    std::vector<uint8_t> dataPool;
+                    dataPool.resize(dataSize);
+                    parser.readBinaryRaw(dataPool.data(), dataSize);
 
-                // Read how many submeshes we got
-                uint8_t numSubmeshes = parser.readBinaryByte();
+                    // Read how many submeshes we got
+                    uint8_t numSubmeshes = parser.readBinaryByte();
 
-                // Read data offsets for the main position/normal-list
-                MeshOffsetsMain mainOffsets;
-                parser.readStructure(mainOffsets);
+                    // Read data offsets for the main position/normal-list
+                    MeshOffsetsMain mainOffsets;
+                    parser.readStructure(mainOffsets);
 
-                // Read offsets to indices data
-                std::vector<MeshOffsetsSubMesh> subMeshOffsets;
-                subMeshOffsets.resize(numSubmeshes);
-                parser.readBinaryRaw(subMeshOffsets.data(), numSubmeshes * sizeof(MeshOffsetsSubMesh));
+                    // Read offsets to indices data
+                    std::vector<MeshOffsetsSubMesh> subMeshOffsets;
+                    subMeshOffsets.resize(numSubmeshes);
+                    parser.readBinaryRaw(subMeshOffsets.data(), numSubmeshes * sizeof(MeshOffsetsSubMesh));
 
-                // Read materials
+                    // Read materials
 
-                // ZenArchive - Header
-                // uint32_t - Num materials
-                // For each material:
-                //  - String - Name
-                //  - zCMaterial-Chunk
+                    // ZenArchive - Header
+                    // uint32_t - Num materials
+                    // For each material:
+                    //  - String - Name
+                    //  - zCMaterial-Chunk
 
-                ZenParser p2(&parser.getData()[parser.getSeek()], parser.getData().size() - parser.getSeek());
-                p2.readHeader();
+                    ZenParser p2(&parser.getData()[parser.getSeek()], parser.getData().size() - parser.getSeek());
+                    p2.readHeader();
 
-                // Read every stored material
-                for (uint32_t i = 0; i < numSubmeshes; i++)
-                {
-                    p2.readLine(false);  // Read unused material name (Stored a second time later)
+                    // Read every stored material
+                    for (uint32_t i = 0; i < numSubmeshes; i++)
+                    {
+                        p2.readLine(false);  // Read unused material name (Stored a second time later)
 
-                    // Skip chunk headers - we know these are zCMaterial
-                    uint32_t chunksize = p2.readBinaryDWord();
-                    uint16_t version = p2.readBinaryWord();
-                    uint32_t objectIndex = p2.readBinaryDWord();
+                        // Skip chunk headers - we know these are zCMaterial
+                        uint32_t chunksize = p2.readBinaryDWord();
+                        uint16_t version = p2.readBinaryWord();
+                        uint32_t objectIndex = p2.readBinaryDWord();
 
-                    p2.skipSpaces();
+                        p2.skipSpaces();
 
-                    // Skip chunk-header
-                    std::string name = p2.readLine();
-                    std::string classname = p2.readLine();
+                        // Skip chunk-header
+                        std::string name = p2.readLine();
+                        std::string classname = p2.readLine();
 
-                    // Save into vector
-                    m_Materials.emplace_back(zCMaterial::readObjectData(p2, version));
+                        // Save into vector
+                        m_Materials.emplace_back(zCMaterial::readObjectData(p2, version));
+                    }
+
+                    parser.setSeek(p2.getSeek() + parser.getSeek());
+
+                    if (version == zCPROGMESH_FILE_VERS_G2)
+                    {
+                        // Read whether we want to have alphatesting
+                        m_IsUsingAlphaTest = parser.readBinaryByte() != 0;
+                    }
+                    else
+                    {
+                        m_IsUsingAlphaTest = false;
+                    }
+
+                    // Read boundingbox
+                    ZMath::float3 min, max;
+                    parser.readStructure(min);
+                    parser.readStructure(max);
+
+                    m_BBMin = ZMath::float3(min.x, min.y, min.z);
+                    m_BBMax = ZMath::float3(max.x, max.y, max.z);
+
+                    // Extract data
+                    m_Vertices.resize(mainOffsets.position.size);
+                    m_Normals.resize(mainOffsets.normal.size);
+
+                    // Copy vertex-data
+                    memcpy(m_Vertices.data(), &dataPool[mainOffsets.position.offset], sizeof(float) * 3 * mainOffsets.position.size);
+                    memcpy(m_Normals.data(), &dataPool[mainOffsets.normal.offset], sizeof(float) * 3 * mainOffsets.normal.size);
+
+                    // Copy submesh-data
+                    m_SubMeshes.resize(numSubmeshes);
+                    for (uint32_t i = 0; i < numSubmeshes; i++)
+                    {
+                        auto& d = subMeshOffsets[i];
+
+                        m_SubMeshes[i].m_Material = m_Materials[i];
+                        m_SubMeshes[i].m_TriangleList.resize(d.triangleList.size);
+                        m_SubMeshes[i].m_WedgeList.resize(d.wedgeList.size);
+                        m_SubMeshes[i].m_ColorList.resize(d.colorList.size);
+                        m_SubMeshes[i].m_TrianglePlaneIndexList.resize(d.trianglePlaneIndexList.size);
+                        m_SubMeshes[i].m_TrianglePlaneList.resize(d.trianglePlaneList.size);
+                        m_SubMeshes[i].m_TriEdgeList.resize(d.triangleEdgeList.size);
+                        m_SubMeshes[i].m_EdgeList.resize(d.edgeList.size);
+                        m_SubMeshes[i].m_EdgeScoreList.resize(d.edgeScoreList.size);
+                        m_SubMeshes[i].m_WedgeMap.resize(d.wedgeMap.size);
+
+                        if (!m_SubMeshes[i].m_TriangleList.empty())
+                            memcpy(m_SubMeshes[i].m_TriangleList.data(), &dataPool[d.triangleList.offset], sizeof(zTriangle) * d.triangleList.size);
+
+                        if (!m_SubMeshes[i].m_WedgeList.empty())
+                            memcpy(m_SubMeshes[i].m_WedgeList.data(), &dataPool[d.wedgeList.offset], sizeof(zWedge) * d.wedgeList.size);
+
+                        if (!m_SubMeshes[i].m_ColorList.empty())
+                            memcpy(m_SubMeshes[i].m_ColorList.data(), &dataPool[d.colorList.offset], sizeof(float) * d.colorList.size);
+
+                        if (!m_SubMeshes[i].m_TrianglePlaneIndexList.empty())
+                            memcpy(m_SubMeshes[i].m_TrianglePlaneIndexList.data(), &dataPool[d.trianglePlaneIndexList.offset], sizeof(uint16_t) * d.trianglePlaneIndexList.size);
+
+                        if (!m_SubMeshes[i].m_TrianglePlaneList.empty())
+                            memcpy(m_SubMeshes[i].m_TrianglePlaneList.data(), &dataPool[d.trianglePlaneList.offset], sizeof(zTPlane) * d.trianglePlaneList.size);
+
+                        if (!m_SubMeshes[i].m_TriEdgeList.empty())
+                            memcpy(m_SubMeshes[i].m_TriEdgeList.data(), &dataPool[d.triangleEdgeList.offset], sizeof(zTriangleEdges) * d.triangleEdgeList.size);
+
+                        if (!m_SubMeshes[i].m_EdgeList.empty())
+                            memcpy(m_SubMeshes[i].m_EdgeList.data(), &dataPool[d.edgeList.offset], sizeof(zEdge) * d.edgeList.size);
+
+                        if (!m_SubMeshes[i].m_EdgeScoreList.empty())
+                            memcpy(m_SubMeshes[i].m_EdgeScoreList.data(), &dataPool[d.edgeScoreList.offset], sizeof(float) * d.edgeScoreList.size);
+
+                        if (!m_SubMeshes[i].m_WedgeMap.empty())
+                            memcpy(m_SubMeshes[i].m_WedgeMap.data(), &dataPool[d.wedgeMap.offset], sizeof(uint16_t) * d.wedgeMap.size);
+                    }
                 }
 
-                parser.setSeek(p2.getSeek() + parser.getSeek());
+                    parser.setSeek(chunkEnd);
+                    break;
 
-                if (version == zCPROGMESH_FILE_VERS_G2)
-                {
-                    // Read whether we want to have alphatesting
-                    m_IsUsingAlphaTest = parser.readBinaryByte() != 0;
-                }
-                else
-                {
-                    m_IsUsingAlphaTest = false;
-                }
-
-                // Read boundingbox
-                ZMath::float3 min, max;
-                parser.readStructure(min);
-                parser.readStructure(max);
-
-                m_BBMin = ZMath::float3(min.x, min.y, min.z);
-                m_BBMax = ZMath::float3(max.x, max.y, max.z);
-
-                // Extract data
-                m_Vertices.resize(mainOffsets.position.size);
-                m_Normals.resize(mainOffsets.normal.size);
-
-                // Copy vertex-data
-                memcpy(m_Vertices.data(), &dataPool[mainOffsets.position.offset], sizeof(float) * 3 * mainOffsets.position.size);
-                memcpy(m_Normals.data(), &dataPool[mainOffsets.normal.offset], sizeof(float) * 3 * mainOffsets.normal.size);
-
-                // Copy submesh-data
-                m_SubMeshes.resize(numSubmeshes);
-                for (uint32_t i = 0; i < numSubmeshes; i++)
-                {
-                    auto& d = subMeshOffsets[i];
-
-                    m_SubMeshes[i].m_Material = m_Materials[i];
-                    m_SubMeshes[i].m_TriangleList.resize(d.triangleList.size);
-                    m_SubMeshes[i].m_WedgeList.resize(d.wedgeList.size);
-                    m_SubMeshes[i].m_ColorList.resize(d.colorList.size);
-                    m_SubMeshes[i].m_TrianglePlaneIndexList.resize(d.trianglePlaneIndexList.size);
-                    m_SubMeshes[i].m_TrianglePlaneList.resize(d.trianglePlaneList.size);
-                    m_SubMeshes[i].m_TriEdgeList.resize(d.triangleEdgeList.size);
-                    m_SubMeshes[i].m_EdgeList.resize(d.edgeList.size);
-                    m_SubMeshes[i].m_EdgeScoreList.resize(d.edgeScoreList.size);
-                    m_SubMeshes[i].m_WedgeMap.resize(d.wedgeMap.size);
-
-                    if (!m_SubMeshes[i].m_TriangleList.empty())
-                        memcpy(m_SubMeshes[i].m_TriangleList.data(), &dataPool[d.triangleList.offset], sizeof(zTriangle) * d.triangleList.size);
-
-                    if (!m_SubMeshes[i].m_WedgeList.empty())
-                        memcpy(m_SubMeshes[i].m_WedgeList.data(), &dataPool[d.wedgeList.offset], sizeof(zWedge) * d.wedgeList.size);
-
-                    if (!m_SubMeshes[i].m_ColorList.empty())
-                        memcpy(m_SubMeshes[i].m_ColorList.data(), &dataPool[d.colorList.offset], sizeof(float) * d.colorList.size);
-
-                    if (!m_SubMeshes[i].m_TrianglePlaneIndexList.empty())
-                        memcpy(m_SubMeshes[i].m_TrianglePlaneIndexList.data(), &dataPool[d.trianglePlaneIndexList.offset], sizeof(uint16_t) * d.trianglePlaneIndexList.size);
-
-                    if (!m_SubMeshes[i].m_TrianglePlaneList.empty())
-                        memcpy(m_SubMeshes[i].m_TrianglePlaneList.data(), &dataPool[d.trianglePlaneList.offset], sizeof(zTPlane) * d.trianglePlaneList.size);
-
-                    if (!m_SubMeshes[i].m_TriEdgeList.empty())
-                        memcpy(m_SubMeshes[i].m_TriEdgeList.data(), &dataPool[d.triangleEdgeList.offset], sizeof(zTriangleEdges) * d.triangleEdgeList.size);
-
-                    if (!m_SubMeshes[i].m_EdgeList.empty())
-                        memcpy(m_SubMeshes[i].m_EdgeList.data(), &dataPool[d.edgeList.offset], sizeof(zEdge) * d.edgeList.size);
-
-                    if (!m_SubMeshes[i].m_EdgeScoreList.empty())
-                        memcpy(m_SubMeshes[i].m_EdgeScoreList.data(), &dataPool[d.edgeScoreList.offset], sizeof(float) * d.edgeScoreList.size);
-
-                    if (!m_SubMeshes[i].m_WedgeMap.empty())
-                        memcpy(m_SubMeshes[i].m_WedgeMap.data(), &dataPool[d.wedgeMap.offset], sizeof(uint16_t) * d.wedgeMap.size);
-                }
+                case MSID_PROGMESH_END:
+                    doneReadingChunks = true;
+                    break;
+                default:
+                    parser.setSeek(chunkEnd);
             }
-
-                parser.setSeek(chunkEnd);
-                break;
-
-            case MSID_PROGMESH_END:
-                doneReadingChunks = true;
-                break;
-            default:
-                parser.setSeek(chunkEnd);
         }
     }
-}
 
-/**
+    /**
  * @brief Packs vertices only
  */
-void ZenLoad::zCProgMeshProto::packVertices(std::vector<WorldVertex>& vxs, std::vector<uint32_t>& ixs, uint32_t indexStart, std::vector<uint32_t>& submeshIndexStarts, float scale) const
-{
-    for (size_t s = 0; s < m_SubMeshes.size(); s++)
+    void ZenLoad::zCProgMeshProto::packVertices(std::vector<WorldVertex>& vxs, std::vector<uint32_t>& ixs, uint32_t indexStart, std::vector<uint32_t>& submeshIndexStarts, float scale) const
     {
-        const SubMesh& sm = m_SubMeshes[s];
-
-        unsigned int meshVxStart = vxs.size();
-
-        // Get data
-        for (size_t i = 0; i < sm.m_WedgeList.size(); i++)
+        for (size_t s = 0; s < m_SubMeshes.size(); s++)
         {
-            const zWedge& wedge = sm.m_WedgeList[i];
+            const SubMesh& sm = m_SubMeshes[s];
 
-            WorldVertex v;
-            v.Position = m_Vertices[wedge.m_VertexIndex] * scale;
-            v.Normal = wedge.m_Normal;
-            v.TexCoord = wedge.m_Texcoord;
-            //v.TexCoord2 = float2(0,0);
-            v.Color = 0xFFFFFFFF;  // TODO: Apply color from material!
-            vxs.push_back(v);
-        }
+            unsigned int meshVxStart = vxs.size();
 
-        // Mark when the submesh starts
-        submeshIndexStarts.push_back(ixs.size());
-
-        // And get the indices
-        for (size_t i = 0; i < sm.m_TriangleList.size(); i++)
-        {
-            //for(int j=2;j>=0;j--)
-            for (int j = 0; j < 3; j++)
+            // Get data
+            for (size_t i = 0; i < sm.m_WedgeList.size(); i++)
             {
-                ixs.push_back((sm.m_TriangleList[i].m_Wedges[j])  // Take wedge-index of submesh
-                              + indexStart                        // Add our custom offset
-                              + meshVxStart);                     // And add the starting location of the vertices for this submesh
+                const zWedge& wedge = sm.m_WedgeList[i];
+
+                WorldVertex v;
+                v.Position = m_Vertices[wedge.m_VertexIndex] * scale;
+                v.Normal = wedge.m_Normal;
+                v.TexCoord = wedge.m_Texcoord;
+                //v.TexCoord2 = float2(0,0);
+                v.Color = 0xFFFFFFFF;  // TODO: Apply color from material!
+                vxs.push_back(v);
+            }
+
+            // Mark when the submesh starts
+            submeshIndexStarts.push_back(ixs.size());
+
+            // And get the indices
+            for (size_t i = 0; i < sm.m_TriangleList.size(); i++)
+            {
+                //for(int j=2;j>=0;j--)
+                for (int j = 0; j < 3; j++)
+                {
+                    ixs.push_back((sm.m_TriangleList[i].m_Wedges[j])  // Take wedge-index of submesh
+                                  + indexStart                        // Add our custom offset
+                                  + meshVxStart);                     // And add the starting location of the vertices for this submesh
+                }
             }
         }
     }
-}
 
-/**
+    /**
 * @brief Creates packed submesh-data
 */
-void zCProgMeshProto::packMesh(PackedMesh& mesh, float scale) const
-{
-    std::vector<uint32_t> submeshIndexStarts;
-    std::vector<uint32_t> indices;
-    packVertices(mesh.vertices, indices, 0, submeshIndexStarts, scale);
-
-    // Put in all materials. There could be more than there are submeshes for animated textures or headmeshes
-    mesh.subMeshes.resize(std::max(m_Materials.size(), m_SubMeshes.size()));
-    for (size_t i = 0; i < m_SubMeshes.size(); i++)
+    void zCProgMeshProto::packMesh(PackedMesh& mesh, float scale) const
     {
-        auto& sm = mesh.subMeshes[i];
-        sm.material = m_SubMeshes[i].m_Material;
-    }
+        std::vector<uint32_t> submeshIndexStarts;
+        std::vector<uint32_t> indices;
+        packVertices(mesh.vertices, indices, 0, submeshIndexStarts, scale);
 
-    // Create objects for all submeshes
-    for (size_t i = 0; i < m_SubMeshes.size(); i++)
-    {
-        auto& sm = mesh.subMeshes[i];
-
-        // Get indices
-        for (size_t j = submeshIndexStarts[i]; j < submeshIndexStarts[i] + m_SubMeshes[i].m_TriangleList.size() * 3; j++)
+        // Put in all materials. There could be more than there are submeshes for animated textures or headmeshes
+        mesh.subMeshes.resize(std::max(m_Materials.size(), m_SubMeshes.size()));
+        for (size_t i = 0; i < m_SubMeshes.size(); i++)
         {
-            sm.indices.push_back(indices[j]);
+            auto& sm = mesh.subMeshes[i];
+            sm.material = m_SubMeshes[i].m_Material;
         }
-    }
 
-    mesh.bbox[0] = m_BBMin * scale;
-    mesh.bbox[1] = m_BBMax * scale;
-}
+        // Create objects for all submeshes
+        for (size_t i = 0; i < m_SubMeshes.size(); i++)
+        {
+            auto& sm = mesh.subMeshes[i];
+
+            // Get indices
+            for (size_t j = submeshIndexStarts[i]; j < submeshIndexStarts[i] + m_SubMeshes[i].m_TriangleList.size() * 3; j++)
+            {
+                sm.indices.push_back(indices[j]);
+            }
+        }
+
+        mesh.bbox[0] = m_BBMin * scale;
+        mesh.bbox[1] = m_BBMax * scale;
+    }
+}  // namespace ZenLib

--- a/zenload/zCProgMeshProto.h
+++ b/zenload/zCProgMeshProto.h
@@ -3,125 +3,128 @@
 #include "zTypes.h"
 #include "utils/mathlib.h"
 
-namespace VDFS
+namespace ZenLib
 {
-    class FileIndex;
-}
-
-namespace ZenLoad
-{
-    class ZenParser;
-    class zCProgMeshProto
+    namespace VDFS
     {
-    public:
-        struct SubMesh
+        class FileIndex;
+    }
+
+    namespace ZenLoad
+    {
+        class ZenParser;
+        class zCProgMeshProto
         {
-            zCMaterialData m_Material;
-            std::vector<zTriangle> m_TriangleList;
-            std::vector<zWedge> m_WedgeList;
-            std::vector<float> m_ColorList;
-            std::vector<uint16_t> m_TrianglePlaneIndexList;
-            std::vector<zTPlane> m_TrianglePlaneList;
-            std::vector<zTriangleEdges> m_TriEdgeList;
-            std::vector<zEdge> m_EdgeList;
-            std::vector<float> m_EdgeScoreList;
-            std::vector<uint16_t> m_WedgeMap;
-        };
+        public:
+            struct SubMesh
+            {
+                zCMaterialData m_Material;
+                std::vector<zTriangle> m_TriangleList;
+                std::vector<zWedge> m_WedgeList;
+                std::vector<float> m_ColorList;
+                std::vector<uint16_t> m_TrianglePlaneIndexList;
+                std::vector<zTPlane> m_TrianglePlaneList;
+                std::vector<zTriangleEdges> m_TriEdgeList;
+                std::vector<zEdge> m_EdgeList;
+                std::vector<float> m_EdgeScoreList;
+                std::vector<uint16_t> m_WedgeMap;
+            };
 
-        zCProgMeshProto() {}
+            zCProgMeshProto() {}
 
-        /**
+            /**
 		 * @brief Loads the mesh from the given VDF-Archive
 		 */
-        zCProgMeshProto(const std::string& fileName, const VDFS::FileIndex& fileIndex);
+            zCProgMeshProto(const std::string& fileName, const VDFS::FileIndex& fileIndex);
 
-        /**
+            /**
 		 * @brief Reads the mesh-object from the given binary stream
 		 */
-        void readObjectData(ZenParser& parser);
+            void readObjectData(ZenParser& parser);
 
-        /**
+            /**
 		@ brief returns the vector of vertex-positions
 		*/
-        const std::vector<ZMath::float3>& getVertices() const { return m_Vertices; }
+            const std::vector<ZMath::float3>& getVertices() const { return m_Vertices; }
 
-        /**
+            /**
 		@ brief returns the vector of features
 		*/
-        const std::vector<zTMSH_FeatureChunk>& getFeatures() const { return m_Features; }
+            const std::vector<zTMSH_FeatureChunk>& getFeatures() const { return m_Features; }
 
-        /**
+            /**
 		 * @brief returns the vector of the materials used by this mesh
 		 */
-        const std::vector<zCMaterialData>& getMaterials() const { return m_Materials; }
+            const std::vector<zCMaterialData>& getMaterials() const { return m_Materials; }
 
-        /**
+            /**
 		 * @brief getter for the boudingboxes
 		 */
-        void getBoundingBox(ZMath::float3& min, ZMath::float3& max) const
-        {
-            min = m_BBMin;
-            max = m_BBMax;
-        }
+            void getBoundingBox(ZMath::float3& min, ZMath::float3& max) const
+            {
+                min = m_BBMin;
+                max = m_BBMax;
+            }
 
-        /**
+            /**
 		 * @brief Returns the submesh with the given index
 		 */
-        const SubMesh& getSubmesh(size_t idx) const { return m_SubMeshes[idx]; }
-        size_t getNumSubmeshes() const { return m_SubMeshes.size(); }
+            const SubMesh& getSubmesh(size_t idx) const { return m_SubMeshes[idx]; }
+            size_t getNumSubmeshes() const { return m_SubMeshes.size(); }
 
-        /**
+            /**
 		 * @brief Returns the global position-list
 		 */
-        const std::vector<ZMath::float3> getPositionList() const { return m_Vertices; }
+            const std::vector<ZMath::float3> getPositionList() const { return m_Vertices; }
 
-        /**
+            /**
 		* @brief Creates packed submesh-data
 		*/
-        void packMesh(PackedMesh& mesh, float scale = 1.0f) const;
+            void packMesh(PackedMesh& mesh, float scale = 1.0f) const;
 
-        /**
+            /**
 		* @brief Packs vertices only
 		*/
-        void packVertices(std::vector<WorldVertex>& vxs, std::vector<uint32_t>& ixs, uint32_t indexStart, std::vector<uint32_t>& submeshIndexStarts, float scale = 1.0f) const;
+            void packVertices(std::vector<WorldVertex>& vxs, std::vector<uint32_t>& ixs, uint32_t indexStart, std::vector<uint32_t>& submeshIndexStarts, float scale = 1.0f) const;
 
-        /**
+            /**
 		 * @return BBox min/max
 		 */
-        ZMath::float3 getBBoxMin() { return m_BBMin; }
-        ZMath::float3 getBBoxMax() { return m_BBMax; }
+            ZMath::float3 getBBoxMin() { return m_BBMin; }
+            ZMath::float3 getBBoxMax() { return m_BBMax; }
 
-    private:
-        /**
+        private:
+            /**
 		 * @brief vector of vertex-positions for this mesh
 		 */
-        std::vector<ZMath::float3> m_Vertices;
-        std::vector<ZMath::float3> m_Normals;
+            std::vector<ZMath::float3> m_Vertices;
+            std::vector<ZMath::float3> m_Normals;
 
-        /** 
+            /** 
 		 * @brief Featues for the vertices with the corresponding index
 		 */
-        std::vector<zTMSH_FeatureChunk> m_Features;
+            std::vector<zTMSH_FeatureChunk> m_Features;
 
-        /** 
+            /** 
 		* @brief List of submeshes
 		*/
-        std::vector<SubMesh> m_SubMeshes;
+            std::vector<SubMesh> m_SubMeshes;
 
-        /**
+            /**
 		* @brief All materials used by this mesh
 		*/
-        std::vector<zCMaterialData> m_Materials;
+            std::vector<zCMaterialData> m_Materials;
 
-        /**
+            /**
 		 * @brief Whether this mesh is using alphatest
 		 */
-        uint8_t m_IsUsingAlphaTest;
+            uint8_t m_IsUsingAlphaTest;
 
-        /**
+            /**
 		 * @brief Bounding-box of this mesh
 		 */
-        ZMath::float3 m_BBMin;
-        ZMath::float3 m_BBMax;
-    };
-}  // namespace ZenLoad
+            ZMath::float3 m_BBMin;
+            ZMath::float3 m_BBMax;
+        };
+    }  // namespace ZenLoad
+}  // namespace ZenLib

--- a/zenload/zCVob.h
+++ b/zenload/zCVob.h
@@ -3,111 +3,113 @@
 #include "zenParser.h"
 #include "zenParserPropRead.h"
 
-namespace ZenLoad
+namespace ZenLib
 {
-    class zCVob
+    namespace ZenLoad
     {
-#pragma pack(push, 1)
-        struct packedVobData
+        class zCVob
         {
-            ZMath::float3 bbox3DWS[2];
-            ZMath::float3 positionWS;
-            zMAT3 trafoRotWS;
-
-            struct packedBitField
+#pragma pack(push, 1)
+            struct packedVobData
             {
-                uint8_t showVisual : 1;
-                uint8_t visualCamAlign : 2;
-                uint8_t cdStatic : 1;
-                uint8_t cdDyn : 1;
-                uint8_t staticVob : 1;
-                uint8_t dynShadow : 2;
-                uint8_t hasPresetName : 1;
-                uint8_t hasVobName : 1;
-                uint8_t hasVisualName : 1;
-                uint8_t hasRelevantVisualObject : 1;
-                uint8_t hasAIObject : 1;
-                uint8_t hasEventManObject : 1;
-                uint8_t physicsEnabled : 1;
-                uint8_t visualAniMode : 2;
-                uint8_t zbias : 5;
-                uint8_t bAmbient : 1;
-            } bitfield;
+                ZMath::float3 bbox3DWS[2];
+                ZMath::float3 positionWS;
+                zMAT3 trafoRotWS;
 
-            float visualAniStrength;
-            float vobFarClipZ;
-        };
+                struct packedBitField
+                {
+                    uint8_t showVisual : 1;
+                    uint8_t visualCamAlign : 2;
+                    uint8_t cdStatic : 1;
+                    uint8_t cdDyn : 1;
+                    uint8_t staticVob : 1;
+                    uint8_t dynShadow : 2;
+                    uint8_t hasPresetName : 1;
+                    uint8_t hasVobName : 1;
+                    uint8_t hasVisualName : 1;
+                    uint8_t hasRelevantVisualObject : 1;
+                    uint8_t hasAIObject : 1;
+                    uint8_t hasEventManObject : 1;
+                    uint8_t physicsEnabled : 1;
+                    uint8_t visualAniMode : 2;
+                    uint8_t zbias : 5;
+                    uint8_t bAmbient : 1;
+                } bitfield;
+
+                float visualAniStrength;
+                float vobFarClipZ;
+            };
 #pragma pack(pop)
 
-        enum
-        {
-            VERSION_G1_08k = 12289,
-            VERSION_G26fix = 0  // TODO
-        };
+            enum
+            {
+                VERSION_G1_08k = 12289,
+                VERSION_G26fix = 0  // TODO
+            };
 
-    public:
-        /**
+        public:
+            /**
 		* Reads this object from an internal zen
 		*/
-        static void readObjectData(zCVobData& info, ZenParser& parser, WorldVersion version, const ZenParser::ChunkHeader& header)
-        {
-            info.objectClass = "zCVob";
-            info.vobType = zCVobData::VT_zCVob;
-
-            info.rotationMatrix = ZMath::Matrix::CreateIdentity();
-
-            // Read how many vobs this one has as child
-            parser.getImpl()->readEntry("", &info.pack, sizeof(info.pack), ZenLoad::ParserImpl::ZVT_INT);
-
-            if (info.pack)
+            static void readObjectData(zCVobData& info, ZenParser& parser, WorldVersion version, const ZenParser::ChunkHeader& header)
             {
-                packedVobData pd;
-                parser.getImpl()->readEntry("", &pd, sizeof(pd), ZenLoad::ParserImpl::ZVT_RAW);
+                info.objectClass = "zCVob";
+                info.vobType = zCVobData::VT_zCVob;
 
-                info.bbox[0] = pd.bbox3DWS[0];
-                info.bbox[1] = pd.bbox3DWS[1];
-                info.position = pd.positionWS;
-                info.rotationMatrix3x3 = pd.trafoRotWS;
-                info.rotationMatrix = info.rotationMatrix3x3.toMatrix();
-                info.showVisual = pd.bitfield.showVisual;
-                info.visualCamAlign = pd.bitfield.visualCamAlign;
-                info.cdStatic = pd.bitfield.cdStatic;
-                info.cdDyn = pd.bitfield.cdDyn;
-                info.staticVob = pd.bitfield.staticVob;
-                info.dynamicShadow = pd.bitfield.dynShadow;
-                info.physicsEnabled = pd.bitfield.physicsEnabled;
-                info.visualAniMode = pd.bitfield.visualAniMode;
-                info.zBias = pd.bitfield.zbias;
-                info.isAmbient = pd.bitfield.bAmbient;
-                info.visualAniModeStrength = pd.visualAniStrength;
-                info.vobFarClipScale = pd.vobFarClipZ;
+                info.rotationMatrix = ZMath::Matrix::CreateIdentity();
 
-                if (pd.bitfield.hasPresetName)
-                    parser.getImpl()->readEntry("", &info.presetName, 0, ZenLoad::ParserImpl::ZVT_STRING);
+                // Read how many vobs this one has as child
+                parser.getImpl()->readEntry("", &info.pack, sizeof(info.pack), ZenLoad::ParserImpl::ZVT_INT);
 
-                if (pd.bitfield.hasVobName)
-                    parser.getImpl()->readEntry("", &info.vobName, 0, ZenLoad::ParserImpl::ZVT_STRING);
-
-                if (pd.bitfield.hasVisualName)
-                    parser.getImpl()->readEntry("", &info.visual, 0, ZenLoad::ParserImpl::ZVT_STRING);
-
-                if (pd.bitfield.hasRelevantVisualObject)
+                if (info.pack)
                 {
-                    // Skip visual-chunk
-                    ZenParser::ChunkHeader tmph;
-                    parser.readChunkStart(tmph);
-                    parser.skipChunk();
-                }
+                    packedVobData pd;
+                    parser.getImpl()->readEntry("", &pd, sizeof(pd), ZenLoad::ParserImpl::ZVT_RAW);
 
-                if (pd.bitfield.hasAIObject)
-                {
-                    // Skip ai-chunk
-                    ZenParser::ChunkHeader tmph;
-                    parser.readChunkStart(tmph);
-                    parser.skipChunk();
-                }
+                    info.bbox[0] = pd.bbox3DWS[0];
+                    info.bbox[1] = pd.bbox3DWS[1];
+                    info.position = pd.positionWS;
+                    info.rotationMatrix3x3 = pd.trafoRotWS;
+                    info.rotationMatrix = info.rotationMatrix3x3.toMatrix();
+                    info.showVisual = pd.bitfield.showVisual;
+                    info.visualCamAlign = pd.bitfield.visualCamAlign;
+                    info.cdStatic = pd.bitfield.cdStatic;
+                    info.cdDyn = pd.bitfield.cdDyn;
+                    info.staticVob = pd.bitfield.staticVob;
+                    info.dynamicShadow = pd.bitfield.dynShadow;
+                    info.physicsEnabled = pd.bitfield.physicsEnabled;
+                    info.visualAniMode = pd.bitfield.visualAniMode;
+                    info.zBias = pd.bitfield.zbias;
+                    info.isAmbient = pd.bitfield.bAmbient;
+                    info.visualAniModeStrength = pd.visualAniStrength;
+                    info.vobFarClipScale = pd.vobFarClipZ;
 
-                /*info.properties.insert(std::make_pair("PresetName", info.presetName));
+                    if (pd.bitfield.hasPresetName)
+                        parser.getImpl()->readEntry("", &info.presetName, 0, ZenLoad::ParserImpl::ZVT_STRING);
+
+                    if (pd.bitfield.hasVobName)
+                        parser.getImpl()->readEntry("", &info.vobName, 0, ZenLoad::ParserImpl::ZVT_STRING);
+
+                    if (pd.bitfield.hasVisualName)
+                        parser.getImpl()->readEntry("", &info.visual, 0, ZenLoad::ParserImpl::ZVT_STRING);
+
+                    if (pd.bitfield.hasRelevantVisualObject)
+                    {
+                        // Skip visual-chunk
+                        ZenParser::ChunkHeader tmph;
+                        parser.readChunkStart(tmph);
+                        parser.skipChunk();
+                    }
+
+                    if (pd.bitfield.hasAIObject)
+                    {
+                        // Skip ai-chunk
+                        ZenParser::ChunkHeader tmph;
+                        parser.readChunkStart(tmph);
+                        parser.skipChunk();
+                    }
+
+                    /*info.properties.insert(std::make_pair("PresetName", info.presetName));
 				info.properties.insert(std::make_pair("BBoxMin", info.bbox[0].toString()));
 				info.properties.insert(std::make_pair("BBoxMax", info.bbox[1].toString()));
 				info.properties.insert(std::make_pair("RotationMatrix", info.rotationMatrix.toString()));
@@ -125,61 +127,61 @@ namespace ZenLoad
 				info.properties.insert(std::make_pair("DynamicShadow", std::to_string(info.dynamicShadow ? 1 : 0)));
 				info.properties.insert(std::make_pair("zBias", std::to_string(info.zBias)));
 				info.properties.insert(std::make_pair("IsAmbient", std::to_string(info.isAmbient ? 1 : 0)));*/
-            }
-            else
-            {
-                ReadObjectProperties(parser, info.properties,
-                                     Prop("PresetName", info.presetName));
-
-                parser.getImpl()->readEntry("", info.bbox, sizeof(info.bbox), ZenLoad::ParserImpl::ZVT_RAW_FLOAT);
-                parser.getImpl()->readEntry("", &info.rotationMatrix3x3, sizeof(info.rotationMatrix3x3), ZenLoad::ParserImpl::ZVT_RAW);
-
-                parser.getImpl()->readEntry("", &info.position, sizeof(float) * 3, ZenLoad::ParserImpl::ZVT_VEC3);
-
-                info.rotationMatrix = info.rotationMatrix3x3.toMatrix();
-
-                if (version != WorldVersion::VERSION_G1_08k)
-                {
-                    ReadObjectProperties(parser, info.properties,
-                                         Prop("vobName", info.vobName),
-                                         Prop("visual", info.visual),
-                                         Prop("showVisual", info.showVisual),
-                                         Prop("visualCamAlign", info.visualCamAlign),
-                                         Prop("visualAniMode", info.visualAniMode),
-                                         Prop("visualAniModeStrength", info.visualAniModeStrength),
-                                         Prop("vobFarClipZScale", info.vobFarClipScale),
-                                         Prop("cdStatic", info.cdStatic),
-                                         Prop("cdDyn", info.cdDyn),
-                                         Prop("staticVob", info.staticVob),
-                                         Prop("dynShadow", info.dynamicShadow),
-                                         Prop("zBias", info.zBias),
-                                         Prop("isAmbient", info.isAmbient));  // TODO: References!
                 }
                 else
                 {
                     ReadObjectProperties(parser, info.properties,
-                                         Prop("vobName", info.vobName),
-                                         Prop("visual", info.visual),
-                                         Prop("showVisual", info.showVisual),
-                                         Prop("visualCamAlign", info.visualCamAlign),
-                                         Prop("cdStatic", info.cdStatic),
-                                         Prop("cdDyn", info.cdDyn),
-                                         Prop("staticVob", info.staticVob),
-                                         Prop("dynShadow", info.dynamicShadow),
-                                         Prop("visualAniMode", info.visualAniMode));  // TODO: References!
+                                         Prop("PresetName", info.presetName));
+
+                    parser.getImpl()->readEntry("", info.bbox, sizeof(info.bbox), ZenLoad::ParserImpl::ZVT_RAW_FLOAT);
+                    parser.getImpl()->readEntry("", &info.rotationMatrix3x3, sizeof(info.rotationMatrix3x3), ZenLoad::ParserImpl::ZVT_RAW);
+
+                    parser.getImpl()->readEntry("", &info.position, sizeof(float) * 3, ZenLoad::ParserImpl::ZVT_VEC3);
+
+                    info.rotationMatrix = info.rotationMatrix3x3.toMatrix();
+
+                    if (version != WorldVersion::VERSION_G1_08k)
+                    {
+                        ReadObjectProperties(parser, info.properties,
+                                             Prop("vobName", info.vobName),
+                                             Prop("visual", info.visual),
+                                             Prop("showVisual", info.showVisual),
+                                             Prop("visualCamAlign", info.visualCamAlign),
+                                             Prop("visualAniMode", info.visualAniMode),
+                                             Prop("visualAniModeStrength", info.visualAniModeStrength),
+                                             Prop("vobFarClipZScale", info.vobFarClipScale),
+                                             Prop("cdStatic", info.cdStatic),
+                                             Prop("cdDyn", info.cdDyn),
+                                             Prop("staticVob", info.staticVob),
+                                             Prop("dynShadow", info.dynamicShadow),
+                                             Prop("zBias", info.zBias),
+                                             Prop("isAmbient", info.isAmbient));  // TODO: References!
+                    }
+                    else
+                    {
+                        ReadObjectProperties(parser, info.properties,
+                                             Prop("vobName", info.vobName),
+                                             Prop("visual", info.visual),
+                                             Prop("showVisual", info.showVisual),
+                                             Prop("visualCamAlign", info.visualCamAlign),
+                                             Prop("cdStatic", info.cdStatic),
+                                             Prop("cdDyn", info.cdDyn),
+                                             Prop("staticVob", info.staticVob),
+                                             Prop("dynShadow", info.dynamicShadow),
+                                             Prop("visualAniMode", info.visualAniMode));  // TODO: References!
+                    }
+
+                    // Skip visual-chunk
+                    ZenParser::ChunkHeader tmph;
+                    parser.readChunkStart(tmph);
+                    parser.skipChunk();
+
+                    // Skip ai-chunk
+                    parser.readChunkStart(tmph);
+                    parser.skipChunk();
                 }
 
-                // Skip visual-chunk
-                ZenParser::ChunkHeader tmph;
-                parser.readChunkStart(tmph);
-                parser.skipChunk();
-
-                // Skip ai-chunk
-                parser.readChunkStart(tmph);
-                parser.skipChunk();
-            }
-
-            /*// Skip visual-chunk
+                /*// Skip visual-chunk
 			ZenParser::ChunkHeader tmph;
 			parser.readChunkStart(tmph);
 			parser.skipChunk();
@@ -188,114 +190,115 @@ namespace ZenLoad
 			parser.readChunkStart(tmph);
 			parser.skipChunk();*/
 
-            // Check subclasses
-            if (header.classname == "oCItem:zCVob")
-            {
-                info.vobType = zCVobData::VT_oCItem;
-                parser.getImpl()->readEntry("itemInstance", &info.oCItem.instanceName);
-            }
+                // Check subclasses
+                if (header.classname == "oCItem:zCVob")
+                {
+                    info.vobType = zCVobData::VT_oCItem;
+                    parser.getImpl()->readEntry("itemInstance", &info.oCItem.instanceName);
+                }
 
-            if (header.classname.find("oCMOB:") != std::string::npos)
-            {
-                info.vobType = zCVobData::VT_oCMOB;
+                if (header.classname.find("oCMOB:") != std::string::npos)
+                {
+                    info.vobType = zCVobData::VT_oCMOB;
 
-                parser.getImpl()->readEntry("focusName", &info.oCMOB.focusName);
-                parser.getImpl()->readEntry("hitpoints", &info.oCMOB.hitpoints);
-                parser.getImpl()->readEntry("damage", &info.oCMOB.damage);
-                parser.getImpl()->readEntry("moveable", &info.oCMOB.moveable);
-                parser.getImpl()->readEntry("takeable", &info.oCMOB.takeable);
-                parser.getImpl()->readEntry("focusOverride", &info.oCMOB.focusOverride);
-                parser.getImpl()->readEntry("soundMaterial", &info.oCMOB.soundMaterial);
-                parser.getImpl()->readEntry("visualDestroyed", &info.oCMOB.visualDestroyed);
-                parser.getImpl()->readEntry("owner", &info.oCMOB.owner);
-                parser.getImpl()->readEntry("ownerGuild", &info.oCMOB.ownerGuild);
-                parser.getImpl()->readEntry("isDestroyed", &info.oCMOB.isDestroyed);
-            }
+                    parser.getImpl()->readEntry("focusName", &info.oCMOB.focusName);
+                    parser.getImpl()->readEntry("hitpoints", &info.oCMOB.hitpoints);
+                    parser.getImpl()->readEntry("damage", &info.oCMOB.damage);
+                    parser.getImpl()->readEntry("moveable", &info.oCMOB.moveable);
+                    parser.getImpl()->readEntry("takeable", &info.oCMOB.takeable);
+                    parser.getImpl()->readEntry("focusOverride", &info.oCMOB.focusOverride);
+                    parser.getImpl()->readEntry("soundMaterial", &info.oCMOB.soundMaterial);
+                    parser.getImpl()->readEntry("visualDestroyed", &info.oCMOB.visualDestroyed);
+                    parser.getImpl()->readEntry("owner", &info.oCMOB.owner);
+                    parser.getImpl()->readEntry("ownerGuild", &info.oCMOB.ownerGuild);
+                    parser.getImpl()->readEntry("isDestroyed", &info.oCMOB.isDestroyed);
+                }
 
-            if (header.classname.find("oCMobInter:") != std::string::npos)
-            {
-                info.vobType = zCVobData::VT_oCMobInter;
+                if (header.classname.find("oCMobInter:") != std::string::npos)
+                {
+                    info.vobType = zCVobData::VT_oCMobInter;
 
-                /*if(version == WorldVersion::VERSION_G1_08k)
+                    /*if(version == WorldVersion::VERSION_G1_08k)
 				{
 					int32_t tmp;
 					parser.getImpl()->readEntry("state", &tmp);
 					parser.getImpl()->readEntry("stateTarget", &tmp);
 				}*/
 
-                parser.getImpl()->readEntry("stateNum", &info.oCMobInter.stateNum);
-                parser.getImpl()->readEntry("triggerTarget", &info.oCMobInter.triggerTarget);
-                parser.getImpl()->readEntry("useWithItem", &info.oCMobInter.useWithItem);
-                parser.getImpl()->readEntry("conditionFunc", &info.oCMobInter.conditionFunc);
-                parser.getImpl()->readEntry("onStateFunc", &info.oCMobInter.onStateFunc);
-                parser.getImpl()->readEntry("rewind", &info.oCMobInter.rewind);
+                    parser.getImpl()->readEntry("stateNum", &info.oCMobInter.stateNum);
+                    parser.getImpl()->readEntry("triggerTarget", &info.oCMobInter.triggerTarget);
+                    parser.getImpl()->readEntry("useWithItem", &info.oCMobInter.useWithItem);
+                    parser.getImpl()->readEntry("conditionFunc", &info.oCMobInter.conditionFunc);
+                    parser.getImpl()->readEntry("onStateFunc", &info.oCMobInter.onStateFunc);
+                    parser.getImpl()->readEntry("rewind", &info.oCMobInter.rewind);
 
-                if (header.classname.find("oCMobContainer:") != std::string::npos)
-                {
-                    parser.getImpl()->readEntry("locked", &info.oCMobContainer.locked);
-                    parser.getImpl()->readEntry("keyInstance", &info.oCMobContainer.keyInstance);
-                    parser.getImpl()->readEntry("pickLockStr", &info.oCMobContainer.pickLockStr);
-                    parser.getImpl()->readEntry("contains", &info.oCMobContainer.contains);
+                    if (header.classname.find("oCMobContainer:") != std::string::npos)
+                    {
+                        parser.getImpl()->readEntry("locked", &info.oCMobContainer.locked);
+                        parser.getImpl()->readEntry("keyInstance", &info.oCMobContainer.keyInstance);
+                        parser.getImpl()->readEntry("pickLockStr", &info.oCMobContainer.pickLockStr);
+                        parser.getImpl()->readEntry("contains", &info.oCMobContainer.contains);
+                    }
                 }
+                else if (header.classname.find("zCVobLight:") != std::string::npos)
+                {
+                    info.vobType = zCVobData::VT_zCVobLight;
+
+                    parser.getImpl()->readEntry("lightPresetInUse", &info.zCVobLight.lightPresetInUse);
+                    parser.getImpl()->readEntry("lightType", &info.zCVobLight.lightType);
+                    parser.getImpl()->readEntry("range", &info.zCVobLight.range);
+                    parser.getImpl()->readEntry("color", &info.zCVobLight.color);
+                    parser.getImpl()->readEntry("spotConeAngle", &info.zCVobLight.spotConeAngle);
+                    parser.getImpl()->readEntry("lightStatic", &info.zCVobLight.lightStatic);
+                    parser.getImpl()->readEntry("lightQuality", &info.zCVobLight.lightQuality);
+                    parser.getImpl()->readEntry("lensflareFX", &info.zCVobLight.lensflareFX);
+                }
+                else if (header.classname.find("zCVobSound:") != std::string::npos)
+                {
+                    info.vobType = zCVobData::VT_zCVobSound;
+
+                    parser.getImpl()->readEntry("sndVolume", &info.zCVobSound.sndVolume);
+                    parser.getImpl()->readEntry("sndMode", (uint32_t*)&info.zCVobSound.sndType);
+                    parser.getImpl()->readEntry("sndRandDelay", &info.zCVobSound.sndRandDelay);
+                    parser.getImpl()->readEntry("sndRandDelayVar", &info.zCVobSound.sndRandDelayVar);
+                    parser.getImpl()->readEntry("sndStartOn", &info.zCVobSound.sndStartOn);
+                    parser.getImpl()->readEntry("sndAmbient3D", &info.zCVobSound.sndAmbient3D);
+                    parser.getImpl()->readEntry("sndObstruction", &info.zCVobSound.sndObstruction);
+                    parser.getImpl()->readEntry("sndConeAngle", &info.zCVobSound.sndConeAngle);
+                    parser.getImpl()->readEntry("sndVolType", (uint32_t*)&info.zCVobSound.sndVolType);
+                    parser.getImpl()->readEntry("sndRadius", &info.zCVobSound.sndRadius);
+                    parser.getImpl()->readEntry("sndName", &info.zCVobSound.sndName);
+                }
+                else if (header.classname.find("oCZoneMusicDefault:") != std::string::npos)
+                {
+                    info.vobType = zCVobData::VT_oCZoneMusicDefault;
+
+                    parser.getImpl()->readEntry("enabled", &info.oCZoneMusic.enabled);
+                    parser.getImpl()->readEntry("priority", &info.oCZoneMusic.priority);
+                    parser.getImpl()->readEntry("ellipsoid", &info.oCZoneMusic.ellipsoid);
+                    parser.getImpl()->readEntry("reverbLevel", &info.oCZoneMusic.reverbLevel);
+                    parser.getImpl()->readEntry("volumeLevel", &info.oCZoneMusic.volumeLevel);
+                    parser.getImpl()->readEntry("loop", &info.oCZoneMusic.loop);
+                }
+                else if (header.classname.find("oCZoneMusic:") != std::string::npos)
+                {
+                    info.vobType = zCVobData::VT_oCZoneMusic;
+
+                    parser.getImpl()->readEntry("enabled", &info.oCZoneMusic.enabled);
+                    parser.getImpl()->readEntry("priority", &info.oCZoneMusic.priority);
+                    parser.getImpl()->readEntry("ellipsoid", &info.oCZoneMusic.ellipsoid);
+                    parser.getImpl()->readEntry("reverbLevel", &info.oCZoneMusic.reverbLevel);
+                    parser.getImpl()->readEntry("volumeLevel", &info.oCZoneMusic.volumeLevel);
+                    parser.getImpl()->readEntry("loop", &info.oCZoneMusic.loop);
+                }
+
+                parser.skipChunk();
+
+                // Generate world-matrix
+                info.worldMatrix = info.rotationMatrix3x3.toMatrix(info.position);
             }
-            else if (header.classname.find("zCVobLight:") != std::string::npos)
-            {
-                info.vobType = zCVobData::VT_zCVobLight;
 
-                parser.getImpl()->readEntry("lightPresetInUse", &info.zCVobLight.lightPresetInUse);
-                parser.getImpl()->readEntry("lightType", &info.zCVobLight.lightType);
-                parser.getImpl()->readEntry("range", &info.zCVobLight.range);
-                parser.getImpl()->readEntry("color", &info.zCVobLight.color);
-                parser.getImpl()->readEntry("spotConeAngle", &info.zCVobLight.spotConeAngle);
-                parser.getImpl()->readEntry("lightStatic", &info.zCVobLight.lightStatic);
-                parser.getImpl()->readEntry("lightQuality", &info.zCVobLight.lightQuality);
-                parser.getImpl()->readEntry("lensflareFX", &info.zCVobLight.lensflareFX);
-            }
-            else if (header.classname.find("zCVobSound:") != std::string::npos)
-            {
-                info.vobType = zCVobData::VT_zCVobSound;
-
-                parser.getImpl()->readEntry("sndVolume", &info.zCVobSound.sndVolume);
-                parser.getImpl()->readEntry("sndMode", (uint32_t*)&info.zCVobSound.sndType);
-                parser.getImpl()->readEntry("sndRandDelay", &info.zCVobSound.sndRandDelay);
-                parser.getImpl()->readEntry("sndRandDelayVar", &info.zCVobSound.sndRandDelayVar);
-                parser.getImpl()->readEntry("sndStartOn", &info.zCVobSound.sndStartOn);
-                parser.getImpl()->readEntry("sndAmbient3D", &info.zCVobSound.sndAmbient3D);
-                parser.getImpl()->readEntry("sndObstruction", &info.zCVobSound.sndObstruction);
-                parser.getImpl()->readEntry("sndConeAngle", &info.zCVobSound.sndConeAngle);
-                parser.getImpl()->readEntry("sndVolType", (uint32_t*)&info.zCVobSound.sndVolType);
-                parser.getImpl()->readEntry("sndRadius", &info.zCVobSound.sndRadius);
-                parser.getImpl()->readEntry("sndName", &info.zCVobSound.sndName);
-            }
-            else if (header.classname.find("oCZoneMusicDefault:") != std::string::npos)
-            {
-                info.vobType = zCVobData::VT_oCZoneMusicDefault;
-
-                parser.getImpl()->readEntry("enabled", &info.oCZoneMusic.enabled);
-                parser.getImpl()->readEntry("priority", &info.oCZoneMusic.priority);
-                parser.getImpl()->readEntry("ellipsoid", &info.oCZoneMusic.ellipsoid);
-                parser.getImpl()->readEntry("reverbLevel", &info.oCZoneMusic.reverbLevel);
-                parser.getImpl()->readEntry("volumeLevel", &info.oCZoneMusic.volumeLevel);
-                parser.getImpl()->readEntry("loop", &info.oCZoneMusic.loop);
-            }
-            else if (header.classname.find("oCZoneMusic:") != std::string::npos)
-            {
-                info.vobType = zCVobData::VT_oCZoneMusic;
-
-                parser.getImpl()->readEntry("enabled", &info.oCZoneMusic.enabled);
-                parser.getImpl()->readEntry("priority", &info.oCZoneMusic.priority);
-                parser.getImpl()->readEntry("ellipsoid", &info.oCZoneMusic.ellipsoid);
-                parser.getImpl()->readEntry("reverbLevel", &info.oCZoneMusic.reverbLevel);
-                parser.getImpl()->readEntry("volumeLevel", &info.oCZoneMusic.volumeLevel);
-                parser.getImpl()->readEntry("loop", &info.oCZoneMusic.loop);
-            }
-
-            parser.skipChunk();
-
-            // Generate world-matrix
-            info.worldMatrix = info.rotationMatrix3x3.toMatrix(info.position);
-        }
-
-    private:
-    };
-}  // namespace ZenLoad
+        private:
+        };
+    }  // namespace ZenLoad
+}  // namespace ZenLib

--- a/zenload/zCWayNet.h
+++ b/zenload/zCWayNet.h
@@ -4,116 +4,119 @@
 #include "zenParser.h"
 #include "utils/logger.h"
 
-namespace ZenLoad
+namespace ZenLib
 {
-    class zCWayNet
+    namespace ZenLoad
     {
-    public:
-        /**
+        class zCWayNet
+        {
+        public:
+            /**
          * Reads a single waypoint
          */
-        static zCWaypointData readWaypoint(ZenParser& parser)
-        {
-            zCWaypointData info;
+            static zCWaypointData readWaypoint(ZenParser& parser)
+            {
+                zCWaypointData info;
 
-            parser.getImpl()->readEntry("wpName", &info.wpName);
-            parser.getImpl()->readEntry("waterDepth", &info.waterDepth);
-            parser.getImpl()->readEntry("underWater", &info.underWater);
-            parser.getImpl()->readEntry("position", &info.position);
-            parser.getImpl()->readEntry("direction", &info.direction);
+                parser.getImpl()->readEntry("wpName", &info.wpName);
+                parser.getImpl()->readEntry("waterDepth", &info.waterDepth);
+                parser.getImpl()->readEntry("underWater", &info.underWater);
+                parser.getImpl()->readEntry("position", &info.position);
+                parser.getImpl()->readEntry("direction", &info.direction);
 
-            return info;
-        }
+                return info;
+            }
 
-        /**
+            /**
          * Reads this object from an internal zen
          */
-        static void readObjectData(zCWayNetData& info, ZenParser& parser)
-        {
-            ZenParser::ChunkHeader waynetHeader;
-            parser.readChunkStart(waynetHeader);
-
-            ReadObjectProperties(parser, info.properties,
-                                 Prop("waynetVersion", info.waynetVersion));
-
-            if (info.waynetVersion == 0)
+            static void readObjectData(zCWayNetData& info, ZenParser& parser)
             {
-                // TODO: Implement old waynet format
-                LogWarn() << "Old waynet-format not yet supported!";
-                return;
-            }
+                ZenParser::ChunkHeader waynetHeader;
+                parser.readChunkStart(waynetHeader);
 
-            // First, read the waypoints array
-            uint32_t numWaypoints;
-            parser.getImpl()->readEntry("numWaypoints", &numWaypoints, sizeof(numWaypoints), ParserImpl::ZVT_INT);
+                ReadObjectProperties(parser, info.properties,
+                                     Prop("waynetVersion", info.waynetVersion));
 
-            LogInfo() << "Loading " << numWaypoints << " freepoints";
+                if (info.waynetVersion == 0)
+                {
+                    // TODO: Implement old waynet format
+                    LogWarn() << "Old waynet-format not yet supported!";
+                    return;
+                }
 
-            std::map<uint32_t, size_t> wpRefMap;
-            for (uint32_t i = 0; i < numWaypoints; i++)
-            {
-                ZenParser::ChunkHeader wph;
+                // First, read the waypoints array
+                uint32_t numWaypoints;
+                parser.getImpl()->readEntry("numWaypoints", &numWaypoints, sizeof(numWaypoints), ParserImpl::ZVT_INT);
 
-                // These are always new ones
-                parser.readChunkStart(wph);
-                zCWaypointData w = readWaypoint(parser);
-                w.objectClass = wph.classname;
-                info.waypoints.push_back(w);
+                LogInfo() << "Loading " << numWaypoints << " freepoints";
 
-                parser.readChunkEnd();
-
-                // Save for later access
-                wpRefMap[wph.objectID] = info.waypoints.size() - 1;
-            }
-
-            // Then, the edges (ways)
-            uint32_t numWays;
-            parser.getImpl()->readEntry("numWays", &numWays, sizeof(numWays), ParserImpl::ZVT_INT);
-
-            LogInfo() << "Loading " << numWays << " edges";
-
-            for (uint32_t i = 0; i < numWays; i++)
-            {
-                size_t wp1, wp2;
-
-                size_t* tgt = &wp1;
-                for (int j = 0; j < 2; j++)
+                std::map<uint32_t, size_t> wpRefMap;
+                for (uint32_t i = 0; i < numWaypoints; i++)
                 {
                     ZenParser::ChunkHeader wph;
 
-                    // References might occur here
+                    // These are always new ones
                     parser.readChunkStart(wph);
-
-                    // Loading a reference?
-                    if (wph.classname.empty())
-                    {
-                        *tgt = wpRefMap[wph.objectID];
-                    }
-                    else
-                    {
-                        // Create new waypoint
-                        zCWaypointData w = readWaypoint(parser);
-                        w.objectClass = wph.classname;
-                        info.waypoints.push_back(w);
-
-                        // Save for later access
-                        wpRefMap[wph.objectID] = info.waypoints.size() - 1;
-                        *tgt = info.waypoints.size() - 1;
-                    }
+                    zCWaypointData w = readWaypoint(parser);
+                    w.objectClass = wph.classname;
+                    info.waypoints.push_back(w);
 
                     parser.readChunkEnd();
 
-                    tgt = &wp2;
+                    // Save for later access
+                    wpRefMap[wph.objectID] = info.waypoints.size() - 1;
                 }
-                info.edges.emplace_back(wp1, wp2);
+
+                // Then, the edges (ways)
+                uint32_t numWays;
+                parser.getImpl()->readEntry("numWays", &numWays, sizeof(numWays), ParserImpl::ZVT_INT);
+
+                LogInfo() << "Loading " << numWays << " edges";
+
+                for (uint32_t i = 0; i < numWays; i++)
+                {
+                    size_t wp1, wp2;
+
+                    size_t* tgt = &wp1;
+                    for (int j = 0; j < 2; j++)
+                    {
+                        ZenParser::ChunkHeader wph;
+
+                        // References might occur here
+                        parser.readChunkStart(wph);
+
+                        // Loading a reference?
+                        if (wph.classname.empty())
+                        {
+                            *tgt = wpRefMap[wph.objectID];
+                        }
+                        else
+                        {
+                            // Create new waypoint
+                            zCWaypointData w = readWaypoint(parser);
+                            w.objectClass = wph.classname;
+                            info.waypoints.push_back(w);
+
+                            // Save for later access
+                            wpRefMap[wph.objectID] = info.waypoints.size() - 1;
+                            *tgt = info.waypoints.size() - 1;
+                        }
+
+                        parser.readChunkEnd();
+
+                        tgt = &wp2;
+                    }
+                    info.edges.emplace_back(wp1, wp2);
+                }
+
+                LogInfo() << "Done loading edges!";
+
+                parser.readChunkEnd();
             }
 
-            LogInfo() << "Done loading edges!";
+        private:
+        };
 
-            parser.readChunkEnd();
-        }
-
-    private:
-    };
-
-}  // namespace ZenLoad
+    }  // namespace ZenLoad
+}  // namespace ZenLib

--- a/zenload/zTypes.h
+++ b/zenload/zTypes.h
@@ -5,375 +5,377 @@
 #include <inttypes.h>
 #include "utils/mathlib.h"
 
-namespace ZenLoad
+namespace ZenLib
 {
-    enum class WorldVersion
+    namespace ZenLoad
     {
-        VERSION_G1_08k = 1,
-        VERSION_G26fix = 2
-    };
+        enum class WorldVersion
+        {
+            VERSION_G1_08k = 1,
+            VERSION_G26fix = 2
+        };
 
-    /**
+        /**
 	 * Used by zCVobSound
 	 */
-    enum SoundMode : uint32_t
-    {
-        SM_LOOPING,
-        SM_ONCE,
-        SM_RANDOM
-    };
+        enum SoundMode : uint32_t
+        {
+            SM_LOOPING,
+            SM_ONCE,
+            SM_RANDOM
+        };
 
-    /**
+        /**
 	 * Used by zCVobSound
 	 */
-    enum SoundVolType
-    {
-        SVT_SPHERE = 0,
-        SVT_ELLIPSOID
-    };
+        enum SoundVolType
+        {
+            SVT_SPHERE = 0,
+            SVT_ELLIPSOID
+        };
 
-    /**
+        /**
 	 * @brief Maximum amount of nodes a skeletal mesh can render
 	 */
-    const size_t MAX_NUM_SKELETAL_NODES = 96;
+        const size_t MAX_NUM_SKELETAL_NODES = 96;
 
-    struct WorldVertex
-    {
-        ZMath::float3 Position;
-        ZMath::float3 Normal;
-        ZMath::float2 TexCoord;
-        uint32_t Color;
-    };
-
-    struct SkeletalVertex
-    {
-        ZMath::float3 Normal;
-        ZMath::float2 TexCoord;
-        uint32_t Color;
-        ZMath::float3 LocalPositions[4];
-        unsigned char BoneIndices[4];
-        float Weights[4];
-    };
-
-    struct zMAT3
-    {
-        float v[3][3];
-
-        ZMath::float3 getUpVector() const { return ZMath::float3(v[0][1], v[1][1], v[2][1]); };
-        ZMath::float3 getRightVector() const { return ZMath::float3(v[0][0], v[1][0], v[2][0]); };
-        ZMath::float3 getAtVector() const { return ZMath::float3(v[0][2], v[1][2], v[2][2]); };
-
-        void setAtVector(const ZMath::float3& a)
+        struct WorldVertex
         {
-            v[0][2] = a.x;
-            v[1][2] = a.y;
-            v[2][2] = a.z;
-        }
-        void setUpVector(const ZMath::float3& a)
+            ZMath::float3 Position;
+            ZMath::float3 Normal;
+            ZMath::float2 TexCoord;
+            uint32_t Color;
+        };
+
+        struct SkeletalVertex
         {
-            v[0][1] = a.x;
-            v[1][1] = a.y;
-            v[2][1] = a.z;
-        }
-        void setRightVector(const ZMath::float3& a)
+            ZMath::float3 Normal;
+            ZMath::float2 TexCoord;
+            uint32_t Color;
+            ZMath::float3 LocalPositions[4];
+            unsigned char BoneIndices[4];
+            float Weights[4];
+        };
+
+        struct zMAT3
         {
-            v[0][0] = a.x;
-            v[1][0] = a.y;
-            v[2][0] = a.z;
-        }
+            float v[3][3];
 
-        ZMath::Matrix toMatrix(const ZMath::float3& position = ZMath::float3(0, 0, 0)) const
-        {
-            ZMath::Matrix m = ZMath::Matrix::CreateIdentity();
-            m.Up(getUpVector());
+            ZMath::float3 getUpVector() const { return ZMath::float3(v[0][1], v[1][1], v[2][1]); };
+            ZMath::float3 getRightVector() const { return ZMath::float3(v[0][0], v[1][0], v[2][0]); };
+            ZMath::float3 getAtVector() const { return ZMath::float3(v[0][2], v[1][2], v[2][2]); };
 
-            ZMath::float3 fwd = getAtVector();
-            fwd.x *= -1.0f;
-            fwd.y *= -1.0f;
-            fwd.z *= -1.0f;
+            void setAtVector(const ZMath::float3& a)
+            {
+                v[0][2] = a.x;
+                v[1][2] = a.y;
+                v[2][2] = a.z;
+            }
+            void setUpVector(const ZMath::float3& a)
+            {
+                v[0][1] = a.x;
+                v[1][1] = a.y;
+                v[2][1] = a.z;
+            }
+            void setRightVector(const ZMath::float3& a)
+            {
+                v[0][0] = a.x;
+                v[1][0] = a.y;
+                v[2][0] = a.z;
+            }
 
-            m.Forward(fwd);
-            m.Right(getRightVector());
-            m.Translation(position);
+            ZMath::Matrix toMatrix(const ZMath::float3& position = ZMath::float3(0, 0, 0)) const
+            {
+                ZMath::Matrix m = ZMath::Matrix::CreateIdentity();
+                m.Up(getUpVector());
 
-            return m;
-        }
-    };
+                ZMath::float3 fwd = getAtVector();
+                fwd.x *= -1.0f;
+                fwd.y *= -1.0f;
+                fwd.z *= -1.0f;
 
-    /**
+                m.Forward(fwd);
+                m.Right(getRightVector());
+                m.Translation(position);
+
+                return m;
+            }
+        };
+
+        /**
 	 * @brief Base for an object parsed from a zen-file.
 	 *		  Contains a map of all properties and their values as text
 	 */
-    struct ParsedZenObject
-    {
-        std::unordered_map<std::string, std::string> properties;
-        std::string objectClass;
-    };
+        struct ParsedZenObject
+        {
+            std::unordered_map<std::string, std::string> properties;
+            std::string objectClass;
+        };
 
-    /**
+        /**
 	* @brief All kinds of information found in a zCMaterial
 	*/
-    struct zCMaterialData : public ParsedZenObject
-    {
-        std::string matName;
-        uint8_t matGroup;
-        uint32_t color;
-        float smoothAngle;
-        std::string texture;
-        std::string texScale;
-        float texAniFPS;
-        uint8_t texAniMapMode;
-        std::string texAniMapDir;
-        bool noCollDet;
-        bool noLighmap;
-        uint8_t loadDontCollapse;
-        std::string detailObject;
-        float detailTextureScale;
-        uint8_t forceOccluder;
-        uint8_t environmentMapping;
-        float environmentalMappingStrength;
-        uint8_t waveMode;
-        uint8_t waveSpeed;
-        float waveMaxAmplitude;
-        float waveGridSize;
-        uint8_t ignoreSun;
-        uint8_t alphaFunc;
-        ZMath::float2 defaultMapping;
-    };
+        struct zCMaterialData : public ParsedZenObject
+        {
+            std::string matName;
+            uint8_t matGroup;
+            uint32_t color;
+            float smoothAngle;
+            std::string texture;
+            std::string texScale;
+            float texAniFPS;
+            uint8_t texAniMapMode;
+            std::string texAniMapDir;
+            bool noCollDet;
+            bool noLighmap;
+            uint8_t loadDontCollapse;
+            std::string detailObject;
+            float detailTextureScale;
+            uint8_t forceOccluder;
+            uint8_t environmentMapping;
+            float environmentalMappingStrength;
+            uint8_t waveMode;
+            uint8_t waveSpeed;
+            float waveMaxAmplitude;
+            float waveGridSize;
+            uint8_t ignoreSun;
+            uint8_t alphaFunc;
+            ZMath::float2 defaultMapping;
+        };
 
-    struct zCVisualData : public ParsedZenObject
-    {
-    };
+        struct zCVisualData : public ParsedZenObject
+        {
+        };
 
-    struct zCAIBaseData : public ParsedZenObject
-    {
-    };
+        struct zCAIBaseData : public ParsedZenObject
+        {
+        };
 
-    struct zCEventManagerData : public ParsedZenObject
-    {
-    };
+        struct zCEventManagerData : public ParsedZenObject
+        {
+        };
 
-    //#pragma pack(push, 1)
-    /**
+        //#pragma pack(push, 1)
+        /**
 	 * @brief Data of zCVob
 	 */
-    struct zCVobData : public ParsedZenObject
-    {
-        enum EVobType
+        struct zCVobData : public ParsedZenObject
         {
-            VT_zCVob,
-            VT_oCItem,
-            VT_oCMOB,
-            VT_oCMobInter,
-            VT_oCMobContainer,
-            VT_zCVobLight,
-            VT_zCVobSound,
-            VT_oCZoneMusic,
-            VT_oCZoneMusicDefault,
+            enum EVobType
+            {
+                VT_zCVob,
+                VT_oCItem,
+                VT_oCMOB,
+                VT_oCMobInter,
+                VT_oCMobContainer,
+                VT_zCVobLight,
+                VT_zCVobSound,
+                VT_oCZoneMusic,
+                VT_oCZoneMusicDefault,
+            };
+
+            EVobType vobType;
+
+            uint32_t pack;
+            std::string presetName;
+            ZMath::float3 bbox[2];
+            ZMath::Matrix rotationMatrix;
+            zMAT3 rotationMatrix3x3;
+            ZMath::Matrix worldMatrix;
+            ZMath::float3 position;
+            std::string vobName;
+            std::string visual;
+            bool showVisual;
+            uint8_t visualCamAlign;
+            uint8_t visualAniMode;
+            float visualAniModeStrength;
+            float vobFarClipScale;
+            bool cdStatic;
+            bool cdDyn;
+            bool staticVob;
+            uint8_t dynamicShadow;
+            int32_t zBias;
+            bool isAmbient;
+
+            // References
+            size_t visualReference;
+            size_t aiReference;
+            size_t eventMgrReference;
+
+            bool physicsEnabled;
+
+            // Sub-classes
+            struct
+            {
+                std::string instanceName;
+            } oCItem;
+
+            struct
+            {
+                std::string focusName;
+                int32_t hitpoints;
+                int32_t damage;
+                bool moveable;
+                bool takeable;
+                bool focusOverride;
+                uint8_t soundMaterial;
+                std::string visualDestroyed;
+                std::string owner;
+                std::string ownerGuild;
+                bool isDestroyed;
+            } oCMOB;
+
+            struct
+            {
+                int stateNum;
+                std::string triggerTarget;
+                std::string useWithItem;
+                std::string conditionFunc;
+                std::string onStateFunc;
+                bool rewind;
+            } oCMobInter;
+
+            struct
+            {
+                bool locked;
+                std::string keyInstance;
+                std::string pickLockStr;
+                std::string contains;
+            } oCMobContainer;
+
+            struct
+            {
+                std::string lightPresetInUse;
+                uint32_t lightType;
+                float range;
+                uint32_t color;
+                float spotConeAngle;
+                bool lightStatic;
+                uint32_t lightQuality;
+                std::string lensflareFX;
+            } zCVobLight;
+
+            struct
+            {
+                float sndVolume;
+                SoundMode sndType;
+                float sndRandDelay;
+                float sndRandDelayVar;
+                bool sndStartOn;
+                bool sndAmbient3D;
+                bool sndObstruction;
+                float sndConeAngle;
+                SoundVolType sndVolType;
+                float sndRadius;
+                std::string sndName;
+            } zCVobSound;
+
+            struct
+            {
+                bool enabled;
+                uint32_t priority;
+                bool ellipsoid;
+                float reverbLevel;
+                float volumeLevel;
+                bool loop;
+            } oCZoneMusic;
+
+            std::vector<zCVobData> childVobs;
         };
 
-        EVobType vobType;
-
-        uint32_t pack;
-        std::string presetName;
-        ZMath::float3 bbox[2];
-        ZMath::Matrix rotationMatrix;
-        zMAT3 rotationMatrix3x3;
-        ZMath::Matrix worldMatrix;
-        ZMath::float3 position;
-        std::string vobName;
-        std::string visual;
-        bool showVisual;
-        uint8_t visualCamAlign;
-        uint8_t visualAniMode;
-        float visualAniModeStrength;
-        float vobFarClipScale;
-        bool cdStatic;
-        bool cdDyn;
-        bool staticVob;
-        uint8_t dynamicShadow;
-        int32_t zBias;
-        bool isAmbient;
-
-        // References
-        size_t visualReference;
-        size_t aiReference;
-        size_t eventMgrReference;
-
-        bool physicsEnabled;
-
-        // Sub-classes
-        struct
+        struct zCBspNode
         {
-            std::string instanceName;
-        } oCItem;
+            enum : size_t
+            {
+                INVALID_NODE = static_cast<size_t>(-1)
+            };
 
-        struct
-        {
-            std::string focusName;
-            int32_t hitpoints;
-            int32_t damage;
-            bool moveable;
-            bool takeable;
-            bool focusOverride;
-            uint8_t soundMaterial;
-            std::string visualDestroyed;
-            std::string owner;
-            std::string ownerGuild;
-            bool isDestroyed;
-        } oCMOB;
+            ZMath::float4 plane;
+            size_t front, back;
+            size_t parent;
 
-        struct
-        {
-            int stateNum;
-            std::string triggerTarget;
-            std::string useWithItem;
-            std::string conditionFunc;
-            std::string onStateFunc;
-            bool rewind;
-        } oCMobInter;
+            ZMath::float3 bbox3dMin, bbox3dMax;
 
-        struct
-        {
-            bool locked;
-            std::string keyInstance;
-            std::string pickLockStr;
-            std::string contains;
-        } oCMobContainer;
+            size_t treePolyIndex;
+            size_t numPolys;
 
-        struct
-        {
-            std::string lightPresetInUse;
-            uint32_t lightType;
-            float range;
-            uint32_t color;
-            float spotConeAngle;
-            bool lightStatic;
-            uint32_t lightQuality;
-            std::string lensflareFX;
-        } zCVobLight;
-
-        struct
-        {
-            float sndVolume;
-            SoundMode sndType;
-            float sndRandDelay;
-            float sndRandDelayVar;
-            bool sndStartOn;
-            bool sndAmbient3D;
-            bool sndObstruction;
-            float sndConeAngle;
-            SoundVolType sndVolType;
-            float sndRadius;
-            std::string sndName;
-        } zCVobSound;
-
-        struct
-        {
-            bool enabled;
-            uint32_t priority;
-            bool ellipsoid;
-            float reverbLevel;
-            float volumeLevel;
-            bool loop;
-        } oCZoneMusic;
-
-        std::vector<zCVobData> childVobs;
-    };
-
-    struct zCBspNode
-    {
-        enum : size_t
-        {
-            INVALID_NODE = static_cast<size_t>(-1)
+            bool isLeaf()
+            {
+                return front == INVALID_NODE && back == INVALID_NODE;
+            }
         };
 
-        ZMath::float4 plane;
-        size_t front, back;
-        size_t parent;
-
-        ZMath::float3 bbox3dMin, bbox3dMax;
-
-        size_t treePolyIndex;
-        size_t numPolys;
-
-        bool isLeaf()
+        struct zCBspTreeData
         {
-            return front == INVALID_NODE && back == INVALID_NODE;
-        }
-    };
+            enum TreeMode
+            {
+                Indoor = 0,
+                Outdoor = 1
+            };
 
-    struct zCBspTreeData
-    {
-        enum TreeMode
-        {
-            Indoor = 0,
-            Outdoor = 1
-        };
-
-        /**
+            /**
 		 * Whether this tree is an indoor or outdoor location
 		 */
-        TreeMode mode;
+            TreeMode mode;
 
-        std::vector<zCBspNode> nodes;
-        std::vector<uint32_t> leafIndices;
-        std::vector<uint32_t> treePolyIndices;
-    };
-
-    struct zCBspTreeData2
-    {
-        enum TreeMode
-        {
-            Indoor = 0,
-            Outdoor = 1
+            std::vector<zCBspNode> nodes;
+            std::vector<uint32_t> leafIndices;
+            std::vector<uint32_t> treePolyIndices;
         };
 
-        /**
+        struct zCBspTreeData2
+        {
+            enum TreeMode
+            {
+                Indoor = 0,
+                Outdoor = 1
+            };
+
+            /**
 		 * Whether this tree is an indoor or outdoor location
 		 */
-        TreeMode mode;
+            TreeMode mode;
 
-        std::vector<zCBspNode> nodes;
-        std::vector<uint8_t> leafIndices;
-        std::vector<uint16_t> treePolyIndices;
-    };
-    //#pragma pack(pop)
+            std::vector<zCBspNode> nodes;
+            std::vector<uint8_t> leafIndices;
+            std::vector<uint16_t> treePolyIndices;
+        };
+        //#pragma pack(pop)
 
-    struct oCMsgConversationData : public ParsedZenObject
-    {
-        uint8_t subType;
-        std::string text;
-        std::string name;
-    };
+        struct oCMsgConversationData : public ParsedZenObject
+        {
+            uint8_t subType;
+            std::string text;
+            std::string name;
+        };
 
-    struct zCCSRoleData : public ParsedZenObject
-    {
-        bool mustBeAlive;
-        std::string roleName;
-        uint8_t roleType;
-    };
+        struct zCCSRoleData : public ParsedZenObject
+        {
+            bool mustBeAlive;
+            std::string roleName;
+            uint8_t roleType;
+        };
 
-    struct zCCSBlockSyncData : public ParsedZenObject
-    {
-        std::vector<uint32_t> roleAss;
-    };
+        struct zCCSBlockSyncData : public ParsedZenObject
+        {
+            std::vector<uint32_t> roleAss;
+        };
 
-    struct zCCSAtomicBlockData : public ParsedZenObject
-    {
-        oCMsgConversationData command;
-    };
+        struct zCCSAtomicBlockData : public ParsedZenObject
+        {
+            oCMsgConversationData command;
+        };
 
-    struct zCCSBlockData : public ParsedZenObject
-    {
-        std::string blockName;
+        struct zCCSBlockData : public ParsedZenObject
+        {
+            std::string blockName;
 
-        // This structure is different in the original files, but this is the only
-        // configuration happening while loading
-        zCCSAtomicBlockData atomicBlockData;
-    };
+            // This structure is different in the original files, but this is the only
+            // configuration happening while loading
+            zCCSAtomicBlockData atomicBlockData;
+        };
 
-    /*struct zCCutsceneData
+        /*struct zCCutsceneData
 	{
 		zCCSPropsData props;
 		std::vector<zCCSRoleData> roles;
@@ -381,189 +383,189 @@ namespace ZenLoad
 		zCVobData mainRoleVob;
 	};*/
 
-    /*struct zCEventManagerData
+        /*struct zCEventManagerData
 	{
 		bool cleared;
 		bool active;
 		zCCutsceneData cutsceneData;
 	};*/
 
-    struct zCCSLibData : public ParsedZenObject
-    {
-        std::vector<zCCSAtomicBlockData> blocks;  // Gothic is only using atomic blocks, as it seems
-    };
+        struct zCCSLibData : public ParsedZenObject
+        {
+            std::vector<zCCSAtomicBlockData> blocks;  // Gothic is only using atomic blocks, as it seems
+        };
 
-    struct zCWaypointData : public ParsedZenObject
-    {
-        std::string wpName;
-        int32_t waterDepth;
-        bool underWater;
-        ZMath::float3 position;
-        ZMath::float3 direction;
-    };
+        struct zCWaypointData : public ParsedZenObject
+        {
+            std::string wpName;
+            int32_t waterDepth;
+            bool underWater;
+            ZMath::float3 position;
+            ZMath::float3 direction;
+        };
 
-    struct zCWayNetData : public ParsedZenObject
-    {
-        uint32_t waynetVersion;
-        std::vector<zCWaypointData> waypoints;
-        std::vector<std::pair<size_t, size_t>> edges;
-    };
+        struct zCWayNetData : public ParsedZenObject
+        {
+            uint32_t waynetVersion;
+            std::vector<zCWaypointData> waypoints;
+            std::vector<std::pair<size_t, size_t>> edges;
+        };
 
-    /**
+        /**
 	* @brief All kinds of information found in a oCWorld
 	*/
-    struct oCWorldData : public ParsedZenObject
-    {
-        std::vector<zCVobData> rootVobs;
-        zCWayNetData waynet;
-        zCBspTreeData bspTree;
-        size_t numVobsTotal;
-    };
+        struct oCWorldData : public ParsedZenObject
+        {
+            std::vector<zCVobData> rootVobs;
+            zCWayNetData waynet;
+            zCBspTreeData bspTree;
+            size_t numVobsTotal;
+        };
 
 #pragma pack(push, 1)
-    // Information about the whole file we are reading here
-    struct BinaryFileInfo
-    {
-        uint32_t version;
-        uint32_t size;
-    };
+        // Information about the whole file we are reading here
+        struct BinaryFileInfo
+        {
+            uint32_t version;
+            uint32_t size;
+        };
 
-    // Information about a single chunk
-    struct BinaryChunkInfo
-    {
-        uint16_t id;
-        uint32_t length;
-    };
+        // Information about a single chunk
+        struct BinaryChunkInfo
+        {
+            uint16_t id;
+            uint32_t length;
+        };
 
-    /**
+        /**
 	 * @brief Merged flags-struct to contain all flags from all versions of the files
 	 */
-    struct PolyFlags
-    {
-        uint8_t portalPoly : 2;
-        uint8_t occluder : 1;
-        uint8_t sectorPoly : 1;
-        uint8_t mustRelight : 1;
-        uint8_t portalIndoorOutdoor : 1;
-        uint8_t ghostOccluder : 1;
-        uint8_t noDynLightNear : 1;
-        uint16_t sectorIndex : 16;
-        uint8_t lodFlag : 1;
-        uint8_t normalMainAxis : 2;
-    };
-
-    struct PolyFlags2_6fix
-    {
-        uint8_t portalPoly : 2;
-        uint8_t occluder : 1;
-        uint8_t sectorPoly : 1;
-        uint8_t mustRelight : 1;
-        uint8_t portalIndoorOutdoor : 1;
-        uint8_t ghostOccluder : 1;
-        uint8_t noDynLightNear : 1;
-        uint16_t sectorIndex : 16;
-
-        PolyFlags2_6fix() {}
-        PolyFlags2_6fix(const PolyFlags& p)
+        struct PolyFlags
         {
-            portalPoly = p.portalPoly;
-            occluder = p.occluder;
-            sectorPoly = p.sectorPoly;
-            mustRelight = p.mustRelight;
-            portalIndoorOutdoor = p.portalIndoorOutdoor;
-            ghostOccluder = p.ghostOccluder;
-            noDynLightNear = p.noDynLightNear;
-            sectorIndex = p.sectorIndex;
-        }
+            uint8_t portalPoly : 2;
+            uint8_t occluder : 1;
+            uint8_t sectorPoly : 1;
+            uint8_t mustRelight : 1;
+            uint8_t portalIndoorOutdoor : 1;
+            uint8_t ghostOccluder : 1;
+            uint8_t noDynLightNear : 1;
+            uint16_t sectorIndex : 16;
+            uint8_t lodFlag : 1;
+            uint8_t normalMainAxis : 2;
+        };
 
-        PolyFlags generify() const
+        struct PolyFlags2_6fix
         {
-            PolyFlags p;
-            memset(&p, 0, sizeof(p));
+            uint8_t portalPoly : 2;
+            uint8_t occluder : 1;
+            uint8_t sectorPoly : 1;
+            uint8_t mustRelight : 1;
+            uint8_t portalIndoorOutdoor : 1;
+            uint8_t ghostOccluder : 1;
+            uint8_t noDynLightNear : 1;
+            uint16_t sectorIndex : 16;
 
-            p.portalPoly = portalPoly;
-            p.occluder = occluder;
-            p.sectorPoly = sectorPoly;
-            p.mustRelight = mustRelight;
-            p.portalIndoorOutdoor = portalIndoorOutdoor;
-            p.ghostOccluder = ghostOccluder;
-            p.noDynLightNear = noDynLightNear;
-            p.sectorIndex = sectorIndex;
+            PolyFlags2_6fix() {}
+            PolyFlags2_6fix(const PolyFlags& p)
+            {
+                portalPoly = p.portalPoly;
+                occluder = p.occluder;
+                sectorPoly = p.sectorPoly;
+                mustRelight = p.mustRelight;
+                portalIndoorOutdoor = p.portalIndoorOutdoor;
+                ghostOccluder = p.ghostOccluder;
+                noDynLightNear = p.noDynLightNear;
+                sectorIndex = p.sectorIndex;
+            }
 
-            return p;
-        }
-    };
+            PolyFlags generify() const
+            {
+                PolyFlags p;
+                memset(&p, 0, sizeof(p));
 
-    struct PolyFlags1_08k
-    {
-        uint8_t portalPoly : 2;
-        uint8_t occluder : 1;
-        uint8_t sectorPoly : 1;
-        uint8_t lodFlag : 1;
-        uint8_t portalIndoorOutdoor : 1;
-        uint8_t ghostOccluder : 1;
-        uint8_t normalMainAxis : 2;
-        uint16_t sectorIndex : 16;
+                p.portalPoly = portalPoly;
+                p.occluder = occluder;
+                p.sectorPoly = sectorPoly;
+                p.mustRelight = mustRelight;
+                p.portalIndoorOutdoor = portalIndoorOutdoor;
+                p.ghostOccluder = ghostOccluder;
+                p.noDynLightNear = noDynLightNear;
+                p.sectorIndex = sectorIndex;
 
-        PolyFlags1_08k() {}
-        PolyFlags1_08k(const PolyFlags& p)
+                return p;
+            }
+        };
+
+        struct PolyFlags1_08k
         {
-            portalPoly = p.portalPoly;
-            occluder = p.occluder;
-            sectorPoly = p.sectorPoly;
-            lodFlag = p.lodFlag;
-            portalIndoorOutdoor = p.portalIndoorOutdoor;
-            ghostOccluder = p.ghostOccluder;
-            normalMainAxis = p.normalMainAxis;
-            sectorIndex = p.sectorIndex;
-        }
+            uint8_t portalPoly : 2;
+            uint8_t occluder : 1;
+            uint8_t sectorPoly : 1;
+            uint8_t lodFlag : 1;
+            uint8_t portalIndoorOutdoor : 1;
+            uint8_t ghostOccluder : 1;
+            uint8_t normalMainAxis : 2;
+            uint16_t sectorIndex : 16;
 
-        PolyFlags generify() const
+            PolyFlags1_08k() {}
+            PolyFlags1_08k(const PolyFlags& p)
+            {
+                portalPoly = p.portalPoly;
+                occluder = p.occluder;
+                sectorPoly = p.sectorPoly;
+                lodFlag = p.lodFlag;
+                portalIndoorOutdoor = p.portalIndoorOutdoor;
+                ghostOccluder = p.ghostOccluder;
+                normalMainAxis = p.normalMainAxis;
+                sectorIndex = p.sectorIndex;
+            }
+
+            PolyFlags generify() const
+            {
+                PolyFlags p;
+                memset(&p, 0, sizeof(p));
+
+                p.portalPoly = portalPoly;
+                p.occluder = occluder;
+                p.sectorPoly = sectorPoly;
+                p.lodFlag = lodFlag;
+                p.portalIndoorOutdoor = portalIndoorOutdoor;
+                p.ghostOccluder = ghostOccluder;
+                p.normalMainAxis = normalMainAxis;
+                p.sectorIndex = sectorIndex;
+
+                return p;
+            }
+        };
+
+        struct zTMSH_FeatureChunk
         {
-            PolyFlags p;
-            memset(&p, 0, sizeof(p));
-
-            p.portalPoly = portalPoly;
-            p.occluder = occluder;
-            p.sectorPoly = sectorPoly;
-            p.lodFlag = lodFlag;
-            p.portalIndoorOutdoor = portalIndoorOutdoor;
-            p.ghostOccluder = ghostOccluder;
-            p.normalMainAxis = normalMainAxis;
-            p.sectorIndex = sectorIndex;
-
-            return p;
-        }
-    };
-
-    struct zTMSH_FeatureChunk
-    {
-        float uv[2];
-        uint32_t lightStat;
-        ZMath::float3 vertNormal;
-    };
+            float uv[2];
+            uint32_t lightStat;
+            ZMath::float3 vertNormal;
+        };
 
 #pragma pack(pop)
 
-    /**
+        /**
 	* @brief Information about a triangle in the World. Contains whether the triangle 
 	*		  belongs to an outside/inside location, the static lighting colors of the edges,
 	*		  material-information and to which sector this belongs, amongst others
 	*/
-    struct WorldTriangle
-    {
-        /**
+        struct WorldTriangle
+        {
+            /**
 		* @brief Returns whether this triangle is outside or inside
 		*/
-        bool isOutside() const { return !flags.sectorPoly; }
+            bool isOutside() const { return !flags.sectorPoly; }
 
-        /**
+            /**
 		* @brief Returns the interpolated lighting value for the given position on the triangle
 		*/
 
-        ZMath::float4 interpolateLighting(const ZMath::float3& position) const
-        {
-            /*float u,v,w;
+            ZMath::float4 interpolateLighting(const ZMath::float3& position) const
+            {
+                /*float u,v,w;
 			ZMath::barycentric(position, vertices[0].Position, vertices[1].Position, vertices[2].Position, u, v, w);
 
 			ZMath::float4 c[3];
@@ -573,172 +575,173 @@ namespace ZenLoad
 
 			return u * c[0] + v * c[1] + w * c[2];*/
 
-            return ZMath::float4(1, 1, 1, 1);  // TODO: Implementation missing without GLM
-        }
+                return ZMath::float4(1, 1, 1, 1);  // TODO: Implementation missing without GLM
+            }
 
-        /**
+            /**
 		* @brief Flags taken from the original ZEN-File
 		*/
-        PolyFlags flags;
+            PolyFlags flags;
 
-        /**
+            /**
 		 * @brief Index to the lightmap stored in the zCMesh
 		 */
-        int16_t lightmapIndex;
+            int16_t lightmapIndex;
 
-        /**
+            /**
 		* @brief Vertices belonging to this triangle
 		*/
-        WorldVertex vertices[3];
+            WorldVertex vertices[3];
 
-        /**
+            /**
 		* @brief Index of submesh correlated with this triangle
 		*/
-        int16_t submeshIndex;
-    };
+            int16_t submeshIndex;
+        };
 
-    /**
+        /**
 	* @brief Simple generic packed mesh, containing all useful information of a (lod-level of) zCMesh and zCProgMeshProto
 	*/
-    // FIXME: Probably move this to renderer-package
-    struct PackedMesh
-    {
-        struct SubMesh
+        // FIXME: Probably move this to renderer-package
+        struct PackedMesh
         {
-            zCMaterialData material;
-            std::vector<uint32_t> indices;
-            std::vector<int16_t> triangleLightmapIndices;  // Index values to the texture found in zCMesh
+            struct SubMesh
+            {
+                zCMaterialData material;
+                std::vector<uint32_t> indices;
+                std::vector<int16_t> triangleLightmapIndices;  // Index values to the texture found in zCMesh
+            };
+
+            std::vector<WorldTriangle> triangles;  // Use index / 3 to access these
+            std::vector<WorldVertex> vertices;
+            std::vector<SubMesh> subMeshes;
+            ZMath::float3 bbox[2];
         };
 
-        std::vector<WorldTriangle> triangles;  // Use index / 3 to access these
-        std::vector<WorldVertex> vertices;
-        std::vector<SubMesh> subMeshes;
-        ZMath::float3 bbox[2];
-    };
-
-    struct PackedSkeletalMesh
-    {
-        struct SubMesh
+        struct PackedSkeletalMesh
         {
-            zCMaterialData material;
-            std::vector<uint32_t> indices;
-        };
+            struct SubMesh
+            {
+                zCMaterialData material;
+                std::vector<uint32_t> indices;
+            };
 
-        ZMath::float3 bbox[2];
-        std::vector<SkeletalVertex> vertices;
-        std::vector<SubMesh> subMeshes;
-    };
+            ZMath::float3 bbox[2];
+            std::vector<SkeletalVertex> vertices;
+            std::vector<SubMesh> subMeshes;
+        };
 
 #pragma pack(push, 4)
 
-    struct VobObjectInfo
-    {
-        ZMath::Matrix worldMatrix;
-        ZMath::float4 color;
-    };
+        struct VobObjectInfo
+        {
+            ZMath::Matrix worldMatrix;
+            ZMath::float4 color;
+        };
 
-    struct SkeletalMeshInstanceInfo
-    {
-        ZMath::Matrix worldMatrix;
-        ZMath::Matrix nodeTransforms[MAX_NUM_SKELETAL_NODES];
-        ZMath::float4 color;
-    };
+        struct SkeletalMeshInstanceInfo
+        {
+            ZMath::Matrix worldMatrix;
+            ZMath::Matrix nodeTransforms[MAX_NUM_SKELETAL_NODES];
+            ZMath::float4 color;
+        };
 
-    struct zDate
-    {
-        uint32_t year;
-        uint16_t month;
-        uint16_t day;
-        uint16_t hour;
-        uint16_t minute;
-        uint16_t second;
-    };
+        struct zDate
+        {
+            uint32_t year;
+            uint16_t month;
+            uint16_t day;
+            uint16_t hour;
+            uint16_t minute;
+            uint16_t second;
+        };
 
-    struct zTPlane
-    {
-        float distance;
-        ZMath::float3 normal;
-    };
+        struct zTPlane
+        {
+            float distance;
+            ZMath::float3 normal;
+        };
 #pragma pack(pop)
 
-    struct zWedge
-    {
-        ZMath::float3 m_Normal;
-        ZMath::float2 m_Texcoord;
-        uint16_t m_VertexIndex;
-    };
+        struct zWedge
+        {
+            ZMath::float3 m_Normal;
+            ZMath::float2 m_Texcoord;
+            uint16_t m_VertexIndex;
+        };
 
-    struct zTriangle
-    {
-        uint16_t m_Wedges[3];
-    };
+        struct zTriangle
+        {
+            uint16_t m_Wedges[3];
+        };
 
-    struct zTriangleEdges
-    {
-        uint16_t m_Edges[3];
-    };
+        struct zTriangleEdges
+        {
+            uint16_t m_Edges[3];
+        };
 
-    struct zEdge
-    {
-        uint16_t m_Wedges[2];
-    };
+        struct zEdge
+        {
+            uint16_t m_Wedges[2];
+        };
 
 #pragma pack(push, 4)
-    struct zTNodeWedgeNormal
-    {
-        ZMath::float3 m_Normal;
-        int m_NodeIndex;
-    };
+        struct zTNodeWedgeNormal
+        {
+            ZMath::float3 m_Normal;
+            int m_NodeIndex;
+        };
 
-    struct zTLODParams
-    {
-        float m_LodStrength;
-        float m_ZDisplace2;
-        float m_MorphPercent;
-        int32_t m_MinNumVertices;
-    };
+        struct zTLODParams
+        {
+            float m_LodStrength;
+            float m_ZDisplace2;
+            float m_MorphPercent;
+            int32_t m_MinNumVertices;
+        };
 
 #pragma pack(pop)
 
 #pragma pack(push, 1)
-    class zCModelNodeInst
-    {
-    public:
-    };
+        class zCModelNodeInst
+        {
+        public:
+        };
 
-    struct zTMdl_AniSample
-    {
-        uint16_t rotation[3];  // 16bit quantized euler angles
-        uint16_t position[3];  // 16bit quantized float3
-    };
+        struct zTMdl_AniSample
+        {
+            uint16_t rotation[3];  // 16bit quantized euler angles
+            uint16_t position[3];  // 16bit quantized float3
+        };
 #pragma pack(pop)
 
 #pragma pack(push, 1)
-    struct zTWeightEntry
-    {
-        // Weight and position of the vertex.
-        // This vertexposition is in the local space of the joint-Matrix!
-        float weight;
-        ZMath::float3 localVertexPosition;
+        struct zTWeightEntry
+        {
+            // Weight and position of the vertex.
+            // This vertexposition is in the local space of the joint-Matrix!
+            float weight;
+            ZMath::float3 localVertexPosition;
 
-        // Nodeindex this belongs to
-        unsigned char nodeIndex;
-    };
+            // Nodeindex this belongs to
+            unsigned char nodeIndex;
+        };
 #pragma pack(pop)
 
-    enum zTMdl_AniEventType
-    {
-        zMDL_EVENT_TAG,
-        zMDL_EVENT_SOUND,
-        zMDL_EVENT_SOUND_GRND,
-        zMDL_EVENT_ANIBATCH,
-        zMDL_EVENT_SWAPMESH,
-        zMDL_EVENT_HEADING,
-        zMDL_EVENT_PFX,
-        zMDL_EVENT_PFX_GRND,
-        zMDL_EVENT_PFX_STOP,
-        zMDL_EVENT_SETMESH,
-        zMDL_EVENT_MM_STARTANI,
-        zMDL_EVENT_CAM_TREMOR,
-    };
-}  // namespace ZenLoad
+        enum zTMdl_AniEventType
+        {
+            zMDL_EVENT_TAG,
+            zMDL_EVENT_SOUND,
+            zMDL_EVENT_SOUND_GRND,
+            zMDL_EVENT_ANIBATCH,
+            zMDL_EVENT_SWAPMESH,
+            zMDL_EVENT_HEADING,
+            zMDL_EVENT_PFX,
+            zMDL_EVENT_PFX_GRND,
+            zMDL_EVENT_PFX_STOP,
+            zMDL_EVENT_SETMESH,
+            zMDL_EVENT_MM_STARTANI,
+            zMDL_EVENT_CAM_TREMOR,
+        };
+    }  // namespace ZenLoad
+}  // namespace ZenLib

--- a/zenload/zenParser.cpp
+++ b/zenload/zenParser.cpp
@@ -11,7 +11,9 @@
 #include "utils/logger.h"
 #include <vdfs/fileIndex.h>
 
-using namespace ZenLoad;
+namespace ZenLib
+{
+    using namespace ZenLoad;
 
 #ifdef __ANDROID__
 #define ERROR(msg)         \
@@ -27,183 +29,184 @@ using namespace ZenLoad;
     } while (0)
 #endif
 
-/**
+    /**
  * @brief reads a zen from a file
  */
-ZenParser::ZenParser(const std::string& file)
-    : m_Seek(0)
-    , m_pWorldMesh(0)
-{
-    // Get data from zenfile
-    readFile(file, m_Data);
-}
+    ZenParser::ZenParser(const std::string& file)
+        : m_Seek(0)
+        , m_pWorldMesh(0)
+    {
+        // Get data from zenfile
+        readFile(file, m_Data);
+    }
 
-/**
+    /**
  * @brief reads a zen from a vdf
  */
-ZenParser::ZenParser(const std::string& file, const VDFS::FileIndex& vdfs)
-    : m_Seek(0)
-    , m_pWorldMesh(0)
-{
-    vdfs.getFileData(file, m_Data);
-}
+    ZenParser::ZenParser(const std::string& file, const VDFS::FileIndex& vdfs)
+        : m_Seek(0)
+        , m_pWorldMesh(0)
+    {
+        vdfs.getFileData(file, m_Data);
+    }
 
-/**
+    /**
  * @brief reads a zen from memory
  */
-ZenParser::ZenParser(const uint8_t* data, size_t size)
-    : m_Seek(0)
-    , m_pWorldMesh(0)
-{
-    m_Data.assign(data, data + size);
-}
+    ZenParser::ZenParser(const uint8_t* data, size_t size)
+        : m_Seek(0)
+        , m_pWorldMesh(0)
+    {
+        m_Data.assign(data, data + size);
+    }
 
-ZenLoad::ZenParser::~ZenParser()
-{
-    delete m_pWorldMesh;
-}
+    ZenLoad::ZenParser::~ZenParser()
+    {
+        delete m_pWorldMesh;
+    }
 
-/**
+    /**
 * @brief Read the given file and places the data in the given vector
 */
-bool ZenParser::readFile(const std::string& fileName, std::vector<uint8_t>& data)
-{
-    std::ifstream file(fileName, std::ios::in | std::ios::ate | std::ios::binary);
-    size_t size = file.tellg();
-    file.seekg(0, std::ios::beg);
-
-    if (!file.good())
+    bool ZenParser::readFile(const std::string& fileName, std::vector<uint8_t>& data)
     {
-        ERROR("File does not exist");
-        ERROR(strerror(errno));
+        std::ifstream file(fileName, std::ios::in | std::ios::ate | std::ios::binary);
+        size_t size = file.tellg();
+        file.seekg(0, std::ios::beg);
+
+        if (!file.good())
+        {
+            ERROR("File does not exist");
+            ERROR(strerror(errno));
+        }
+        LogInfo() << "Zen-File found! Size: " << size;
+
+        data.resize(size);
+
+        LogInfo() << "Reading...";
+        file.read(reinterpret_cast<char*>(data.data()), size);
+
+        return true;
     }
-    LogInfo() << "Zen-File found! Size: " << size;
 
-    data.resize(size);
-
-    LogInfo() << "Reading...";
-    file.read(reinterpret_cast<char*>(data.data()), size);
-
-    return true;
-}
-
-/**
+    /**
 * @brief returns whether the given string is a number
 */
-bool ZenParser::isNumber(const std::string& expr)
-{
-    return !expr.empty() && std::find_if(expr.begin(), expr.end(), [](unsigned char c) { return !std::isdigit(c); }) == expr.end();
-}
+    bool ZenParser::isNumber(const std::string& expr)
+    {
+        return !expr.empty() && std::find_if(expr.begin(), expr.end(), [](unsigned char c)
+                                             { return !std::isdigit(c); }) == expr.end();
+    }
 
-/**
+    /**
 * @brief Reads the main ZEN-Header
 */
-void ZenParser::readHeader()
-{
-    readHeader(m_Header, m_pParserImpl);
-}
+    void ZenParser::readHeader()
+    {
+        readHeader(m_Header, m_pParserImpl);
+    }
 
-/**
+    /**
 * @brief Skips the main header
 */
-void ZenParser::skipHeader()
-{
-    ZenHeader header;
-    ParserImpl* impl = nullptr;
-    readHeader(header, impl);
+    void ZenParser::skipHeader()
+    {
+        ZenHeader header;
+        ParserImpl* impl = nullptr;
+        readHeader(header, impl);
 
-    delete impl;
-}
+        delete impl;
+    }
 
-/**
+    /**
 * @brief Skipts the ZEN-Header
 */
-void ZenParser::readHeader(ZenHeader& header, ParserImpl*& impl)
-{
-    if (!skipString("ZenGin Archive"))
-        ERROR("Not a valid format");
-
-    if (!skipString("ver"))
-        ERROR("Not a valid header");
-
-    // Version should be always 1...
-    header.version = readIntASCII();
-
-    // Skip archiver type
-    skipString();
-
-    // Read file-type, to create the right archiver implementation
-    std::string fileType = readLine();
-    if (fileType == "ASCII")
+    void ZenParser::readHeader(ZenHeader& header, ParserImpl*& impl)
     {
-        header.fileType = FT_ASCII;
-        impl = new ParserImplASCII(this);
+        if (!skipString("ZenGin Archive"))
+            ERROR("Not a valid format");
+
+        if (!skipString("ver"))
+            ERROR("Not a valid header");
+
+        // Version should be always 1...
+        header.version = readIntASCII();
+
+        // Skip archiver type
+        skipString();
+
+        // Read file-type, to create the right archiver implementation
+        std::string fileType = readLine();
+        if (fileType == "ASCII")
+        {
+            header.fileType = FT_ASCII;
+            impl = new ParserImplASCII(this);
+        }
+        else if (fileType == "BINARY")
+        {
+            header.fileType = FT_BINARY;
+            impl = new ParserImplBinary(this);
+        }
+        else if (fileType == "BIN_SAFE")
+        {
+            header.fileType = FT_BINSAFE;
+            impl = new ParserImplBinSafe(this);
+        }
+        else
+            ERROR("Unsupported file format");
+
+        // Read string of the format "savegame b", where b is 0 or 1
+        if (!skipString("saveGame"))
+            ERROR("Unsupported file format");
+
+        header.saveGame = readBoolASCII();
+
+        // Read possible date
+        if (skipString("date"))
+        {
+            header.date = readString() + " ";
+            header.date += readString();
+        }
+
+        // Skip possible user
+        if (skipString("user"))
+            header.user = readString();
+
+        // Reached the end of the main header
+        if (!skipString("END"))
+            ERROR("No END in header(1)");
+
+        // Continue with the implementationspecific header
+        skipSpaces();
+
+        impl->readImplHeader();
     }
-    else if (fileType == "BINARY")
-    {
-        header.fileType = FT_BINARY;
-        impl = new ParserImplBinary(this);
-    }
-    else if (fileType == "BIN_SAFE")
-    {
-        header.fileType = FT_BINSAFE;
-        impl = new ParserImplBinSafe(this);
-    }
-    else
-        ERROR("Unsupported file format");
 
-    // Read string of the format "savegame b", where b is 0 or 1
-    if (!skipString("saveGame"))
-        ERROR("Unsupported file format");
-
-    header.saveGame = readBoolASCII();
-
-    // Read possible date
-    if (skipString("date"))
-    {
-        header.date = readString() + " ";
-        header.date += readString();
-    }
-
-    // Skip possible user
-    if (skipString("user"))
-        header.user = readString();
-
-    // Reached the end of the main header
-    if (!skipString("END"))
-        ERROR("No END in header(1)");
-
-    // Continue with the implementationspecific header
-    skipSpaces();
-
-    impl->readImplHeader();
-}
-
-/**
+    /**
 * @brief reads the main oCWorld-Object, found in the level-zens
 */
-void ZenParser::readWorld(oCWorldData& info)
-{
-    LogInfo() << "ZEN: Reading world...";
-
-    ChunkHeader header;
-    readChunkStart(header);
-
-    if (header.classname != "oCWorld:zCWorld")
-        ERROR("Expected oCWorld:zCWorld-Chunk not found!");
-
-    oCWorld::readObjectData(info, *this, header.version);
-}
-
-void ZenParser::readWorldMesh(oCWorldData& info)
-{
-    LogInfo() << "ZEN: Reading mesh...";
-    m_pWorldMesh = new zCMesh;
-
-    // Read worldmesh, if needed
-    if (m_pWorldMesh)
+    void ZenParser::readWorld(oCWorldData& info)
     {
-        /*size_t totalStart = m_Seek;
+        LogInfo() << "ZEN: Reading world...";
+
+        ChunkHeader header;
+        readChunkStart(header);
+
+        if (header.classname != "oCWorld:zCWorld")
+            ERROR("Expected oCWorld:zCWorld-Chunk not found!");
+
+        oCWorld::readObjectData(info, *this, header.version);
+    }
+
+    void ZenParser::readWorldMesh(oCWorldData& info)
+    {
+        LogInfo() << "ZEN: Reading mesh...";
+        m_pWorldMesh = new zCMesh;
+
+        // Read worldmesh, if needed
+        if (m_pWorldMesh)
+        {
+            /*size_t totalStart = m_Seek;
         readBinaryDWord();
         size_t size = readBinaryDWord();
         size_t start = m_Seek;
@@ -212,26 +215,26 @@ void ZenParser::readWorldMesh(oCWorldData& info)
         m_Seek = start + size;
 
         m_Seek = totalStart;*/
-        info.bspTree = zCBspTree::readObjectData(*this, m_pWorldMesh);
+            info.bspTree = zCBspTree::readObjectData(*this, m_pWorldMesh);
 
-        //m_pWorldMesh->readObjectData(*this);
+            //m_pWorldMesh->readObjectData(*this);
+        }
+        else
+        {
+            // Skip
+            readBinaryDWord();  // Version
+            m_Seek += readBinaryDWord();
+        }
+
+        LogInfo() << "ZEN: Done reading mesh!";
     }
-    else
-    {
-        // Skip
-        readBinaryDWord();  // Version
-        m_Seek += readBinaryDWord();
-    }
 
-    LogInfo() << "ZEN: Done reading mesh!";
-}
-
-/**
+    /**
 * @brief reads a full chunk (TESTING ONLY)
 */
-void ZenParser::readChunkTest()
-{
-    /*ChunkHeader header;
+    void ZenParser::readChunkTest()
+    {
+        /*ChunkHeader header;
 	m_pParserImpl->readChunkStart(header);
 
 	if(header.name == "MeshAndBsp")
@@ -274,248 +277,249 @@ void ZenParser::readChunkTest()
 			}
 		}
 	}while(str != "[]");*/
-}
+    }
 
-/**
+    /**
 * @brief Reads a chunk-header
 */
-bool ZenParser::readChunkStart(ChunkHeader& header)
-{
-    return m_pParserImpl->readChunkStart(header);
-}
+    bool ZenParser::readChunkStart(ChunkHeader& header)
+    {
+        return m_pParserImpl->readChunkStart(header);
+    }
 
-/**
+    /**
  * @brief Reads the end of a chunk. Returns true if there actually was an end. 
  *		  Otherwise it will leave m_Seek untouched and return false.
  */
-bool ZenParser::readChunkEnd()
-{
-    return m_pParserImpl->readChunkEnd();
-}
+    bool ZenParser::readChunkEnd()
+    {
+        return m_pParserImpl->readChunkEnd();
+    }
 
-/**
+    /**
  * @brief  Skips an already started chunk
  */
-void ZenParser::skipChunk()
-{
-    size_t level = 1;
-
-    do
+    void ZenParser::skipChunk()
     {
-        ChunkHeader header;
-        if (readChunkStart(header))
+        size_t level = 1;
+
+        do
         {
-            level++;
+            ChunkHeader header;
+            if (readChunkStart(header))
+            {
+                level++;
+            }
+            else if (readChunkEnd())
+            {
+                level--;
+            }
+            else
+            {
+                skipEntry();
+            }
+
+        } while (level > 0);
+    }
+
+    /**
+* @brief Skips an entry
+*/
+    void ZenParser::skipEntry()
+    {
+        ParserImpl::EZenValueType type;
+        size_t size;
+        size_t ts = m_Seek;
+
+        // Read type and size first, so we can allocate the data
+        m_pParserImpl->readEntryType(type, size);
+
+        // Skip the entry
+        m_Seek += size;
+    }
+
+    /**
+ * @brief reads an ASCII datatype from the loaded file
+ */
+    int32_t ZenParser::readIntASCII()
+    {
+        skipSpaces();
+        std::string number;
+        while (m_Data[m_Seek] >= '0' && m_Data[m_Seek] <= '9')
+        {
+            number += m_Data[m_Seek];
+            ++m_Seek;
         }
-        else if (readChunkEnd())
+        return std::stoi(number);
+    }
+
+    /**
+ * @brief reads an ASCII datatype from the loaded file
+ */
+    bool ZenParser::readBoolASCII()
+    {
+        skipSpaces();
+        bool retVal;
+        if (m_Data[m_Seek] != '0' && m_Data[m_Seek] != '1')
+            ERROR("Value is not a bool");
+        else
+            retVal = m_Data[m_Seek] == '0' ? false : true;
+
+        ++m_Seek;
+        return retVal;
+    }
+
+    /**
+ * @brief Reads a string until \r, \n or a space is found
+ */
+    std::string ZenParser::readString(bool skip)
+    {
+        if (skip)
+            skipSpaces();
+
+        std::string str;
+        while (m_Data[m_Seek] != '\r' && m_Data[m_Seek] != '\n' && m_Data[m_Seek] != ' ')
         {
-            level--;
+            str += m_Data[m_Seek];
+            ++m_Seek;
+        }
+        return str;
+    }
+
+    /**
+ * @brief skips a string and checks if it matches the given expected one
+ */
+    bool ZenParser::skipString(const std::string& pattern)
+    {
+        skipSpaces();
+        bool retVal = true;
+        if (pattern.empty())
+        {
+            while (!(m_Data[m_Seek] == '\n' || m_Data[m_Seek] == ' '))
+                ++m_Seek;
+            ++m_Seek;
         }
         else
         {
-            skipEntry();
-        }
-
-    } while (level > 0);
-}
-
-/**
-* @brief Skips an entry
-*/
-void ZenParser::skipEntry()
-{
-    ParserImpl::EZenValueType type;
-    size_t size;
-    size_t ts = m_Seek;
-
-    // Read type and size first, so we can allocate the data
-    m_pParserImpl->readEntryType(type, size);
-
-    // Skip the entry
-    m_Seek += size;
-}
-
-/**
- * @brief reads an ASCII datatype from the loaded file
- */
-int32_t ZenParser::readIntASCII()
-{
-    skipSpaces();
-    std::string number;
-    while (m_Data[m_Seek] >= '0' && m_Data[m_Seek] <= '9')
-    {
-        number += m_Data[m_Seek];
-        ++m_Seek;
-    }
-    return std::stoi(number);
-}
-
-/**
- * @brief reads an ASCII datatype from the loaded file
- */
-bool ZenParser::readBoolASCII()
-{
-    skipSpaces();
-    bool retVal;
-    if (m_Data[m_Seek] != '0' && m_Data[m_Seek] != '1')
-        ERROR("Value is not a bool");
-    else
-        retVal = m_Data[m_Seek] == '0' ? false : true;
-
-    ++m_Seek;
-    return retVal;
-}
-
-/**
- * @brief Reads a string until \r, \n or a space is found
- */
-std::string ZenParser::readString(bool skip)
-{
-    if (skip)
-        skipSpaces();
-
-    std::string str;
-    while (m_Data[m_Seek] != '\r' && m_Data[m_Seek] != '\n' && m_Data[m_Seek] != ' ')
-    {
-        str += m_Data[m_Seek];
-        ++m_Seek;
-    }
-    return str;
-}
-
-/**
- * @brief skips a string and checks if it matches the given expected one
- */
-bool ZenParser::skipString(const std::string& pattern)
-{
-    skipSpaces();
-    bool retVal = true;
-    if (pattern.empty())
-    {
-        while (!(m_Data[m_Seek] == '\n' || m_Data[m_Seek] == ' '))
-            ++m_Seek;
-        ++m_Seek;
-    }
-    else
-    {
-        size_t lineSeek = 0;
-        while (lineSeek < pattern.size())
-        {
-            if (m_Data[m_Seek] != pattern[lineSeek])
+            size_t lineSeek = 0;
+            while (lineSeek < pattern.size())
             {
-                retVal = false;
-                break;
-            }
+                if (m_Data[m_Seek] != pattern[lineSeek])
+                {
+                    retVal = false;
+                    break;
+                }
 
-            ++m_Seek;
-            ++lineSeek;
+                ++m_Seek;
+                ++lineSeek;
+            }
         }
+
+        return retVal;
     }
 
-    return retVal;
-}
-
-/**
+    /**
 * @brief Skips all whitespace-characters until it hits a non-whitespace one
 */
-void ZenParser::skipSpaces()
-{
-    bool search = true;
-    while (search && m_Seek < m_Data.size())
+    void ZenParser::skipSpaces()
     {
-        switch (m_Data[m_Seek])
+        bool search = true;
+        while (search && m_Seek < m_Data.size())
         {
-            case ' ':
-            case '\r':
-            case '\t':
-            case '\n':
-                ++m_Seek;
-                break;
-            default:
-                search = false;
-                break;
+            switch (m_Data[m_Seek])
+            {
+                case ' ':
+                case '\r':
+                case '\t':
+                case '\n':
+                    ++m_Seek;
+                    break;
+                default:
+                    search = false;
+                    break;
+            }
         }
     }
-}
 
-/**
+    /**
  * @brief Skips all newline-characters until it hits a non-newline one
  */
-void ZenParser::skipNewLines()
-{
-    while (m_Seek < m_Data.size() && m_Data[m_Seek] == '\n')
-        ++m_Seek;
-}
+    void ZenParser::skipNewLines()
+    {
+        while (m_Seek < m_Data.size() && m_Data[m_Seek] == '\n')
+            ++m_Seek;
+    }
 
-/**
+    /**
 * @brief Throws an exception if the current seek is behind the file-size
 */
-void ZenParser::checkArraySize()
-{
-    if (m_Seek >= m_Data.size())
-        throw std::logic_error("Out of range");
-}
+    void ZenParser::checkArraySize()
+    {
+        if (m_Seek >= m_Data.size())
+            throw std::logic_error("Out of range");
+    }
 
-/**
+    /**
 * @brief Reads the given type as binary data and returns it
 */
-uint32_t ZenParser::readBinaryDWord()
-{
-    uint32_t retVal;
-    readStructure(retVal);
-
-    return retVal;
-}
-
-uint16_t ZenParser::readBinaryWord()
-{
-    uint16_t retVal;
-    readStructure(retVal);
-
-    return retVal;
-}
-
-uint8_t ZenParser::readBinaryByte()
-{
-    uint8_t retVal = *reinterpret_cast<uint8_t*>(&m_Data[m_Seek]);
-    m_Seek += sizeof(uint8_t);
-    return retVal;
-}
-
-float ZenParser::readBinaryFloat()
-{
-    float retVal;
-    readStructure(retVal);
-
-    return retVal;
-}
-
-void ZenParser::readBinaryRaw(void* target, size_t numBytes)
-{
-    if (target != nullptr && numBytes != 0)
+    uint32_t ZenParser::readBinaryDWord()
     {
-        std::memcpy(target, &m_Data[m_Seek], numBytes);
-        m_Seek += numBytes;
-    }
-}
+        uint32_t retVal;
+        readStructure(retVal);
 
-/**
+        return retVal;
+    }
+
+    uint16_t ZenParser::readBinaryWord()
+    {
+        uint16_t retVal;
+        readStructure(retVal);
+
+        return retVal;
+    }
+
+    uint8_t ZenParser::readBinaryByte()
+    {
+        uint8_t retVal = *reinterpret_cast<uint8_t*>(&m_Data[m_Seek]);
+        m_Seek += sizeof(uint8_t);
+        return retVal;
+    }
+
+    float ZenParser::readBinaryFloat()
+    {
+        float retVal;
+        readStructure(retVal);
+
+        return retVal;
+    }
+
+    void ZenParser::readBinaryRaw(void* target, size_t numBytes)
+    {
+        if (target != nullptr && numBytes != 0)
+        {
+            std::memcpy(target, &m_Data[m_Seek], numBytes);
+            m_Seek += numBytes;
+        }
+    }
+
+    /**
 * @brief Reads a line to \r or \n
 */
-std::string ZenParser::readLine(bool skip)
-{
-    std::string retVal;
-    while (m_Data[m_Seek] != '\r' && m_Data[m_Seek] != '\n' && m_Data[m_Seek] != '\0')
+    std::string ZenParser::readLine(bool skip)
     {
-        checkArraySize();
-        retVal += m_Data[m_Seek++];
+        std::string retVal;
+        while (m_Data[m_Seek] != '\r' && m_Data[m_Seek] != '\n' && m_Data[m_Seek] != '\0')
+        {
+            checkArraySize();
+            retVal += m_Data[m_Seek++];
+        }
+
+        // Skip trailing \n\r\0
+        //if(m_Header.fileType == FT_BINARY)
+        m_Seek++;
+
+        if (skip)
+            skipSpaces();
+        return retVal;
     }
-
-    // Skip trailing \n\r\0
-    //if(m_Header.fileType == FT_BINARY)
-    m_Seek++;
-
-    if (skip)
-        skipSpaces();
-    return retVal;
-}
+}  // namespace ZenLib

--- a/zenload/zenParser.h
+++ b/zenload/zenParser.h
@@ -9,264 +9,267 @@
 #include "utils/split.h"
 #include "utils/tuple.h"
 
-namespace VDFS
+namespace ZenLib
 {
-    class FileIndex;
-}
-
-namespace ZenLoad
-{
-    class ParserImpl;
-    class zCMesh;
-    class ZenParser
+    namespace VDFS
     {
-        friend class ParserImpl;
-        friend class ParserImplBinSafe;
-        friend class ParserImplASCII;
-        friend class ParserImplBinary;
+        class FileIndex;
+    }
 
-    public:
-        /**
+    namespace ZenLoad
+    {
+        class ParserImpl;
+        class zCMesh;
+        class ZenParser
+        {
+            friend class ParserImpl;
+            friend class ParserImplBinSafe;
+            friend class ParserImplASCII;
+            friend class ParserImplBinary;
+
+        public:
+            /**
 		 * @brief Possible filetypes this zen can have
 		 */
-        enum EFileType
-        {
-            FT_UNKNOWN,
-            FT_ASCII,
-            FT_BINARY,
-            FT_BINSAFE
-        };
+            enum EFileType
+            {
+                FT_UNKNOWN,
+                FT_ASCII,
+                FT_BINARY,
+                FT_BINSAFE
+            };
 
-        /**
+            /**
 		 * @brief Information about one of the chunks in a zen-file
 		 */
-        struct ChunkHeader
-        {
-            uint32_t startPosition;
-            uint32_t size;
-            uint16_t version;
-            uint32_t objectID;
-            std::string name;
-            std::string classname;
-            bool createObject;
-        };
+            struct ChunkHeader
+            {
+                uint32_t startPosition;
+                uint32_t size;
+                uint16_t version;
+                uint32_t objectID;
+                std::string name;
+                std::string classname;
+                bool createObject;
+            };
 
-        /**
+            /**
 		 * @brief File-Header for ZEN-Files
 		 */
-        struct ZenHeader
-        {
-            int version;
-            EFileType fileType;
-            bool saveGame;
-            std::string date;
-            std::string user;
-            int objectCount;
-
-            struct
+            struct ZenHeader
             {
-                uint32_t bsVersion;
-                uint32_t bsHashTableOffset;
-            } binSafeHeader;
-        };
+                int version;
+                EFileType fileType;
+                bool saveGame;
+                std::string date;
+                std::string user;
+                int objectCount;
 
-        /**
+                struct
+                {
+                    uint32_t bsVersion;
+                    uint32_t bsHashTableOffset;
+                } binSafeHeader;
+            };
+
+            /**
 		 * @brief reads a zen from a file
 		 */
-        ZenParser(const std::string& file);
-        ZenParser(const std::string& file, const VDFS::FileIndex& vdfs);
+            ZenParser(const std::string& file);
+            ZenParser(const std::string& file, const VDFS::FileIndex& vdfs);
 
-        /**
+            /**
 		* @brief reads a zen from memory
 		*/
-        ZenParser(const uint8_t* data, size_t size);
+            ZenParser(const uint8_t* data, size_t size);
 
-        ZenParser() {}
-        ~ZenParser();
+            ZenParser() {}
+            ~ZenParser();
 
-        /**
+            /**
          * @brief Returns the file-header
          */
-        const ZenHeader& getZenHeader() { return m_Header; }
-        void setZenHeader(const ZenHeader& header) { m_Header = header; }
+            const ZenHeader& getZenHeader() { return m_Header; }
+            void setZenHeader(const ZenHeader& header) { m_Header = header; }
 
-        /**
+            /**
 		 * @brief Returns the parsed world-mesh
 		 */
-        zCMesh* getWorldMesh() { return m_pWorldMesh; }
+            zCMesh* getWorldMesh() { return m_pWorldMesh; }
 
-        /**
+            /**
 		 * @brief returns the total size of the loaded file
 		 */
-        size_t getFileSize() { return m_Data.size(); }
+            size_t getFileSize() { return m_Data.size(); }
 
-        /**
+            /**
 		 * @brief Reads the main ZEN-Header
 		 */
-        void readHeader();
+            void readHeader();
 
-        /**
+            /**
 		 * @brief Reads the main ZEN-Header
 		 */
-        void readHeader(ZenHeader& header, ParserImpl*& impl);
+            void readHeader(ZenHeader& header, ParserImpl*& impl);
 
-        /**
+            /**
 		 * @brief Skips the main header
 		 */
-        void skipHeader();
+            void skipHeader();
 
-        /**
+            /**
 		 * @brief reads the main oCWorld-Object, found in the level-zens
 		 */
-        void readWorld(oCWorldData& info);
+            void readWorld(oCWorldData& info);
 
-        /****************************************************************************************************************/
-        /* ############### Note: Rest of the methods are to be used only if you know what you are doing ############### */
-        /****************************************************************************************************************/
+            /****************************************************************************************************************/
+            /* ############### Note: Rest of the methods are to be used only if you know what you are doing ############### */
+            /****************************************************************************************************************/
 
-        /**
+            /**
 		* @brief Reads the given type as binary data and returns it
 		*/
-        uint32_t readBinaryDWord();
-        uint16_t readBinaryWord();
-        uint8_t readBinaryByte();
-        float readBinaryFloat();
-        void readBinaryRaw(void* target, size_t numBytes);
+            uint32_t readBinaryDWord();
+            uint16_t readBinaryWord();
+            uint8_t readBinaryByte();
+            float readBinaryFloat();
+            void readBinaryRaw(void* target, size_t numBytes);
 
-        /**
+            /**
 		 * @brief Reads a line to \r or \n
 		 */
-        std::string readLine(bool skipSpaces = true);
+            std::string readLine(bool skipSpaces = true);
 
-        /**
+            /**
 		 * @brief skips a string and checks if it matches the given expected one
 		 */
-        bool skipString(const std::string& pattern = std::string());
+            bool skipString(const std::string& pattern = std::string());
 
-        /**
+            /**
 		 * @brief Skips all whitespace-characters until it hits a non-whitespace one
 		 */
-        void skipSpaces();
+            void skipSpaces();
 
-        /**
+            /**
 		 * @brief Skips all newline-characters until it hits a non-newline one
 		 */
-        void skipNewLines();
+            void skipNewLines();
 
-        /**
+            /**
 		 * @brief Throws an exception if the current seek is behind the file-size
 		 */
-        void checkArraySize();
+            void checkArraySize();
 
-        /**
+            /**
 		 * @brief Reads a string until \r, \n or a space is found
 		 */
-        std::string readString(bool skipSpaces = true);
+            std::string readString(bool skipSpaces = true);
 
-        /**
+            /**
 		 * @brief reads an ASCII datatype from the loaded file
 		 */
-        int32_t readIntASCII();
-        bool readBoolASCII();
+            int32_t readIntASCII();
+            bool readBoolASCII();
 
-        /**
+            /**
 		 * @brief returns whether the given string is a number
 		 */
-        bool isNumber(const std::string& expr);
+            bool isNumber(const std::string& expr);
 
-        /**
+            /**
 		 * @brief returns the current implementatio
 		 */
-        ParserImpl* getImpl() { return m_pParserImpl; }
-        void setImpl(ParserImpl* impl) { m_pParserImpl = impl; }
+            ParserImpl* getImpl() { return m_pParserImpl; }
+            void setImpl(ParserImpl* impl) { m_pParserImpl = impl; }
 
-        /**
+            /**
 		 * @brief reads a full chunk (TESTING ONLY)
 		 */
-        void readChunkTest();
+            void readChunkTest();
 
-        /**
+            /**
 		* @brief Returns the current position in our loaded file
 		*/
-        size_t getSeek() const { return m_Seek; }
+            size_t getSeek() const { return m_Seek; }
 
-        /**
+            /**
 		* @brief Sets the current position in the loaded file 
 		*/
-        void setSeek(size_t seek) { m_Seek = seek; }
+            void setSeek(size_t seek) { m_Seek = seek; }
 
-        /**
+            /**
 		 * @brief Returns the data-array
 		 */
-        const std::vector<uint8_t>& getData() { return m_Data; }
+            const std::vector<uint8_t>& getData() { return m_Data; }
 
-        /**
+            /**
 		* @brief Reads one structure of type T. Watch for alignment!
 		*/
-        template <typename T>
-        void readStructure(T& s)
-        {
-            if (m_Seek + sizeof(T) <= m_Data.size())
+            template <typename T>
+            void readStructure(T& s)
             {
-                void* _s = (void*)&s;
-                memcpy(_s, &m_Data[m_Seek], sizeof(T));
-                m_Seek += sizeof(T);
+                if (m_Seek + sizeof(T) <= m_Data.size())
+                {
+                    void* _s = (void*)&s;
+                    memcpy(_s, &m_Data[m_Seek], sizeof(T));
+                    m_Seek += sizeof(T);
+                }
             }
-        }
 
-        /**
+            /**
 		 * @brief Reads a chunk-header. Returns true if there actually was a start. 
 		 *		  Otherwise it will leave m_Seek untouched and return false.
 		 */
-        bool readChunkStart(ChunkHeader& header);
+            bool readChunkStart(ChunkHeader& header);
 
-        /**
+            /**
 		 * @brief Reads the end of a chunk. Returns true if there actually was an end. 
 		 *		  Otherwise it will leave m_Seek untouched and return false.
 		 */
-        bool readChunkEnd();
+            bool readChunkEnd();
 
-        /**
+            /**
 		 * @brief Skips an already started chunk
 		 */
-        void skipChunk();
+            void skipChunk();
 
-        /**
+            /**
 		 * @brief Skips an entry
 		 */
-        void skipEntry();
+            void skipEntry();
 
-        /**
+            /**
 		* @brief reads the worldmesh-chunk
 		*/
-        void readWorldMesh(oCWorldData& info);
+            void readWorldMesh(oCWorldData& info);
 
-    private:
-        /**
+        private:
+            /**
 		 * @brief Read the given file and places the data in the given vector
 		 */
-        bool readFile(const std::string& file, std::vector<uint8_t>& data);
+            bool readFile(const std::string& file, std::vector<uint8_t>& data);
 
-        /**
+            /**
 		 * @brief Implementation this archive usese
 		 */
-        ParserImpl* m_pParserImpl;
+            ParserImpl* m_pParserImpl;
 
-        /**
+            /**
 		 * @brief Data currently loaded and the current stream position
 		 */
-        std::vector<uint8_t> m_Data;
-        size_t m_Seek;
+            std::vector<uint8_t> m_Data;
+            size_t m_Seek;
 
-        /**
+            /**
 		 * @brief ZEN-Header of the loaded file
 		 */
-        ZenHeader m_Header;
+            ZenHeader m_Header;
 
-        /**
+            /**
 		* @brief The world mesh. Only non-null if the ZEN had one. (BinSave don't have a worldmesh)
 		*/
-        zCMesh* m_pWorldMesh;
-    };
+            zCMesh* m_pWorldMesh;
+        };
 
-}  // namespace ZenLoad
+    }  // namespace ZenLoad
+}  // namespace ZenLib

--- a/zenload/zenParserPropRead.h
+++ b/zenload/zenParserPropRead.h
@@ -2,98 +2,100 @@
 #include "parserImpl.h"
 #include "zenParser.h"
 
-namespace ZenLoad
+namespace ZenLib
 {
-    /**
+    namespace ZenLoad
+    {
+        /**
 	* @brief Templated function-calls to read the right type of data 
 	*		  and convert it to a string for the given type
 	*/
-    template <typename T>
-    inline void read(ZenParser& /*p*/, std::string& outStr, T& /*outData*/, const char* /*exName*/)
-    {
-        outStr = "INVALID DATATYPE";
-    }
+        template <typename T>
+        inline void read(ZenParser& /*p*/, std::string& outStr, T& /*outData*/, const char* /*exName*/)
+        {
+            outStr = "INVALID DATATYPE";
+        }
 
-    template <>
-    inline void read<float>(ZenParser& p, std::string& /*outStr*/, float& outData, const char* exName)
-    {
-        p.getImpl()->readEntry(exName, &outData, sizeof(float), ParserImpl::ZVT_FLOAT);
-        //outStr = std::to_string(outData);
-    }
+        template <>
+        inline void read<float>(ZenParser& p, std::string& /*outStr*/, float& outData, const char* exName)
+        {
+            p.getImpl()->readEntry(exName, &outData, sizeof(float), ParserImpl::ZVT_FLOAT);
+            //outStr = std::to_string(outData);
+        }
 
-    template <>
-    inline void read<bool>(ZenParser& p, std::string& /*outStr*/, bool& outData, const char* exName)
-    {
-        p.getImpl()->readEntry(exName, &outData, sizeof(bool), ParserImpl::ZVT_BOOL);
-        //outStr = std::to_string(outData ? 1 : 0);
-    }
+        template <>
+        inline void read<bool>(ZenParser& p, std::string& /*outStr*/, bool& outData, const char* exName)
+        {
+            p.getImpl()->readEntry(exName, &outData, sizeof(bool), ParserImpl::ZVT_BOOL);
+            //outStr = std::to_string(outData ? 1 : 0);
+        }
 
-    template <>
-    inline void read<uint32_t>(ZenParser& p, std::string& /*outStr*/, uint32_t& outData, const char* exName)
-    {
-        p.getImpl()->readEntry(exName, &outData, sizeof(uint32_t), ParserImpl::ZVT_INT);
-        //outStr = std::to_string(outData);
-    }
+        template <>
+        inline void read<uint32_t>(ZenParser& p, std::string& /*outStr*/, uint32_t& outData, const char* exName)
+        {
+            p.getImpl()->readEntry(exName, &outData, sizeof(uint32_t), ParserImpl::ZVT_INT);
+            //outStr = std::to_string(outData);
+        }
 
-    template <>
-    inline void read<int32_t>(ZenParser& p, std::string& /*outStr*/, int32_t& outData, const char* exName)
-    {
-        p.getImpl()->readEntry(exName, &outData, sizeof(int32_t), ParserImpl::ZVT_INT);
-        //outStr = std::to_string(outData);
-    }
+        template <>
+        inline void read<int32_t>(ZenParser& p, std::string& /*outStr*/, int32_t& outData, const char* exName)
+        {
+            p.getImpl()->readEntry(exName, &outData, sizeof(int32_t), ParserImpl::ZVT_INT);
+            //outStr = std::to_string(outData);
+        }
 
-    template <>
-    inline void read<uint16_t>(ZenParser& p, std::string& /*outStr*/, uint16_t& outData, const char* exName)
-    {
-        p.getImpl()->readEntry(exName, &outData, sizeof(uint16_t), ParserImpl::ZVT_WORD);
-        //outStr = std::to_string(outData);
-    }
+        template <>
+        inline void read<uint16_t>(ZenParser& p, std::string& /*outStr*/, uint16_t& outData, const char* exName)
+        {
+            p.getImpl()->readEntry(exName, &outData, sizeof(uint16_t), ParserImpl::ZVT_WORD);
+            //outStr = std::to_string(outData);
+        }
 
-    template <>
-    inline void read<uint8_t>(ZenParser& p, std::string& /*outStr*/, uint8_t& outData, const char* exName)
-    {
-        p.getImpl()->readEntry(exName, &outData, sizeof(uint16_t), ParserImpl::ZVT_BYTE);
-        //outStr = std::to_string(outData);
-    }
+        template <>
+        inline void read<uint8_t>(ZenParser& p, std::string& /*outStr*/, uint8_t& outData, const char* exName)
+        {
+            p.getImpl()->readEntry(exName, &outData, sizeof(uint16_t), ParserImpl::ZVT_BYTE);
+            //outStr = std::to_string(outData);
+        }
 
-    template <>
-    inline void read<ZMath::float2>(ZenParser& p, std::string& outStr, ZMath::float2& outData, const char* exName)
-    {
-        p.getImpl()->readEntry(exName, &outData.x, sizeof(float), ParserImpl::ZVT_FLOAT);
-        p.getImpl()->readEntry(exName, &outData.y, sizeof(float), ParserImpl::ZVT_FLOAT);
-        //outStr = "[" + std::to_string(outData.x) + ", " + std::to_string(outData.y) + "]";
-    }
+        template <>
+        inline void read<ZMath::float2>(ZenParser& p, std::string& outStr, ZMath::float2& outData, const char* exName)
+        {
+            p.getImpl()->readEntry(exName, &outData.x, sizeof(float), ParserImpl::ZVT_FLOAT);
+            p.getImpl()->readEntry(exName, &outData.y, sizeof(float), ParserImpl::ZVT_FLOAT);
+            //outStr = "[" + std::to_string(outData.x) + ", " + std::to_string(outData.y) + "]";
+        }
 
-    template <>
-    inline void read<ZMath::float3>(ZenParser& p, std::string& /*outStr*/, ZMath::float3& outData, const char* exName)
-    {
-        p.getImpl()->readEntry(exName, &outData, sizeof(float) * 3, ParserImpl::ZVT_VEC3);
-        /*outStr = "[" + std::to_string(outData.x) 
+        template <>
+        inline void read<ZMath::float3>(ZenParser& p, std::string& /*outStr*/, ZMath::float3& outData, const char* exName)
+        {
+            p.getImpl()->readEntry(exName, &outData, sizeof(float) * 3, ParserImpl::ZVT_VEC3);
+            /*outStr = "[" + std::to_string(outData.x) 
 			+ ", " + std::to_string(outData.y)
 			+ ", " + std::to_string(outData.z) + "]";*/
-    }
+        }
 
-    template <>
-    inline void read<ZMath::float4>(ZenParser& p, std::string& /*outStr*/, ZMath::float4& outData, const char* exName)
-    {
-        p.getImpl()->readEntry(exName, &outData.x, sizeof(float), ParserImpl::ZVT_FLOAT);
-        p.getImpl()->readEntry(exName, &outData.y, sizeof(float), ParserImpl::ZVT_FLOAT);
-        p.getImpl()->readEntry(exName, &outData.z, sizeof(float), ParserImpl::ZVT_FLOAT);
-        p.getImpl()->readEntry(exName, &outData.w, sizeof(float), ParserImpl::ZVT_FLOAT);
-        /*outStr = "[" + std::to_string(outData.x) 
+        template <>
+        inline void read<ZMath::float4>(ZenParser& p, std::string& /*outStr*/, ZMath::float4& outData, const char* exName)
+        {
+            p.getImpl()->readEntry(exName, &outData.x, sizeof(float), ParserImpl::ZVT_FLOAT);
+            p.getImpl()->readEntry(exName, &outData.y, sizeof(float), ParserImpl::ZVT_FLOAT);
+            p.getImpl()->readEntry(exName, &outData.z, sizeof(float), ParserImpl::ZVT_FLOAT);
+            p.getImpl()->readEntry(exName, &outData.w, sizeof(float), ParserImpl::ZVT_FLOAT);
+            /*outStr = "[" + std::to_string(outData.x) 
 			+ ", " + std::to_string(outData.y)
 			+ ", " + std::to_string(outData.z)
 			+ ", " + std::to_string(outData.w) + "]";*/
-    }
+        }
 
-    template <>
-    inline void read<ZMath::Matrix>(ZenParser& p, std::string& /*outStr*/, ZMath::Matrix& outData, const char* exName)
-    {
-        float m[16];
-        p.getImpl()->readEntry(exName, m, sizeof(float) * 16, ParserImpl::ZVT_RAW_FLOAT);
-        outData = m;
+        template <>
+        inline void read<ZMath::Matrix>(ZenParser& p, std::string& /*outStr*/, ZMath::Matrix& outData, const char* exName)
+        {
+            float m[16];
+            p.getImpl()->readEntry(exName, m, sizeof(float) * 16, ParserImpl::ZVT_RAW_FLOAT);
+            outData = m;
 
-        /*outStr = "[";
+            /*outStr = "[";
 		for(size_t i = 0; i < 16; i++)
 		{
 			outStr += std::to_string(m[i]);
@@ -103,37 +105,39 @@ namespace ZenLoad
 				outStr += ", ";
 		}
 		outStr += "]";*/
-    }
+        }
 
-    template <>
-    inline void read<std::string>(ZenParser& p, std::string& outStr, std::string& outData, const char* exName)
-    {
-        p.getImpl()->readEntry(exName, &outData, 0, ParserImpl::ZVT_STRING);
-        outStr = outData;
-    }
+        template <>
+        inline void read<std::string>(ZenParser& p, std::string& outStr, std::string& outData, const char* exName)
+        {
+            p.getImpl()->readEntry(exName, &outData, 0, ParserImpl::ZVT_STRING);
+            outStr = outData;
+        }
 
-    template <typename... T>
-    static void ReadObjectProperties(ZenParser& ZenParser, std::unordered_map<std::string, std::string>& rval, std::pair<const char*, T*>... d)
-    {
-        auto fn = [&ZenParser](auto pair) {
-            std::string outStr;
+        template <typename... T>
+        static void ReadObjectProperties(ZenParser& ZenParser, std::unordered_map<std::string, std::string>& rval, std::pair<const char*, T*>... d)
+        {
+            auto fn = [&ZenParser](auto pair)
+            {
+                std::string outStr;
 
-            // Read the given datatype from the file
-            read<typename std::remove_pointer<decltype(pair.second)>::type>(ZenParser, outStr, *pair.second, pair.first);
+                // Read the given datatype from the file
+                read<typename std::remove_pointer<decltype(pair.second)>::type>(ZenParser, outStr, *pair.second, pair.first);
 
-            // Save the read value as string
-            //rval[pair.first] = outStr;
-        };
+                // Save the read value as string
+                //rval[pair.first] = outStr;
+            };
 
-        auto x = {(fn(d), 0)...};
+            auto x = {(fn(d), 0)...};
 
-        //auto values = std::make_tuple(d...);
-        //Utils::for_each_in_tuple(values, );
-    }
+            //auto values = std::make_tuple(d...);
+            //Utils::for_each_in_tuple(values, );
+        }
 
-    template <typename S>
-    static std::pair<const char*, S*> Prop(const char* t, S& s)
-    {
-        return std::make_pair(t, &s);
-    }
-}  // namespace ZenLoad
+        template <typename S>
+        static std::pair<const char*, S*> Prop(const char* t, S& s)
+        {
+            return std::make_pair(t, &s);
+        }
+    }  // namespace ZenLoad
+}  // namespace ZenLib

--- a/zenload/ztex.h
+++ b/zenload/ztex.h
@@ -24,42 +24,44 @@ Revision History:
 
 #include <inttypes.h>
 
-namespace ZenLoad
+namespace ZenLib
 {
-    /* ZenGin Texture - Render Formats */
-    typedef enum _ZTEX_FORMAT
+    namespace ZenLoad
     {
-        ZTEXFMT_B8G8R8A8, /* 0, 32-bit ARGB pixel format with alpha, using 8 bits per channel */
-        ZTEXFMT_R8G8B8A8, /* 1, 32-bit ARGB pixel format with alpha, using 8 bits per channel */
-        ZTEXFMT_A8B8G8R8, /* 2, 32-bit ARGB pixel format with alpha, using 8 bits per channel */
-        ZTEXFMT_A8R8G8B8, /* 3, 32-bit ARGB pixel format with alpha, using 8 bits per channel */
-        ZTEXFMT_B8G8R8,   /* 4, 24-bit RGB pixel format with 8 bits per channel */
-        ZTEXFMT_R8G8B8,   /* 5, 24-bit RGB pixel format with 8 bits per channel */
-        ZTEXFMT_A4R4G4B4, /* 6, 16-bit ARGB pixel format with 4 bits for each channel */
-        ZTEXFMT_A1R5G5B5, /* 7, 16-bit pixel format where 5 bits are reserved for each color and 1 bit is reserved for alpha */
-        ZTEXFMT_R5G6B5,   /* 8, 16-bit RGB pixel format with 5 bits for red, 6 bits for green, and 5 bits for blue */
-        ZTEXFMT_P8,       /* 9, 8-bit color indexed */
-        ZTEXFMT_DXT1,     /* A, DXT1 compression texture format */
-        ZTEXFMT_DXT2,     /* B, DXT2 compression texture format */
-        ZTEXFMT_DXT3,     /* C, DXT3 compression texture format */
-        ZTEXFMT_DXT4,     /* D, DXT4 compression texture format */
-        ZTEXFMT_DXT5,     /* E, DXT5 compression texture format */
-        ZTEXFMT_COUNT
-    } ZTEX_FORMAT;
+        /* ZenGin Texture - Render Formats */
+        typedef enum _ZTEX_FORMAT
+        {
+            ZTEXFMT_B8G8R8A8, /* 0, 32-bit ARGB pixel format with alpha, using 8 bits per channel */
+            ZTEXFMT_R8G8B8A8, /* 1, 32-bit ARGB pixel format with alpha, using 8 bits per channel */
+            ZTEXFMT_A8B8G8R8, /* 2, 32-bit ARGB pixel format with alpha, using 8 bits per channel */
+            ZTEXFMT_A8R8G8B8, /* 3, 32-bit ARGB pixel format with alpha, using 8 bits per channel */
+            ZTEXFMT_B8G8R8,   /* 4, 24-bit RGB pixel format with 8 bits per channel */
+            ZTEXFMT_R8G8B8,   /* 5, 24-bit RGB pixel format with 8 bits per channel */
+            ZTEXFMT_A4R4G4B4, /* 6, 16-bit ARGB pixel format with 4 bits for each channel */
+            ZTEXFMT_A1R5G5B5, /* 7, 16-bit pixel format where 5 bits are reserved for each color and 1 bit is reserved for alpha */
+            ZTEXFMT_R5G6B5,   /* 8, 16-bit RGB pixel format with 5 bits for red, 6 bits for green, and 5 bits for blue */
+            ZTEXFMT_P8,       /* 9, 8-bit color indexed */
+            ZTEXFMT_DXT1,     /* A, DXT1 compression texture format */
+            ZTEXFMT_DXT2,     /* B, DXT2 compression texture format */
+            ZTEXFMT_DXT3,     /* C, DXT3 compression texture format */
+            ZTEXFMT_DXT4,     /* D, DXT4 compression texture format */
+            ZTEXFMT_DXT5,     /* E, DXT5 compression texture format */
+            ZTEXFMT_COUNT
+        } ZTEX_FORMAT;
 
-    /* ZenGin Texture - Info Block */
-    typedef struct _ZTEX_INFO
-    {
-        uint32_t Format;    /* ZTEXFMT_ */
-        uint32_t Width;     /* mipmap 0 */
-        uint32_t Height;    /* mipmap 0 */
-        uint32_t MipMaps;   /* 1 = none */
-        uint32_t RefWidth;  /* ingame x */
-        uint32_t RefHeight; /* ingame y */
-        uint32_t AvgColor;  /* A8R8G8B8 */
-    } ZTEX_INFO;
+        /* ZenGin Texture - Info Block */
+        typedef struct _ZTEX_INFO
+        {
+            uint32_t Format;    /* ZTEXFMT_ */
+            uint32_t Width;     /* mipmap 0 */
+            uint32_t Height;    /* mipmap 0 */
+            uint32_t MipMaps;   /* 1 = none */
+            uint32_t RefWidth;  /* ingame x */
+            uint32_t RefHeight; /* ingame y */
+            uint32_t AvgColor;  /* A8R8G8B8 */
+        } ZTEX_INFO;
 
-    /* ZenGin Texture - File Signature */
+        /* ZenGin Texture - File Signature */
 #if !defined(__BIG_ENDIAN__) && !defined(_MAC)
 #define ZTEX_FILE_SIGNATURE 0x5845545A /* 'XETZ' (little-endian) */
 #else
@@ -69,115 +71,116 @@ namespace ZenLoad
 /* ZenGin Texture - File Version */
 #define ZTEX_FILE_VERSION_0 0x00000000
 
-    /* ZenGin Texture - File Header */
-    typedef struct _ZTEX_FILE_HEADER
-    {
-        uint32_t Signature; /* ZTEX_FILE_SIGNATURE */
-        uint32_t Version;   /* ZTEX_FILE_VERSION_0 */
-        ZTEX_INFO TexInfo;
-    } ZTEX_FILE_HEADER;
+        /* ZenGin Texture - File Header */
+        typedef struct _ZTEX_FILE_HEADER
+        {
+            uint32_t Signature; /* ZTEX_FILE_SIGNATURE */
+            uint32_t Version;   /* ZTEX_FILE_VERSION_0 */
+            ZTEX_INFO TexInfo;
+        } ZTEX_FILE_HEADER;
 
-    /* ZenGin Texture - Palette Entry */
-    typedef struct _ZTEX_PAL_ENTRY
-    {
-        uint8_t r;
-        uint8_t g;
-        uint8_t b;
-    } ZTEX_PAL_ENTRY;
+        /* ZenGin Texture - Palette Entry */
+        typedef struct _ZTEX_PAL_ENTRY
+        {
+            uint8_t r;
+            uint8_t g;
+            uint8_t b;
+        } ZTEX_PAL_ENTRY;
 
-    /* ZenGin Texture - Number of Palette Entries */
+        /* ZenGin Texture - Number of Palette Entries */
 #define ZTEX_PAL_ENTRIES 0x0100
 
-    /* ZenGin Texture - Stored Palette */
-    typedef struct _ZTEX_PALETTE
-    {
-        ZTEX_PAL_ENTRY Entries[ZTEX_PAL_ENTRIES];
-    } ZTEX_PALETTE;
+        /* ZenGin Texture - Stored Palette */
+        typedef struct _ZTEX_PALETTE
+        {
+            ZTEX_PAL_ENTRY Entries[ZTEX_PAL_ENTRIES];
+        } ZTEX_PALETTE;
 
-    /* OpenZE additions */
+        /* OpenZE additions */
 #ifndef MAKEFOURCC
 #define MAKEFOURCC(ch0, ch1, ch2, ch3)                            \
     ((uint32_t)(uint8_t)(ch0) | ((uint32_t)(uint8_t)(ch1) << 8) | \
      ((uint32_t)(uint8_t)(ch2) << 16) | ((uint32_t)(uint8_t)(ch3) << 24))
 #endif
 
-    enum
-    {
-        DDSD_CAPS = 0x00000001l,
-        DDSD_HEIGHT = 0x00000002l,
-        DDSD_WIDTH = 0x00000004l,
-        DDSD_PITCH = 0x00000008l,
-        DDSD_ALPHABITDEPTH = 0x00000080l,
-        DDSD_PIXELFORMAT = 0x00001000l,
-        DDSD_MIPMAPCOUNT = 0x00020000l,
-        DDSD_LINEARSIZE = 0x00080000l,
-        DDSD_DEPTH = 0x00800000l
-    };
+        enum
+        {
+            DDSD_CAPS = 0x00000001l,
+            DDSD_HEIGHT = 0x00000002l,
+            DDSD_WIDTH = 0x00000004l,
+            DDSD_PITCH = 0x00000008l,
+            DDSD_ALPHABITDEPTH = 0x00000080l,
+            DDSD_PIXELFORMAT = 0x00001000l,
+            DDSD_MIPMAPCOUNT = 0x00020000l,
+            DDSD_LINEARSIZE = 0x00080000l,
+            DDSD_DEPTH = 0x00800000l
+        };
 
-    enum
-    {
-        DDSCAPS_ALPHA = 0x00000002l,    // alpha only surface
-        DDSCAPS_COMPLEX = 0x00000008l,  // complex surface structure
-        DDSCAPS_TEXTURE = 0x00001000l,  // used as texture (should always be set)
-        DDSCAPS_MIPMAP = 0x00400000l    // Mipmap present
-    };
+        enum
+        {
+            DDSCAPS_ALPHA = 0x00000002l,    // alpha only surface
+            DDSCAPS_COMPLEX = 0x00000008l,  // complex surface structure
+            DDSCAPS_TEXTURE = 0x00001000l,  // used as texture (should always be set)
+            DDSCAPS_MIPMAP = 0x00400000l    // Mipmap present
+        };
 
-    typedef struct tagDDPIXELFORMAT
-    {
-        uint32_t dwSize;   // size of this structure (must be 32)
-        uint32_t dwFlags;  // see DDPF_*
-        uint32_t dwFourCC;
-        uint32_t dwRGBBitCount;  // Total number of bits for RGB formats
-        uint32_t dwRBitMask;
-        uint32_t dwGBitMask;
-        uint32_t dwBBitMask;
-        uint32_t dwRGBAlphaBitMask;
-    } DDPIXELFORMAT;
+        typedef struct tagDDPIXELFORMAT
+        {
+            uint32_t dwSize;   // size of this structure (must be 32)
+            uint32_t dwFlags;  // see DDPF_*
+            uint32_t dwFourCC;
+            uint32_t dwRGBBitCount;  // Total number of bits for RGB formats
+            uint32_t dwRBitMask;
+            uint32_t dwGBitMask;
+            uint32_t dwBBitMask;
+            uint32_t dwRGBAlphaBitMask;
+        } DDPIXELFORMAT;
 
-    typedef struct tagDDCAPS2
-    {
-        uint32_t dwCaps1;  // Zero or more of the DDSCAPS_* members
-        uint32_t dwCaps2;  // Zero or more of the DDSCAPS2_* members
-        uint32_t dwReserved[2];
-    } DDCAPS2;
+        typedef struct tagDDCAPS2
+        {
+            uint32_t dwCaps1;  // Zero or more of the DDSCAPS_* members
+            uint32_t dwCaps2;  // Zero or more of the DDSCAPS2_* members
+            uint32_t dwReserved[2];
+        } DDCAPS2;
 
-    enum
-    {
-        DDPF_ALPHAPIXELS = 0x00000001l,  // surface has alpha channel
-        DDPF_ALPHA = 0x00000002l,        // alpha only
-        DDPF_FOURCC = 0x00000004l,       // FOURCC available
-        DDPF_RGB = 0x00000040l,          // RGB(A) bitmap
-        DDPF_PALETTEINDEXED8 = 0x00000020l
-    };
+        enum
+        {
+            DDPF_ALPHAPIXELS = 0x00000001l,  // surface has alpha channel
+            DDPF_ALPHA = 0x00000002l,        // alpha only
+            DDPF_FOURCC = 0x00000004l,       // FOURCC available
+            DDPF_RGB = 0x00000040l,          // RGB(A) bitmap
+            DDPF_PALETTEINDEXED8 = 0x00000020l
+        };
 
-    typedef struct tagDDSURFACEDESC2
-    {
-        uint32_t dwSize;   // size of this structure (must be 124)
-        uint32_t dwFlags;  // combination of the DDSS_* flags
-        uint32_t dwHeight;
-        uint32_t dwWidth;
-        uint32_t dwPitchOrLinearSize;
-        uint32_t dwDepth;  // Depth of a volume texture
-        uint32_t dwMipMapCount;
-        uint32_t dwReserved1[11];
-        DDPIXELFORMAT ddpfPixelFormat;
-        DDCAPS2 ddsCaps;
-        uint32_t dwReserved2;
-    } DDSURFACEDESC2;
+        typedef struct tagDDSURFACEDESC2
+        {
+            uint32_t dwSize;   // size of this structure (must be 124)
+            uint32_t dwFlags;  // combination of the DDSS_* flags
+            uint32_t dwHeight;
+            uint32_t dwWidth;
+            uint32_t dwPitchOrLinearSize;
+            uint32_t dwDepth;  // Depth of a volume texture
+            uint32_t dwMipMapCount;
+            uint32_t dwReserved1[11];
+            DDPIXELFORMAT ddpfPixelFormat;
+            DDCAPS2 ddsCaps;
+            uint32_t dwReserved2;
+        } DDSURFACEDESC2;
 
-    struct ozRGBQUAD
-    {
-        uint8_t rgbBlue;
-        uint8_t rgbGreen;
-        uint8_t rgbRed;
-        uint8_t rgbReserved;
-    };
+        struct ozRGBQUAD
+        {
+            uint8_t rgbBlue;
+            uint8_t rgbGreen;
+            uint8_t rgbRed;
+            uint8_t rgbReserved;
+        };
 
-    struct ozRGBTRIPLE
-    {
-        uint8_t rgbtBlue;
-        uint8_t rgbtGreen;
-        uint8_t rgbtRed;
-    };
-}  // namespace ZenLoad
+        struct ozRGBTRIPLE
+        {
+            uint8_t rgbtBlue;
+            uint8_t rgbtGreen;
+            uint8_t rgbtRed;
+        };
+    }  // namespace ZenLoad
+}  // namespace ZenLib
 #endif /* ZTEX_H_INCLUDE_GUARD */

--- a/zenload/ztex2dds.cpp
+++ b/zenload/ztex2dds.cpp
@@ -21,509 +21,512 @@
 #define ZTEX2DDS_ERROR_WRITE 6  /* Failed to Write Output    */
 #define ZTEX2DDS_ERROR_FORMAT 7 /* Invalid Input File Format */
 
-namespace ZenLoad
+namespace ZenLib
 {
-    /**
+    namespace ZenLoad
+    {
+        /**
 	 * @brief Returns whether x is a power of two
 	 */
-    static bool IsPowerOfTwo(unsigned long x)
-    {
-        if (x == 0)
-            return false;
-        while ((x & 1) == 0)
-            x >>= 1;
-        return (1 == x);
-    }
-
-    /*FIXME: Scanline Alignment */
-    static uint32_t GetMipmapSize(unsigned long format, unsigned long width, unsigned long height, int level)
-    {
-        unsigned long x;
-        unsigned long y;
-        int i;
-
-        x = std::max(1ul, width);
-        y = std::max(1ul, height);
-        for (i = 0; i < level; i++)
+        static bool IsPowerOfTwo(unsigned long x)
         {
-            if (x > 1)
+            if (x == 0)
+                return false;
+            while ((x & 1) == 0)
                 x >>= 1;
-            if (y > 1)
-                y >>= 1;
+            return (1 == x);
         }
 
-        switch (format)
+        /*FIXME: Scanline Alignment */
+        static uint32_t GetMipmapSize(unsigned long format, unsigned long width, unsigned long height, int level)
         {
-            case ZTEXFMT_B8G8R8A8:
-            case ZTEXFMT_R8G8B8A8:
-            case ZTEXFMT_A8B8G8R8:
-            case ZTEXFMT_A8R8G8B8:
-                return x * y * 4;
-            case ZTEXFMT_B8G8R8:
-            case ZTEXFMT_R8G8B8:
-                return x * y * 3;
-            case ZTEXFMT_A4R4G4B4:
-            case ZTEXFMT_A1R5G5B5:
-            case ZTEXFMT_R5G6B5:
-                return x * y * 2;
-            case ZTEXFMT_P8:
-                return x * y;
-            case ZTEXFMT_DXT1:
-                return std::max(1ul, x / 4) * std::max(1ul, y / 4) * 8;
-            case ZTEXFMT_DXT2:
-            case ZTEXFMT_DXT3:
-            case ZTEXFMT_DXT4:
-            case ZTEXFMT_DXT5:
-                return std::max(1ul, x / 4) * std::max(1ul, y / 4) * 16;
-            default:
-                return 0;
-        }
-    }
+            unsigned long x;
+            unsigned long y;
+            int i;
 
-    /**
-	 * @brief Utility function to read data from a vector safely
-	 */
-    static bool readVectorData(void* target, size_t start, size_t size, const std::vector<uint8_t>& data)
-    {
-        if (start + size > data.size())
-            return false;
+            x = std::max(1ul, width);
+            y = std::max(1ul, height);
+            for (i = 0; i < level; i++)
+            {
+                if (x > 1)
+                    x >>= 1;
+                if (y > 1)
+                    y >>= 1;
+            }
 
-        memcpy(target, &data[start], size);
-
-        return true;
-    }
-
-    /**
-	 * @brief Utility function to write to the end of a vector
-	 */
-    static bool writeVectorData(void* data, size_t size, std::vector<uint8_t>& target)
-    {
-        size_t sz=target.size();
-        target.resize(target.size()+size);
-        memcpy(&target[sz],data,size);
-        return true;
-    }
-
-    /**
-	 * @brief Modified ZTEX to DDS conversion
-	 */
-    int convertZTEX2DDS(const std::vector<uint8_t>& ztexData, std::vector<uint8_t>& ddsData, bool optionForceARGB, int* pOutWidth, int* pOutHeight)
-    {
-        ZTEX_FILE_HEADER ZTexHeader;
-        uint32_t BytesRead = 0;
-        uint32_t DdsMagic;
-        uint32_t BytesWritten;
-        DDSURFACEDESC2 DdsHeader;
-        int MipmapCount;
-        int MipmapLevel;
-        int i;
-        ozRGBQUAD palentry;
-        uint32_t BufferSize;
-        uint8_t* Buffer;
-        uint32_t MipmapSize;
-        uint8_t* Mipmap;
-        ozRGBQUAD* Pixel32;
-        ozRGBTRIPLE* Pixel24;
-        uint8_t ColorTemp;
-
-        // Read header
-        if (!readVectorData(&ZTexHeader, 0, sizeof(ZTexHeader), ztexData))
-            return ZTEX2DDS_ERROR_READ;
-
-        if (pOutWidth)
-            *pOutWidth = ZTexHeader.TexInfo.Width;
-
-        if (pOutHeight)
-            *pOutHeight = ZTexHeader.TexInfo.Height;
-
-        BytesRead += sizeof(ZTexHeader);
-
-        /* 'ZTEX' */
-        if (ZTexHeader.Signature != ZTEX_FILE_SIGNATURE ||
-            ZTexHeader.Version != ZTEX_FILE_VERSION_0 ||
-            ZTexHeader.TexInfo.Format > ZTEXFMT_DXT5)
-        {
-            return ZTEX2DDS_ERROR_FORMAT;
-        }
-
-        /* 'DDS ' */
-        DdsMagic = MAKEFOURCC('D', 'D', 'S', ' ');
-        if (!writeVectorData(&DdsMagic, sizeof(DdsMagic), ddsData))
-        {
-            return ZTEX2DDS_ERROR_WRITE;
-        }
-
-        /* DDSURFACEDESC2 */
-        memset(&DdsHeader, 0, sizeof(DdsHeader));
-        DdsHeader.dwSize = sizeof(DDSURFACEDESC2);
-        DdsHeader.dwFlags = DDSD_WIDTH | DDSD_HEIGHT | DDSD_PIXELFORMAT | DDSD_CAPS;
-        DdsHeader.ddsCaps.dwCaps1 = DDSCAPS_TEXTURE;
-        DdsHeader.dwHeight = ZTexHeader.TexInfo.Height;
-        DdsHeader.dwWidth = ZTexHeader.TexInfo.Width;
-        if (ZTexHeader.TexInfo.Format <= ZTEXFMT_P8)
-        {
-            DdsHeader.dwFlags |= DDSD_PITCH;
-            DdsHeader.dwPitchOrLinearSize =
-                GetMipmapSize(ZTexHeader.TexInfo.Format, DdsHeader.dwWidth, 1, 0);
-        }
-        else
-        {
-            DdsHeader.dwFlags |= DDSD_LINEARSIZE;
-            DdsHeader.dwPitchOrLinearSize =
-                GetMipmapSize(ZTexHeader.TexInfo.Format, DdsHeader.dwWidth, DdsHeader.dwHeight, 0);
-        }
-        if (ZTexHeader.TexInfo.MipMaps > 1)
-        {
-            DdsHeader.dwFlags |= DDSD_MIPMAPCOUNT;
-            DdsHeader.ddsCaps.dwCaps1 |= DDSCAPS_MIPMAP | DDSCAPS_COMPLEX;
-            DdsHeader.dwMipMapCount = ZTexHeader.TexInfo.MipMaps;
-        }
-        DdsHeader.ddpfPixelFormat.dwSize = sizeof(DDPIXELFORMAT);
-        switch (ZTexHeader.TexInfo.Format)
-        {
-            case ZTEXFMT_B8G8R8A8:
-                DdsHeader.ddpfPixelFormat.dwFlags = DDPF_RGB | DDPF_ALPHAPIXELS;
-                DdsHeader.ddpfPixelFormat.dwRGBBitCount = 32;
-                DdsHeader.ddpfPixelFormat.dwRBitMask = 0x0000FF00;
-                DdsHeader.ddpfPixelFormat.dwGBitMask = 0x00FF0000;
-                DdsHeader.ddpfPixelFormat.dwBBitMask = 0xFF000000;
-                DdsHeader.ddpfPixelFormat.dwRGBAlphaBitMask = 0x000000FF;
-                break;
-            case ZTEXFMT_R8G8B8A8:
-                DdsHeader.ddpfPixelFormat.dwFlags = DDPF_RGB | DDPF_ALPHAPIXELS;
-                DdsHeader.ddpfPixelFormat.dwRGBBitCount = 32;
-                DdsHeader.ddpfPixelFormat.dwRBitMask = 0xFF000000;
-                DdsHeader.ddpfPixelFormat.dwGBitMask = 0x00FF0000;
-                DdsHeader.ddpfPixelFormat.dwBBitMask = 0x0000FF00;
-                DdsHeader.ddpfPixelFormat.dwRGBAlphaBitMask = 0x000000FF;
-                break;
-            case ZTEXFMT_A8B8G8R8:
-                DdsHeader.ddpfPixelFormat.dwFlags = DDPF_RGB | DDPF_ALPHAPIXELS;
-                // DdsHeader.ddpfPixelFormat.dwFourCC             = D3DFMT_A8B8G8R8; /* 32 */
-                DdsHeader.ddpfPixelFormat.dwRGBBitCount = 32;
-                DdsHeader.ddpfPixelFormat.dwRBitMask = 0x000000FF;
-                DdsHeader.ddpfPixelFormat.dwGBitMask = 0x0000FF00;
-                DdsHeader.ddpfPixelFormat.dwBBitMask = 0x00FF0000;
-                DdsHeader.ddpfPixelFormat.dwRGBAlphaBitMask = 0xFF000000;
-                break;
-            case ZTEXFMT_A8R8G8B8:
-                DdsHeader.ddpfPixelFormat.dwFlags = DDPF_RGB | DDPF_ALPHAPIXELS;
-                // DdsHeader.ddpfPixelFormat.dwFourCC             = D3DFMT_A8R8G8B8; /* 21 */
-                DdsHeader.ddpfPixelFormat.dwRGBBitCount = 32;
-                DdsHeader.ddpfPixelFormat.dwRBitMask = 0x00FF0000;
-                DdsHeader.ddpfPixelFormat.dwGBitMask = 0x0000FF00;
-                DdsHeader.ddpfPixelFormat.dwBBitMask = 0x000000FF;
-                DdsHeader.ddpfPixelFormat.dwRGBAlphaBitMask = 0xFF000000;
-                break;
-            case ZTEXFMT_B8G8R8:
-                DdsHeader.ddpfPixelFormat.dwFlags = DDPF_RGB;
-                DdsHeader.ddpfPixelFormat.dwRGBBitCount = 24;
-                DdsHeader.ddpfPixelFormat.dwRBitMask = 0x000000FF;
-                DdsHeader.ddpfPixelFormat.dwGBitMask = 0x0000FF00;
-                DdsHeader.ddpfPixelFormat.dwBBitMask = 0x00FF0000;
-                break;
-            case ZTEXFMT_R8G8B8:
-                DdsHeader.ddpfPixelFormat.dwFlags = DDPF_RGB;
-                // DdsHeader.ddpfPixelFormat.dwFourCC         = D3DFMT_R8G8B8; /* 20 */
-                DdsHeader.ddpfPixelFormat.dwRGBBitCount = 24;
-                DdsHeader.ddpfPixelFormat.dwRBitMask = 0x00FF0000;
-                DdsHeader.ddpfPixelFormat.dwGBitMask = 0x0000FF00;
-                DdsHeader.ddpfPixelFormat.dwBBitMask = 0x000000FF;
-                break;
-            case ZTEXFMT_A4R4G4B4:
-                DdsHeader.ddpfPixelFormat.dwFlags = DDPF_RGB | DDPF_ALPHAPIXELS;
-                // DdsHeader.ddpfPixelFormat.dwFourCC             = D3DFMT_A4R4G4B4; /* 26 */
-                DdsHeader.ddpfPixelFormat.dwRGBBitCount = 16;
-                DdsHeader.ddpfPixelFormat.dwRBitMask = 0x00000F00;
-                DdsHeader.ddpfPixelFormat.dwGBitMask = 0x000000F0;
-                DdsHeader.ddpfPixelFormat.dwBBitMask = 0x0000000F;
-                DdsHeader.ddpfPixelFormat.dwRGBAlphaBitMask = 0x0000F000;
-                break;
-            case ZTEXFMT_A1R5G5B5:
-                DdsHeader.ddpfPixelFormat.dwFlags = DDPF_RGB | DDPF_ALPHAPIXELS;
-                // DdsHeader.ddpfPixelFormat.dwFourCC             = D3DFMT_A1R5G5B5; /* 25 */
-                DdsHeader.ddpfPixelFormat.dwRGBBitCount = 16;
-                DdsHeader.ddpfPixelFormat.dwRBitMask = 0x00007C00;
-                DdsHeader.ddpfPixelFormat.dwGBitMask = 0x000003E0;
-                DdsHeader.ddpfPixelFormat.dwBBitMask = 0x0000001F;
-                DdsHeader.ddpfPixelFormat.dwRGBAlphaBitMask = 0x00008000;
-                break;
-            case ZTEXFMT_R5G6B5:
-                DdsHeader.ddpfPixelFormat.dwFlags = DDPF_RGB;
-                // DdsHeader.ddpfPixelFormat.dwFourCC         = D3DFMT_R5G6B5; /* 23 */
-                DdsHeader.ddpfPixelFormat.dwRGBBitCount = 16;
-                DdsHeader.ddpfPixelFormat.dwRBitMask = 0x0000F800;
-                DdsHeader.ddpfPixelFormat.dwGBitMask = 0x000007E0;
-                DdsHeader.ddpfPixelFormat.dwBBitMask = 0x0000001F;
-                break;
-            case ZTEXFMT_P8:
-                DdsHeader.ddpfPixelFormat.dwFlags = DDPF_PALETTEINDEXED8;
-                // DdsHeader.ddpfPixelFormat.dwFourCC = D3DFMT_P8; /* 41 */
-                break;
-            case ZTEXFMT_DXT1:
-                DdsHeader.ddpfPixelFormat.dwFlags = DDPF_FOURCC;
-                DdsHeader.ddpfPixelFormat.dwFourCC = MAKEFOURCC('D', 'X', 'T', '1');
-                break;
-            case ZTEXFMT_DXT2:
-                DdsHeader.ddpfPixelFormat.dwFlags = DDPF_FOURCC;
-                DdsHeader.ddpfPixelFormat.dwFourCC = MAKEFOURCC('D', 'X', 'T', '2');
-                break;
-            case ZTEXFMT_DXT3:
-                DdsHeader.ddpfPixelFormat.dwFlags = DDPF_FOURCC;
-                DdsHeader.ddpfPixelFormat.dwFourCC = MAKEFOURCC('D', 'X', 'T', '3');
-                break;
-            case ZTEXFMT_DXT4:
-                DdsHeader.ddpfPixelFormat.dwFlags = DDPF_FOURCC;
-                DdsHeader.ddpfPixelFormat.dwFourCC = MAKEFOURCC('D', 'X', 'T', '4');
-                break;
-            case ZTEXFMT_DXT5:
-                DdsHeader.ddpfPixelFormat.dwFlags = DDPF_FOURCC;
-                DdsHeader.ddpfPixelFormat.dwFourCC = MAKEFOURCC('D', 'X', 'T', '5');
-                break;
-        }
-        if (optionForceARGB)
-        {
-            switch (ZTexHeader.TexInfo.Format)
+            switch (format)
             {
                 case ZTEXFMT_B8G8R8A8:
                 case ZTEXFMT_R8G8B8A8:
                 case ZTEXFMT_A8B8G8R8:
+                case ZTEXFMT_A8R8G8B8:
+                    return x * y * 4;
+                case ZTEXFMT_B8G8R8:
+                case ZTEXFMT_R8G8B8:
+                    return x * y * 3;
+                case ZTEXFMT_A4R4G4B4:
+                case ZTEXFMT_A1R5G5B5:
+                case ZTEXFMT_R5G6B5:
+                    return x * y * 2;
+                case ZTEXFMT_P8:
+                    return x * y;
+                case ZTEXFMT_DXT1:
+                    return std::max(1ul, x / 4) * std::max(1ul, y / 4) * 8;
+                case ZTEXFMT_DXT2:
+                case ZTEXFMT_DXT3:
+                case ZTEXFMT_DXT4:
+                case ZTEXFMT_DXT5:
+                    return std::max(1ul, x / 4) * std::max(1ul, y / 4) * 16;
+                default:
+                    return 0;
+            }
+        }
+
+        /**
+	 * @brief Utility function to read data from a vector safely
+	 */
+        static bool readVectorData(void* target, size_t start, size_t size, const std::vector<uint8_t>& data)
+        {
+            if (start + size > data.size())
+                return false;
+
+            memcpy(target, &data[start], size);
+
+            return true;
+        }
+
+        /**
+	 * @brief Utility function to write to the end of a vector
+	 */
+        static bool writeVectorData(void* data, size_t size, std::vector<uint8_t>& target)
+        {
+            size_t sz = target.size();
+            target.resize(target.size() + size);
+            memcpy(&target[sz], data, size);
+            return true;
+        }
+
+        /**
+	 * @brief Modified ZTEX to DDS conversion
+	 */
+        int convertZTEX2DDS(const std::vector<uint8_t>& ztexData, std::vector<uint8_t>& ddsData, bool optionForceARGB, int* pOutWidth, int* pOutHeight)
+        {
+            ZTEX_FILE_HEADER ZTexHeader;
+            uint32_t BytesRead = 0;
+            uint32_t DdsMagic;
+            uint32_t BytesWritten;
+            DDSURFACEDESC2 DdsHeader;
+            int MipmapCount;
+            int MipmapLevel;
+            int i;
+            ozRGBQUAD palentry;
+            uint32_t BufferSize;
+            uint8_t* Buffer;
+            uint32_t MipmapSize;
+            uint8_t* Mipmap;
+            ozRGBQUAD* Pixel32;
+            ozRGBTRIPLE* Pixel24;
+            uint8_t ColorTemp;
+
+            // Read header
+            if (!readVectorData(&ZTexHeader, 0, sizeof(ZTexHeader), ztexData))
+                return ZTEX2DDS_ERROR_READ;
+
+            if (pOutWidth)
+                *pOutWidth = ZTexHeader.TexInfo.Width;
+
+            if (pOutHeight)
+                *pOutHeight = ZTexHeader.TexInfo.Height;
+
+            BytesRead += sizeof(ZTexHeader);
+
+            /* 'ZTEX' */
+            if (ZTexHeader.Signature != ZTEX_FILE_SIGNATURE ||
+                ZTexHeader.Version != ZTEX_FILE_VERSION_0 ||
+                ZTexHeader.TexInfo.Format > ZTEXFMT_DXT5)
+            {
+                return ZTEX2DDS_ERROR_FORMAT;
+            }
+
+            /* 'DDS ' */
+            DdsMagic = MAKEFOURCC('D', 'D', 'S', ' ');
+            if (!writeVectorData(&DdsMagic, sizeof(DdsMagic), ddsData))
+            {
+                return ZTEX2DDS_ERROR_WRITE;
+            }
+
+            /* DDSURFACEDESC2 */
+            memset(&DdsHeader, 0, sizeof(DdsHeader));
+            DdsHeader.dwSize = sizeof(DDSURFACEDESC2);
+            DdsHeader.dwFlags = DDSD_WIDTH | DDSD_HEIGHT | DDSD_PIXELFORMAT | DDSD_CAPS;
+            DdsHeader.ddsCaps.dwCaps1 = DDSCAPS_TEXTURE;
+            DdsHeader.dwHeight = ZTexHeader.TexInfo.Height;
+            DdsHeader.dwWidth = ZTexHeader.TexInfo.Width;
+            if (ZTexHeader.TexInfo.Format <= ZTEXFMT_P8)
+            {
+                DdsHeader.dwFlags |= DDSD_PITCH;
+                DdsHeader.dwPitchOrLinearSize =
+                    GetMipmapSize(ZTexHeader.TexInfo.Format, DdsHeader.dwWidth, 1, 0);
+            }
+            else
+            {
+                DdsHeader.dwFlags |= DDSD_LINEARSIZE;
+                DdsHeader.dwPitchOrLinearSize =
+                    GetMipmapSize(ZTexHeader.TexInfo.Format, DdsHeader.dwWidth, DdsHeader.dwHeight, 0);
+            }
+            if (ZTexHeader.TexInfo.MipMaps > 1)
+            {
+                DdsHeader.dwFlags |= DDSD_MIPMAPCOUNT;
+                DdsHeader.ddsCaps.dwCaps1 |= DDSCAPS_MIPMAP | DDSCAPS_COMPLEX;
+                DdsHeader.dwMipMapCount = ZTexHeader.TexInfo.MipMaps;
+            }
+            DdsHeader.ddpfPixelFormat.dwSize = sizeof(DDPIXELFORMAT);
+            switch (ZTexHeader.TexInfo.Format)
+            {
+                case ZTEXFMT_B8G8R8A8:
+                    DdsHeader.ddpfPixelFormat.dwFlags = DDPF_RGB | DDPF_ALPHAPIXELS;
+                    DdsHeader.ddpfPixelFormat.dwRGBBitCount = 32;
+                    DdsHeader.ddpfPixelFormat.dwRBitMask = 0x0000FF00;
+                    DdsHeader.ddpfPixelFormat.dwGBitMask = 0x00FF0000;
+                    DdsHeader.ddpfPixelFormat.dwBBitMask = 0xFF000000;
+                    DdsHeader.ddpfPixelFormat.dwRGBAlphaBitMask = 0x000000FF;
+                    break;
+                case ZTEXFMT_R8G8B8A8:
+                    DdsHeader.ddpfPixelFormat.dwFlags = DDPF_RGB | DDPF_ALPHAPIXELS;
+                    DdsHeader.ddpfPixelFormat.dwRGBBitCount = 32;
+                    DdsHeader.ddpfPixelFormat.dwRBitMask = 0xFF000000;
+                    DdsHeader.ddpfPixelFormat.dwGBitMask = 0x00FF0000;
+                    DdsHeader.ddpfPixelFormat.dwBBitMask = 0x0000FF00;
+                    DdsHeader.ddpfPixelFormat.dwRGBAlphaBitMask = 0x000000FF;
+                    break;
+                case ZTEXFMT_A8B8G8R8:
+                    DdsHeader.ddpfPixelFormat.dwFlags = DDPF_RGB | DDPF_ALPHAPIXELS;
+                    // DdsHeader.ddpfPixelFormat.dwFourCC             = D3DFMT_A8B8G8R8; /* 32 */
+                    DdsHeader.ddpfPixelFormat.dwRGBBitCount = 32;
+                    DdsHeader.ddpfPixelFormat.dwRBitMask = 0x000000FF;
+                    DdsHeader.ddpfPixelFormat.dwGBitMask = 0x0000FF00;
+                    DdsHeader.ddpfPixelFormat.dwBBitMask = 0x00FF0000;
+                    DdsHeader.ddpfPixelFormat.dwRGBAlphaBitMask = 0xFF000000;
+                    break;
+                case ZTEXFMT_A8R8G8B8:
+                    DdsHeader.ddpfPixelFormat.dwFlags = DDPF_RGB | DDPF_ALPHAPIXELS;
+                    // DdsHeader.ddpfPixelFormat.dwFourCC             = D3DFMT_A8R8G8B8; /* 21 */
+                    DdsHeader.ddpfPixelFormat.dwRGBBitCount = 32;
                     DdsHeader.ddpfPixelFormat.dwRBitMask = 0x00FF0000;
                     DdsHeader.ddpfPixelFormat.dwGBitMask = 0x0000FF00;
                     DdsHeader.ddpfPixelFormat.dwBBitMask = 0x000000FF;
                     DdsHeader.ddpfPixelFormat.dwRGBAlphaBitMask = 0xFF000000;
                     break;
                 case ZTEXFMT_B8G8R8:
+                    DdsHeader.ddpfPixelFormat.dwFlags = DDPF_RGB;
+                    DdsHeader.ddpfPixelFormat.dwRGBBitCount = 24;
+                    DdsHeader.ddpfPixelFormat.dwRBitMask = 0x000000FF;
+                    DdsHeader.ddpfPixelFormat.dwGBitMask = 0x0000FF00;
+                    DdsHeader.ddpfPixelFormat.dwBBitMask = 0x00FF0000;
+                    break;
+                case ZTEXFMT_R8G8B8:
+                    DdsHeader.ddpfPixelFormat.dwFlags = DDPF_RGB;
+                    // DdsHeader.ddpfPixelFormat.dwFourCC         = D3DFMT_R8G8B8; /* 20 */
+                    DdsHeader.ddpfPixelFormat.dwRGBBitCount = 24;
                     DdsHeader.ddpfPixelFormat.dwRBitMask = 0x00FF0000;
                     DdsHeader.ddpfPixelFormat.dwGBitMask = 0x0000FF00;
                     DdsHeader.ddpfPixelFormat.dwBBitMask = 0x000000FF;
                     break;
-                default:
+                case ZTEXFMT_A4R4G4B4:
+                    DdsHeader.ddpfPixelFormat.dwFlags = DDPF_RGB | DDPF_ALPHAPIXELS;
+                    // DdsHeader.ddpfPixelFormat.dwFourCC             = D3DFMT_A4R4G4B4; /* 26 */
+                    DdsHeader.ddpfPixelFormat.dwRGBBitCount = 16;
+                    DdsHeader.ddpfPixelFormat.dwRBitMask = 0x00000F00;
+                    DdsHeader.ddpfPixelFormat.dwGBitMask = 0x000000F0;
+                    DdsHeader.ddpfPixelFormat.dwBBitMask = 0x0000000F;
+                    DdsHeader.ddpfPixelFormat.dwRGBAlphaBitMask = 0x0000F000;
+                    break;
+                case ZTEXFMT_A1R5G5B5:
+                    DdsHeader.ddpfPixelFormat.dwFlags = DDPF_RGB | DDPF_ALPHAPIXELS;
+                    // DdsHeader.ddpfPixelFormat.dwFourCC             = D3DFMT_A1R5G5B5; /* 25 */
+                    DdsHeader.ddpfPixelFormat.dwRGBBitCount = 16;
+                    DdsHeader.ddpfPixelFormat.dwRBitMask = 0x00007C00;
+                    DdsHeader.ddpfPixelFormat.dwGBitMask = 0x000003E0;
+                    DdsHeader.ddpfPixelFormat.dwBBitMask = 0x0000001F;
+                    DdsHeader.ddpfPixelFormat.dwRGBAlphaBitMask = 0x00008000;
+                    break;
+                case ZTEXFMT_R5G6B5:
+                    DdsHeader.ddpfPixelFormat.dwFlags = DDPF_RGB;
+                    // DdsHeader.ddpfPixelFormat.dwFourCC         = D3DFMT_R5G6B5; /* 23 */
+                    DdsHeader.ddpfPixelFormat.dwRGBBitCount = 16;
+                    DdsHeader.ddpfPixelFormat.dwRBitMask = 0x0000F800;
+                    DdsHeader.ddpfPixelFormat.dwGBitMask = 0x000007E0;
+                    DdsHeader.ddpfPixelFormat.dwBBitMask = 0x0000001F;
+                    break;
+                case ZTEXFMT_P8:
+                    DdsHeader.ddpfPixelFormat.dwFlags = DDPF_PALETTEINDEXED8;
+                    // DdsHeader.ddpfPixelFormat.dwFourCC = D3DFMT_P8; /* 41 */
+                    break;
+                case ZTEXFMT_DXT1:
+                    DdsHeader.ddpfPixelFormat.dwFlags = DDPF_FOURCC;
+                    DdsHeader.ddpfPixelFormat.dwFourCC = MAKEFOURCC('D', 'X', 'T', '1');
+                    break;
+                case ZTEXFMT_DXT2:
+                    DdsHeader.ddpfPixelFormat.dwFlags = DDPF_FOURCC;
+                    DdsHeader.ddpfPixelFormat.dwFourCC = MAKEFOURCC('D', 'X', 'T', '2');
+                    break;
+                case ZTEXFMT_DXT3:
+                    DdsHeader.ddpfPixelFormat.dwFlags = DDPF_FOURCC;
+                    DdsHeader.ddpfPixelFormat.dwFourCC = MAKEFOURCC('D', 'X', 'T', '3');
+                    break;
+                case ZTEXFMT_DXT4:
+                    DdsHeader.ddpfPixelFormat.dwFlags = DDPF_FOURCC;
+                    DdsHeader.ddpfPixelFormat.dwFourCC = MAKEFOURCC('D', 'X', 'T', '4');
+                    break;
+                case ZTEXFMT_DXT5:
+                    DdsHeader.ddpfPixelFormat.dwFlags = DDPF_FOURCC;
+                    DdsHeader.ddpfPixelFormat.dwFourCC = MAKEFOURCC('D', 'X', 'T', '5');
                     break;
             }
-        }
-
-        if (!writeVectorData(&DdsHeader, sizeof(DdsHeader), ddsData))
-        {
-            return ZTEX2DDS_ERROR_WRITE;
-        }
-
-        /* Palette */
-        if (ZTEXFMT_P8 == ZTexHeader.TexInfo.Format)
-        {
-            for (i = 0; i < ZTEX_PAL_ENTRIES; i++)
-            {
-                palentry.rgbReserved = 0x00;
-                if (!readVectorData(&palentry, BytesRead, sizeof(palentry), ztexData))
-                {
-                    return ZTEX2DDS_ERROR_READ;
-                }
-
-                BytesRead += sizeof(palentry);
-
-                if (!writeVectorData(&palentry, sizeof(ozRGBQUAD), ddsData))
-                {
-                    return ZTEX2DDS_ERROR_WRITE;
-                }
-            }
-        }
-        /* Mipmaps */
-        MipmapCount = std::max(1u, ZTexHeader.TexInfo.MipMaps);
-        BufferSize = 0;
-        for (MipmapLevel = 0; MipmapLevel < MipmapCount; MipmapLevel++)
-            BufferSize += GetMipmapSize(ZTexHeader.TexInfo.Format,
-                                        ZTexHeader.TexInfo.Width, ZTexHeader.TexInfo.Height, MipmapLevel);
-
-        Buffer = new uint8_t[BufferSize];
-        if (!Buffer)
-        {
-            return ZTEX2DDS_ERROR_READ;
-        }
-
-        if (!readVectorData(Buffer, BytesRead, BufferSize, ztexData))
-        {
-            return ZTEX2DDS_ERROR_READ;
-        }
-        BytesRead += BufferSize;
-
-        Mipmap = Buffer + BufferSize;
-        for (MipmapLevel = 0; MipmapLevel < MipmapCount; MipmapLevel++)
-        {
-            MipmapSize = GetMipmapSize(ZTexHeader.TexInfo.Format,
-                                       ZTexHeader.TexInfo.Width, ZTexHeader.TexInfo.Height, MipmapLevel);
-            Mipmap -= MipmapSize;
             if (optionForceARGB)
             {
-                Pixel32 = (ozRGBQUAD*)Mipmap;
-                Pixel24 = (ozRGBTRIPLE*)Mipmap;
                 switch (ZTexHeader.TexInfo.Format)
                 {
                     case ZTEXFMT_B8G8R8A8:
-                        for (i = 0; i < (int)MipmapSize / 4; i++)
-                        {
-                            ColorTemp = Pixel32->rgbReserved;
-                            Pixel32->rgbReserved = Pixel32->rgbBlue;
-                            Pixel32->rgbBlue = ColorTemp;
-                            ColorTemp = Pixel32->rgbRed;
-                            Pixel32->rgbRed = Pixel32->rgbGreen;
-                            Pixel32->rgbGreen = ColorTemp;
-                            Pixel32++;
-                        }
-                        break;
                     case ZTEXFMT_R8G8B8A8:
-                        for (i = 0; i < (int)MipmapSize / 4; i++)
-                        {
-                            ColorTemp = Pixel32->rgbBlue;
-                            Pixel32->rgbBlue = Pixel32->rgbGreen;
-                            Pixel32->rgbGreen = Pixel32->rgbRed;
-                            Pixel32->rgbRed = Pixel32->rgbReserved;
-                            Pixel32->rgbReserved = ColorTemp;
-                            Pixel32++;
-                        }
-                        break;
                     case ZTEXFMT_A8B8G8R8:
-                        for (i = 0; i < (int)MipmapSize / 4; i++)
-                        {
-                            ColorTemp = Pixel32->rgbBlue;
-                            Pixel32->rgbBlue = Pixel32->rgbRed;
-                            Pixel32->rgbRed = ColorTemp;
-                            Pixel32++;
-                        }
+                        DdsHeader.ddpfPixelFormat.dwRBitMask = 0x00FF0000;
+                        DdsHeader.ddpfPixelFormat.dwGBitMask = 0x0000FF00;
+                        DdsHeader.ddpfPixelFormat.dwBBitMask = 0x000000FF;
+                        DdsHeader.ddpfPixelFormat.dwRGBAlphaBitMask = 0xFF000000;
                         break;
                     case ZTEXFMT_B8G8R8:
-                        for (i = 0; i < (int)MipmapSize / 3; i++)
-                        {
-                            ColorTemp = Pixel24->rgbtBlue;
-                            Pixel24->rgbtBlue = Pixel24->rgbtRed;
-                            Pixel24->rgbtRed = ColorTemp;
-                            Pixel24++;
-                        }
+                        DdsHeader.ddpfPixelFormat.dwRBitMask = 0x00FF0000;
+                        DdsHeader.ddpfPixelFormat.dwGBitMask = 0x0000FF00;
+                        DdsHeader.ddpfPixelFormat.dwBBitMask = 0x000000FF;
                         break;
                     default:
                         break;
                 }
             }
 
-            if (!writeVectorData(Mipmap, MipmapSize, ddsData))
+            if (!writeVectorData(&DdsHeader, sizeof(DdsHeader), ddsData))
             {
-                delete[] Buffer;
                 return ZTEX2DDS_ERROR_WRITE;
             }
+
+            /* Palette */
+            if (ZTEXFMT_P8 == ZTexHeader.TexInfo.Format)
+            {
+                for (i = 0; i < ZTEX_PAL_ENTRIES; i++)
+                {
+                    palentry.rgbReserved = 0x00;
+                    if (!readVectorData(&palentry, BytesRead, sizeof(palentry), ztexData))
+                    {
+                        return ZTEX2DDS_ERROR_READ;
+                    }
+
+                    BytesRead += sizeof(palentry);
+
+                    if (!writeVectorData(&palentry, sizeof(ozRGBQUAD), ddsData))
+                    {
+                        return ZTEX2DDS_ERROR_WRITE;
+                    }
+                }
+            }
+            /* Mipmaps */
+            MipmapCount = std::max(1u, ZTexHeader.TexInfo.MipMaps);
+            BufferSize = 0;
+            for (MipmapLevel = 0; MipmapLevel < MipmapCount; MipmapLevel++)
+                BufferSize += GetMipmapSize(ZTexHeader.TexInfo.Format,
+                                            ZTexHeader.TexInfo.Width, ZTexHeader.TexInfo.Height, MipmapLevel);
+
+            Buffer = new uint8_t[BufferSize];
+            if (!Buffer)
+            {
+                return ZTEX2DDS_ERROR_READ;
+            }
+
+            if (!readVectorData(Buffer, BytesRead, BufferSize, ztexData))
+            {
+                return ZTEX2DDS_ERROR_READ;
+            }
+            BytesRead += BufferSize;
+
+            Mipmap = Buffer + BufferSize;
+            for (MipmapLevel = 0; MipmapLevel < MipmapCount; MipmapLevel++)
+            {
+                MipmapSize = GetMipmapSize(ZTexHeader.TexInfo.Format,
+                                           ZTexHeader.TexInfo.Width, ZTexHeader.TexInfo.Height, MipmapLevel);
+                Mipmap -= MipmapSize;
+                if (optionForceARGB)
+                {
+                    Pixel32 = (ozRGBQUAD*)Mipmap;
+                    Pixel24 = (ozRGBTRIPLE*)Mipmap;
+                    switch (ZTexHeader.TexInfo.Format)
+                    {
+                        case ZTEXFMT_B8G8R8A8:
+                            for (i = 0; i < (int)MipmapSize / 4; i++)
+                            {
+                                ColorTemp = Pixel32->rgbReserved;
+                                Pixel32->rgbReserved = Pixel32->rgbBlue;
+                                Pixel32->rgbBlue = ColorTemp;
+                                ColorTemp = Pixel32->rgbRed;
+                                Pixel32->rgbRed = Pixel32->rgbGreen;
+                                Pixel32->rgbGreen = ColorTemp;
+                                Pixel32++;
+                            }
+                            break;
+                        case ZTEXFMT_R8G8B8A8:
+                            for (i = 0; i < (int)MipmapSize / 4; i++)
+                            {
+                                ColorTemp = Pixel32->rgbBlue;
+                                Pixel32->rgbBlue = Pixel32->rgbGreen;
+                                Pixel32->rgbGreen = Pixel32->rgbRed;
+                                Pixel32->rgbRed = Pixel32->rgbReserved;
+                                Pixel32->rgbReserved = ColorTemp;
+                                Pixel32++;
+                            }
+                            break;
+                        case ZTEXFMT_A8B8G8R8:
+                            for (i = 0; i < (int)MipmapSize / 4; i++)
+                            {
+                                ColorTemp = Pixel32->rgbBlue;
+                                Pixel32->rgbBlue = Pixel32->rgbRed;
+                                Pixel32->rgbRed = ColorTemp;
+                                Pixel32++;
+                            }
+                            break;
+                        case ZTEXFMT_B8G8R8:
+                            for (i = 0; i < (int)MipmapSize / 3; i++)
+                            {
+                                ColorTemp = Pixel24->rgbtBlue;
+                                Pixel24->rgbtBlue = Pixel24->rgbtRed;
+                                Pixel24->rgbtRed = ColorTemp;
+                                Pixel24++;
+                            }
+                            break;
+                        default:
+                            break;
+                    }
+                }
+
+                if (!writeVectorData(Mipmap, MipmapSize, ddsData))
+                {
+                    delete[] Buffer;
+                    return ZTEX2DDS_ERROR_WRITE;
+                }
+            }
+            delete[] Buffer;
+
+            return ZTEX2DDS_ERROR_NONE;
         }
-        delete[] Buffer;
 
-        return ZTEX2DDS_ERROR_NONE;
-    }
-
-    static uint32_t ComputeSizeInBytes(int mip, int resolutionX, int resolutionY, bool dxt1)
-    {
-        int px = (int)std::max(1.0f, (float)floor(resolutionX / pow(2.0f, mip)));
-        int py = (int)std::max(1.0f, (float)floor(resolutionY / pow(2.0f, mip)));
-        //int px = TextureSize.x;
-        //int py = TextureSize.y;
-
-        // compute the storage requirements
-        int blockcount = ((px + 3) / 4) * ((py + 3) / 4);
-        int blocksize = dxt1 ? 8 : 16;
-        return blockcount * blocksize;
-    }
-
-    DXTLevel getDXTLevelFromDDS(const std::vector<uint8_t>& ddsData)
-    {
-        DDSURFACEDESC2 desc = getSurfaceDesc(ddsData);
-
-        switch (desc.ddpfPixelFormat.dwFourCC)
+        static uint32_t ComputeSizeInBytes(int mip, int resolutionX, int resolutionY, bool dxt1)
         {
-            case MAKEFOURCC('D', 'X', 'T', '1'):
-                return DXTLevel::DXT1;
-                break;
+            int px = (int)std::max(1.0f, (float)floor(resolutionX / pow(2.0f, mip)));
+            int py = (int)std::max(1.0f, (float)floor(resolutionY / pow(2.0f, mip)));
+            //int px = TextureSize.x;
+            //int py = TextureSize.y;
 
-            case MAKEFOURCC('D', 'X', 'T', '3'):
-                return DXTLevel::DXT3;
-                break;
-
-            case MAKEFOURCC('D', 'X', 'T', '5'):
-                return DXTLevel::DXT5;
-                break;
-            default:
-                return DXTLevel::Unknown;
+            // compute the storage requirements
+            int blockcount = ((px + 3) / 4) * ((py + 3) / 4);
+            int blocksize = dxt1 ? 8 : 16;
+            return blockcount * blocksize;
         }
-    }
 
-    size_t getMipFileOffsetFromDDS(const std::vector<uint8_t>& ddsData, int mip)
-    {
-        size_t seek = 0;
-
-        seek += sizeof(uint32_t);        // Skip magic number
-        seek += sizeof(DDSURFACEDESC2);  // Skip header
-
-        DDSURFACEDESC2 desc = getSurfaceDesc(ddsData);
-        DXTLevel dxt = getDXTLevelFromDDS(ddsData);
-
-        for (int i = 0; i < mip; i++)
+        DXTLevel getDXTLevelFromDDS(const std::vector<uint8_t>& ddsData)
         {
-            seek += ComputeSizeInBytes(i, desc.dwWidth, desc.dwHeight, dxt == DXTLevel::DXT1);
+            DDSURFACEDESC2 desc = getSurfaceDesc(ddsData);
+
+            switch (desc.ddpfPixelFormat.dwFourCC)
+            {
+                case MAKEFOURCC('D', 'X', 'T', '1'):
+                    return DXTLevel::DXT1;
+                    break;
+
+                case MAKEFOURCC('D', 'X', 'T', '3'):
+                    return DXTLevel::DXT3;
+                    break;
+
+                case MAKEFOURCC('D', 'X', 'T', '5'):
+                    return DXTLevel::DXT5;
+                    break;
+                default:
+                    return DXTLevel::Unknown;
+            }
         }
 
-        return seek;
-    }
+        size_t getMipFileOffsetFromDDS(const std::vector<uint8_t>& ddsData, int mip)
+        {
+            size_t seek = 0;
 
-    /**
+            seek += sizeof(uint32_t);        // Skip magic number
+            seek += sizeof(DDSURFACEDESC2);  // Skip header
+
+            DDSURFACEDESC2 desc = getSurfaceDesc(ddsData);
+            DXTLevel dxt = getDXTLevelFromDDS(ddsData);
+
+            for (int i = 0; i < mip; i++)
+            {
+                seek += ComputeSizeInBytes(i, desc.dwWidth, desc.dwHeight, dxt == DXTLevel::DXT1);
+            }
+
+            return seek;
+        }
+
+        /**
 	 * @param ddsData Loaded dds
 	 * @return Pointer to the surface info of the given dds
 	 */
-    DDSURFACEDESC2 getSurfaceDesc(const std::vector<uint8_t>& ddsData)
-    {
-        DDSURFACEDESC2 desc;
+        DDSURFACEDESC2 getSurfaceDesc(const std::vector<uint8_t>& ddsData)
+        {
+            DDSURFACEDESC2 desc;
 
-        memcpy(&desc, &ddsData[sizeof(uint32_t)], sizeof(DDSURFACEDESC2));
+            memcpy(&desc, &ddsData[sizeof(uint32_t)], sizeof(DDSURFACEDESC2));
 
-        return desc;
-    }
+            return desc;
+        }
 
-    /**
+        /**
 	 * @brief Convert dds to RGBA8
 	 */
-    void convertDDSToRGBA8(const std::vector<uint8_t>& ddsData, std::vector<uint8_t>& rgba8Data, int mip)
-    {
-        size_t seek = 0;
-        seek += sizeof(uint32_t);  // Skip magic number
-        const DDSURFACEDESC2* desc = reinterpret_cast<const DDSURFACEDESC2*>(&ddsData[seek]);
-        seek += sizeof(DDSURFACEDESC2);
-
-        mip = std::min((int)mip, (int)desc->dwMipMapCount);
-
-        DXTLevel dxtLevel = getDXTLevelFromDDS(ddsData);
-        int squishDxtLevel;
-        switch (dxtLevel)
+        void convertDDSToRGBA8(const std::vector<uint8_t>& ddsData, std::vector<uint8_t>& rgba8Data, int mip)
         {
-            case DXTLevel::DXT1:
-                squishDxtLevel = squish::kDxt1;
-                break;
+            size_t seek = 0;
+            seek += sizeof(uint32_t);  // Skip magic number
+            const DDSURFACEDESC2* desc = reinterpret_cast<const DDSURFACEDESC2*>(&ddsData[seek]);
+            seek += sizeof(DDSURFACEDESC2);
 
-            case DXTLevel::DXT3:
-                squishDxtLevel = squish::kDxt3;
-                break;
+            mip = std::min((int)mip, (int)desc->dwMipMapCount);
 
-            case DXTLevel::DXT5:
-                squishDxtLevel = squish::kDxt5;
-                break;
+            DXTLevel dxtLevel = getDXTLevelFromDDS(ddsData);
+            int squishDxtLevel;
+            switch (dxtLevel)
+            {
+                case DXTLevel::DXT1:
+                    squishDxtLevel = squish::kDxt1;
+                    break;
 
-            case DXTLevel::Unknown:
-                assert(false);
-                return;
+                case DXTLevel::DXT3:
+                    squishDxtLevel = squish::kDxt3;
+                    break;
+
+                case DXTLevel::DXT5:
+                    squishDxtLevel = squish::kDxt5;
+                    break;
+
+                case DXTLevel::Unknown:
+                    assert(false);
+                    return;
+            }
+
+            for (int i = 0; i < mip; i++)
+            {
+                seek += ComputeSizeInBytes(i, desc->dwWidth, desc->dwHeight, squishDxtLevel == squish::kDxt1);
+            }
+
+            int px = (int)std::max(1.0f, (float)floor(desc->dwWidth / pow(2.0f, mip)));
+            int py = (int)std::max(1.0f, (float)floor(desc->dwHeight / pow(2.0f, mip)));
+            rgba8Data.resize(px * py * sizeof(uint32_t));
+
+            squish::DecompressImage(rgba8Data.data(), px, py, &ddsData[seek], squishDxtLevel);
         }
-
-        for (int i = 0; i < mip; i++)
-        {
-            seek += ComputeSizeInBytes(i, desc->dwWidth, desc->dwHeight, squishDxtLevel == squish::kDxt1);
-        }
-
-        int px = (int)std::max(1.0f, (float)floor(desc->dwWidth / pow(2.0f, mip)));
-        int py = (int)std::max(1.0f, (float)floor(desc->dwHeight / pow(2.0f, mip)));
-        rgba8Data.resize(px * py * sizeof(uint32_t));
-
-        squish::DecompressImage(rgba8Data.data(), px, py, &ddsData[seek], squishDxtLevel);
-    }
-}  // namespace ZenLoad
+    }  // namespace ZenLoad
+}  // namespace ZenLib
 /* THE END */

--- a/zenload/ztex2dds.h
+++ b/zenload/ztex2dds.h
@@ -4,39 +4,42 @@
 #include <inttypes.h>
 #include <stddef.h>
 
-namespace ZenLoad
+namespace ZenLib
 {
-    /**
+    namespace ZenLoad
+    {
+        /**
 	* @brief Modified ZTEX to DDS conversion
 	*/
-    int convertZTEX2DDS(const std::vector<uint8_t>& ztexData, std::vector<uint8_t>& ddsData, bool optionForceARGB = false, int* pOutWidth = nullptr, int* pOutHeight = nullptr);
+        int convertZTEX2DDS(const std::vector<uint8_t>& ztexData, std::vector<uint8_t>& ddsData, bool optionForceARGB = false, int* pOutWidth = nullptr, int* pOutHeight = nullptr);
 
-    /**
+        /**
 	 * @brief Convert dds to RGBA8
 	 */
-    void convertDDSToRGBA8(const std::vector<uint8_t>& ddsData, std::vector<uint8_t>& rgba8Data, int mip = 0);
+        void convertDDSToRGBA8(const std::vector<uint8_t>& ddsData, std::vector<uint8_t>& rgba8Data, int mip = 0);
 
-    /**
+        /**
 	 * @return Total offset (including header) of where the given mip-level starts inside ddsData
 	 */
-    size_t getMipFileOffsetFromDDS(const std::vector<uint8_t>& ddsData, int mip);
+        size_t getMipFileOffsetFromDDS(const std::vector<uint8_t>& ddsData, int mip);
 
-    enum class DXTLevel
-    {
-        DXT1,
-        DXT3,
-        DXT5,
-        Unknown,
-    };
+        enum class DXTLevel
+        {
+            DXT1,
+            DXT3,
+            DXT5,
+            Unknown,
+        };
 
-    /**
+        /**
 	 * @return The DXT compression level of the given DDS file
 	 */
-    DXTLevel getDXTLevelFromDDS(const std::vector<uint8_t>& ddsData);
+        DXTLevel getDXTLevelFromDDS(const std::vector<uint8_t>& ddsData);
 
-    /**
+        /**
 	 * @param ddsData Loaded dds
 	 * @return surface info of the given dds
 	 */
-    DDSURFACEDESC2 getSurfaceDesc(const std::vector<uint8_t>& ddsData);
-}  // namespace ZenLoad
+        DDSURFACEDESC2 getSurfaceDesc(const std::vector<uint8_t>& ddsData);
+    }  // namespace ZenLoad
+}  // namespace ZenLib


### PR DESCRIPTION
Might be a bad idea idk (definitely breaks compatibility for pretty much everybody).
I don't like stuff like "Utils" namespaces just flying around, so i just moved everything.

Due to autoformatting, every line is moved in by 4 spaces, which means this breaks any merge strategies that care about whitespace.